### PR TITLE
Update validation for non-cell entities

### DIFF
--- a/src/diamonds/nayms/libs/LibEntity.sol
+++ b/src/diamonds/nayms/libs/LibEntity.sol
@@ -176,7 +176,7 @@ library LibEntity {
 
             // Collateral ratio must be in acceptable range of 1 to 1000 basis points (0.01% to 100% collateralized).
             // Cannot ever be completely uncollateralized (0 basis points), if entity is a cell.
-            require(1 <= _entity.collateralRatio && _entity.collateralRatio <= 1000, "collateral ratio should be 0 to 1000");
+            require(1 <= _entity.collateralRatio && _entity.collateralRatio <= 1000, "collateral ratio should be 1 to 1000");
 
             // Max capacity is the capital amount that an entity can write across all of their policies.
             // note: We do not directly use the value maxCapacity to determine if the entity can or cannot write a policy.

--- a/test/T03SystemFacet.t.sol
+++ b/test/T03SystemFacet.t.sol
@@ -30,8 +30,8 @@ contract T03SystemFacetTest is D03ProtocolDefaults, MockAccounts {
 
     function testZeroCollateralRatioWhenCreatingEntity() public {
         bytes32 objectId1 = "0x1";
-        vm.expectRevert("collateral ratio should be 1 to 1000");
-        nayms.createEntity(objectId1, objectContext1, initEntity(weth, 0, 1, 0, false), "entity test hash");
+        vm.expectRevert("collateral ratio should be 0 to 1000");
+        nayms.createEntity(objectId1, objectContext1, initEntity(weth, 1001, 1, 0, false), "entity test hash");
     }
 
     function testNonManagerCreateEntity() public {

--- a/test/T03SystemFacet.t.sol
+++ b/test/T03SystemFacet.t.sol
@@ -30,8 +30,8 @@ contract T03SystemFacetTest is D03ProtocolDefaults, MockAccounts {
 
     function testZeroCollateralRatioWhenCreatingEntity() public {
         bytes32 objectId1 = "0x1";
-        vm.expectRevert("collateral ratio should be 0 to 1000");
-        nayms.createEntity(objectId1, objectContext1, initEntity(weth, 1001, 1, 0, false), "entity test hash");
+        vm.expectRevert("collateral ratio should be 1 to 1000");
+        nayms.createEntity(objectId1, objectContext1, initEntity(weth, 0, 1, 0, false), "entity test hash");
     }
 
     function testNonManagerCreateEntity() public {

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -111,11 +111,11 @@ contract T04EntityTest is D03ProtocolDefaults {
     function testUpdateEntity() public {
         nayms.createEntity(entityId1, account0Id, initEntity(weth, 500, 10000, 0, false), "entity test hash");
 
-        vm.expectRevert("collateral ratio should be 1 to 1000");
-        nayms.updateEntity(entityId1, initEntity(weth, 0, 1000, 0, false));
-
         vm.expectRevert("external token is not supported");
-        nayms.updateEntity(entityId1, initEntity(wbtc, 1000, 1000, 0, false));
+        nayms.updateEntity(entityId1, initEntity(wbtc, 0, 1000, 0, false));
+
+        vm.expectRevert("collateral ratio should be 0 to 1000");
+        nayms.updateEntity(entityId1, initEntity(weth, 1001, 1000, 0, false));
 
         vm.expectRevert("max capacity should be greater than 0 for policy creation");
         nayms.updateEntity(entityId1, initEntity(weth, 1000, 0, 0, true));

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -110,11 +110,7 @@ contract T04EntityTest is D03ProtocolDefaults {
 
     function testUpdateEntity() public {
         nayms.createEntity(entityId1, account0Id, initEntity2(0, 0, 0, 0, false), "test");
-        // _assetId,
-        // _collateralRatio,
-        // _maxCapacity,
-        // _utilizedCapacity,
-        // _simplePolicyEnabled
+
         vm.expectRevert("only cell has collateral ratio");
         nayms.updateEntity(entityId1, initEntity2(0, 1000, 0, 0, false));
 
@@ -140,7 +136,7 @@ contract T04EntityTest is D03ProtocolDefaults {
         vm.expectRevert("external token is not supported");
         nayms.updateEntity(entityId1, initEntity(wbtc, 0, 1000, 0, false));
 
-        vm.expectRevert("collateral ratio should be 0 to 1000");
+        vm.expectRevert("collateral ratio should be 1 to 1000");
         nayms.updateEntity(entityId1, initEntity(weth, 1001, 1000, 0, false));
 
         vm.expectRevert("max capacity should be greater than 0 for policy creation");

--- a/test/defaults/D03ProtocolDefaults.sol
+++ b/test/defaults/D03ProtocolDefaults.sol
@@ -86,12 +86,23 @@ contract D03ProtocolDefaults is D02TestSetup {
         uint256 _collateralRatio,
         uint256 _maxCapacity,
         uint256 _utilizedCapacity,
-        bool simplePolicyEnabled
+        bool _simplePolicyEnabled
     ) public pure returns (Entity memory e) {
-        e.assetId = LibHelpers._getIdForAddress(address(_asset));
+        bytes32 assetId = LibHelpers._getIdForAddress(address(_asset));
+        return initEntity2(assetId, _collateralRatio, _maxCapacity, _utilizedCapacity, _simplePolicyEnabled);
+    }
+
+    function initEntity2(
+        bytes32 _assetId,
+        uint256 _collateralRatio,
+        uint256 _maxCapacity,
+        uint256 _utilizedCapacity,
+        bool _simplePolicyEnabled
+    ) public pure returns (Entity memory e) {
+        e.assetId = _assetId;
         e.collateralRatio = _collateralRatio;
         e.maxCapacity = _maxCapacity;
         e.utilizedCapacity = _utilizedCapacity;
-        e.simplePolicyEnabled = simplePolicyEnabled;
+        e.simplePolicyEnabled = _simplePolicyEnabled;
     }
 }


### PR DESCRIPTION
Several requirements were being enforced for entity creation/update, but are not really applicable for all entities. Those apply only to entities that are "Cells". 

Only entities having an asset defined will be considered Cells.