### PR TITLE
Publish npm from CI

### DIFF
--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -18,7 +18,12 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           always-auth: true
 
-      - name: Publish to NPM
-        run: echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc && npm publish
+      - name: whoami
+        run: npm whoami --registry https://registry.npmjs.org --scope=@typescript-tools
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+        
+      # - name: Publish to NPM
+      #   run: echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc && npm publish
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -1,0 +1,22 @@
+name: Publish npm package
+
+on:
+    # Trigger manually
+    workflow_dispatch: {}
+    workflow_call:
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Node dependencies
+        run: yarn
+
+      - name: Publish to NPM
+        run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -17,13 +17,8 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
           always-auth: true
-
-      - name: whoami
-        run: npm whoami --registry https://registry.npmjs.org --scope=@typescript-tools
+        
+      - name: Publish to NPM
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-        
-      # - name: Publish to NPM
-      #   run: echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc && npm publish
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -1,9 +1,10 @@
 name: Publish npm package
 
 on:
-    # Trigger manually
-    workflow_dispatch: {}
-    workflow_call:
+  # Trigger manually
+  workflow_dispatch: {}
+  workflow_call:
+  pull_request:
 
 jobs:
   run-tests:

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -5,17 +5,20 @@ on:
     types: [created]
 
 jobs:
-  run-tests:
+  publish-npm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
 
-      - name: Install Node dependencies
-        run: yarn
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+          always-auth: true
 
       - name: Publish to NPM
-        run: yarn publish
+        run: echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc && npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -1,10 +1,8 @@
-name: Publish npm package
+name: npm
 
 on:
-  # Trigger manually
-  workflow_dispatch: {}
-  workflow_call:
-  pull_request:
+  release:
+    types: [created]
 
 jobs:
   run-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,14 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/reference/authentication-in-a-workflow
+    permissions:
+      id-token: write
+      packages: read
+      contents: read
+    timeout-minutes: 15
     container:
-      image: ghcr.io/amarinkovic/build-foundry:latest
+      image: ghcr.io/nayms/contracts-builder:latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,8 +88,3 @@ jobs:
       # - name: Static analyser Mythril (todo)
       #   run: mythril
       #   continue-on-error: true
-
-      # - name: Publish to NPM
-      #   run: yarn publish
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nayms/contracts",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "main": "index.js",
   "repository": "https://github.com/nayms/contracts-v3.git",
   "author": "Kevin Park <kevin@fruitful.fi>",


### PR DESCRIPTION
When a release is created through Github, a `npm` workflow is triggered which automatically publishes the npm package.