### PR TITLE
Move entity creation logic into library

### DIFF
--- a/src/diamonds/nayms/facets/SystemFacet.sol
+++ b/src/diamonds/nayms/facets/SystemFacet.sol
@@ -7,33 +7,13 @@ import { LibACL } from "../libs/LibACL.sol";
 import { LibEntity } from "../libs/LibEntity.sol";
 
 contract SystemFacet is Modifiers {
-    event NewEntity(bytes32 entityId, bytes32 _entityAdmin);
-
     function createEntity(
         bytes32 _entityId,
         bytes32 _entityAdmin,
         Entity memory _entityData,
         bytes32 _dataHash
     ) external assertSysMgr {
-        // note: An entity can be created with a zero max capacity! This is in the event where an entity cannot write any policies.
-
-        LibObject._createObject(_entityId, _dataHash);
-
-        // state that this is an entity
-        s.existingEntities[_entityId] = true;
-
-        // setParent(objectId, parentId)
-        LibObject._setParent(_entityAdmin, _entityId);
-
-        emit NewEntity(_entityId, _entityAdmin);
-
-        LibACL._assignRole(_entityAdmin, _entityId, LibHelpers._stringToBytes32(LibConstants.ROLE_ENTITY_ADMIN));
-
-        // note: A user can pass in a non-zero value for _entityData.utilizedCapacity, but an entity should always start with
-        //       their utilized capacity at zero since they have not written any policies yet.
-        // Ensure _entityData.utilizedCapacity is 0. An entity will start without any capacity utilized.
-        delete _entityData.utilizedCapacity;
-        LibEntity._updateEntity(_entityId, _entityData);
+        LibEntity._createEntity(_entityId, _entityAdmin, _entityData, _dataHash);
     }
 
     function approveUser(bytes32 _userId, bytes32 _entityId) external assertSysMgr {

--- a/src/diamonds/nayms/interfaces/ISystemFacet.sol
+++ b/src/diamonds/nayms/interfaces/ISystemFacet.sol
@@ -29,7 +29,7 @@ interface ISystemFacet {
 
     /**
      * @notice Create an entity
-     * @dev Create a new entity with given properties
+     * @dev An entity can be created with a zero max capacity! This is in the event where an entity cannot write any policies.
      * @param _entityId Unique ID for the entity
      * @param _entityAdmin Unique ID of the entity administrator
      * @param _entityData remaining entity metadata


### PR DESCRIPTION
This pull request implements the move of logic around `Entity` creation down into a library. One of the motives is to have a bit more streamlined sequence of events for backend processing.