### PR TITLE
Close offer matched with a better one

### DIFF
--- a/slither.config.json
+++ b/slither.config.json
@@ -1,5 +1,6 @@
 {
   "filter_paths": "lib",
+  "legacy_ast": false,
   "solc_remaps": [
     "ds-test/=lib/ds-test/src/",
     "forge-std/=lib/forge-std/src/",

--- a/src/diamonds/nayms/libs/LibMarket.sol
+++ b/src/diamonds/nayms/libs/LibMarket.sol
@@ -240,7 +240,7 @@ library LibMarket {
         marketInfo.buyAmountInitial = _buyAmountInitial;
         marketInfo.feeSchedule = _feeSchedule;
 
-        if (_sellAmount <= LibConstants.DUST) {
+        if (_buyAmount <= LibConstants.DUST || _sellAmount <= LibConstants.DUST) {
             marketInfo.state = LibConstants.OFFER_STATE_FULFILLED;
         } else {
             marketInfo.state = LibConstants.OFFER_STATE_ACTIVE;

--- a/test/T04Market.t.sol
+++ b/test/T04Market.t.sol
@@ -271,6 +271,10 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         vm.stopPrank();
 
         assertEq(nayms.internalBalanceOf(entity2, entity1), 500 ether, "should match takers buy amount, not sell amount");
+
+        uint256 offerId = nayms.getLastOfferId();
+        MarketInfo memory offer = nayms.getOffer(offerId);
+        assertEq(offer.state, LibConstants.OFFER_STATE_FULFILLED, "offer should be closed");
     }
 
     function testCancelOffer() public {


### PR DESCRIPTION
When taking an offer which is better than what the taker was asking for, offer status remains `Open`, even though there is nothing left to match.

This PR addresses the issue and moves the offer into `Fulfilled` state as expected.