### PR TITLE
External deposits always go to the user's entity

### DIFF
--- a/src/diamonds/nayms/facets/TokenizedVaultFacet.sol
+++ b/src/diamonds/nayms/facets/TokenizedVaultFacet.sol
@@ -43,7 +43,7 @@ contract TokenizedVaultFacet is Modifiers {
      * @param to token receiver
      * @param tokenId Internal ID of the token
      */
-    function internalTransferFromEntity(
+    function internalTransfer(
         bytes32 to,
         bytes32 tokenId,
         uint256 amount
@@ -53,23 +53,6 @@ contract TokenizedVaultFacet is Modifiers {
         bytes32 senderEntityId = LibObject._getParent(senderId);
         require(LibHelpers._stringToBytes32(LibConstants.STM_IDENTIFIER) != tokenId, "internalTransfer: can't transfer internal veNAYM");
         LibTokenizedVault._internalTransfer(senderEntityId, to, tokenId, amount);
-    }
-
-    /**
-     * @notice Internal transfer of `amount` tokens
-     * @dev Transfer tokens internally
-     * @param to token receiver
-     * @param tokenId Internal ID of the token
-     */
-    function internalTransfer(
-        bytes32 to,
-        bytes32 tokenId,
-        uint256 amount
-    ) external assertEntityAdmin(LibObject._getParent(LibHelpers._getSenderId())) {
-        // require(LibTokenizedVault._internalBalanceOf(senderId, tokenId) >= amount, "internalTransfer: insufficient balance");
-        bytes32 senderId = LibHelpers._getIdForAddress(msg.sender);
-        require(LibHelpers._stringToBytes32(LibConstants.STM_IDENTIFIER) != tokenId, "internalTransfer: can't transfer internal veNAYM");
-        LibTokenizedVault._internalTransfer(senderId, to, tokenId, amount);
     }
 
     function internalBurn(

--- a/src/diamonds/nayms/facets/TokenizedVaultIOFacet.sol
+++ b/src/diamonds/nayms/facets/TokenizedVaultIOFacet.sol
@@ -26,8 +26,7 @@ contract TokenizedVaultIOFacet is Modifiers {
         // a user can only deposit an approved external ERC20 token
         require(LibAdmin._isSupportedExternalTokenAddress(_externalTokenAddress), "extDeposit: invalid ERC20 token");
         // a user can only deposit to their valid entity
-        bytes32 userId = LibHelpers._getIdForAddress(msg.sender);
-        bytes32 entityId = LibObject._getParent(userId);
+        bytes32 entityId = LibObject._getParentFromAddress(msg.sender);
         require(LibEntity._isEntity(entityId), "extDeposit: invalid receiver");
 
         LibTokenizedVaultIO._externalDeposit(entityId, _externalTokenAddress, _amount);

--- a/src/diamonds/nayms/interfaces/ITokenizedVaultFacet.sol
+++ b/src/diamonds/nayms/interfaces/ITokenizedVaultFacet.sol
@@ -33,18 +33,6 @@ interface ITokenizedVaultFacet {
      * @param to token receiver
      * @param tokenId Internal ID of the token
      */
-    function internalTransferFromEntity(
-        bytes32 to,
-        bytes32 tokenId,
-        uint256 amount
-    ) external;
-
-    /**
-     * @notice Internal transfer of `amount` tokens
-     * @dev Transfer tokens internally
-     * @param to token receiver
-     * @param tokenId Internal ID of the token
-     */
     function internalTransfer(
         bytes32 to,
         bytes32 tokenId,

--- a/src/diamonds/nayms/interfaces/ITokenizedVaultIOFacet.sol
+++ b/src/diamonds/nayms/interfaces/ITokenizedVaultIOFacet.sol
@@ -9,30 +9,12 @@ pragma solidity >=0.8.13;
  */
 interface ITokenizedVaultIOFacet {
     /**
-     * @notice Deposit funds into Nayms platform entity
-     * @dev Deposit from an external account
-     * @param _receiverId Internal ID of the account receiving the deposited funds
+     * @notice Deposit funds into msg.sender's Nayms platform entity
+     * @dev Deposit from msg.sender to their associated entity
      * @param _externalTokenAddress Token address
      * @param _amount deposit amount
      */
-    function externalDepositToEntity(
-        bytes32 _receiverId,
-        address _externalTokenAddress,
-        uint256 _amount
-    ) external;
-
-    /**
-     * @notice Deposit funds into Nayms platform
-     * @dev Deposit from an external account
-     * @param _receiverId Internal ID of the account receiving the deposited funds
-     * @param _externalTokenAddress Token address
-     * @param _amount deposit amount
-     */
-    function externalDeposit(
-        bytes32 _receiverId,
-        address _externalTokenAddress,
-        uint256 _amount
-    ) external;
+    function externalDeposit(address _externalTokenAddress, uint256 _amount) external;
 
     /**
      * @notice Withdraw funds out of Nayms platform

--- a/test/T03TokenizedVault.t.sol
+++ b/test/T03TokenizedVault.t.sol
@@ -112,64 +112,91 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         nayms.createEntity(entity1, signer1Id, initEntity(weth, collateralRatio_500, maxCapital_3000eth, totalLimit_2000eth, true), "entity test hash");
         nayms.createEntity(entity2, signer2Id, initEntity(weth, collateralRatio_500, maxCapital_3000eth, totalLimit_2000eth, true), "entity test hash");
 
-        writeTokenBalance(account0, naymsAddress, wethAddress, depositAmount);
-
         uint256 externalDepositAmount = depositAmount / 5;
 
         // note: deposits must be an exisiting entity: s.existingEntities[_receiverId]
+        vm.prank(address(999999));
         vm.expectRevert("extDeposit: invalid receiver");
-        nayms.externalDepositToEntity(dividendBankId, wethAddress, 1);
+        nayms.externalDeposit(wethAddress, 1);
 
         vm.expectRevert("extDeposit: invalid ERC20 token");
-        nayms.externalDepositToEntity(dividendBankId, address(0xBADAAAAAAAAA), 1);
+        nayms.externalDeposit(address(0xBADAAAAAAAAA), 1);
 
         // deposit to entity1
-        nayms.externalDeposit(entity1, wethAddress, externalDepositAmount);
-        assertEq(weth.balanceOf(account0), depositAmount - externalDepositAmount, "account0 WETH balance after externalDeposit should DECREASE (transfer)");
+        vm.startPrank(address(signer1));
+        writeTokenBalance(signer1, naymsAddress, wethAddress, depositAmount);
+        nayms.externalDeposit(wethAddress, externalDepositAmount);
+        assertEq(weth.balanceOf(signer1), depositAmount - externalDepositAmount, "signer1 WETH balance after externalDeposit should DECREASE (transfer)");
         assertEq(weth.balanceOf(naymsAddress), externalDepositAmount, "nayms WETH balance after externalDeposit should INCREASE (transfer)");
         assertEq(nayms.internalBalanceOf(entity1, nWETH), externalDepositAmount, "entity1 nWETH balance should INCREASE (1:1 internal mint)");
         assertEq(nayms.internalTokenSupply(nWETH), externalDepositAmount, "nWETH total supply should INCREASE (1:1 internal mint)");
+        vm.stopPrank();
 
         // deposit to entity2
-        nayms.externalDeposit(entity2, wethAddress, externalDepositAmount);
-        assertEq(weth.balanceOf(account0), depositAmount - externalDepositAmount * 2, "account0 WETH balance after externalDeposit should DECREASE (transfer)");
+        vm.startPrank(address(signer2));
+        writeTokenBalance(signer2, naymsAddress, wethAddress, depositAmount);
+        nayms.externalDeposit(wethAddress, externalDepositAmount);
+        vm.stopPrank();
+        assertEq(weth.balanceOf(signer2), depositAmount - externalDepositAmount, "signer2 WETH balance after externalDeposit should DECREASE (transfer)");
         assertEq(weth.balanceOf(naymsAddress), externalDepositAmount * 2, "nayms WETH balance after externalDeposit should INCREASE (transfer)");
         assertEq(nayms.internalBalanceOf(entity2, nWETH), externalDepositAmount, "entity2 nWETH balance should INCREASE (1:1 internal mint)");
         assertEq(nayms.internalTokenSupply(nWETH), externalDepositAmount * 2, "nWETH total supply should INCREASE (1:1 internal mint)");
     }
 
+    // note: when creating entities for another userId, e.g. Alice is creating an entity for Bob, Alice needs to make sure they create the internal Nayms Id of Bob correctly.
     function testFuzzSingleExternalDeposit(
         bytes32 entity1,
         bytes32 entity2,
-        bytes32 signer1Id,
-        bytes32 signer2Id,
+        address signer1,
+        address signer2,
         uint256 depositAmount
     ) public {
         vm.assume(entity1 > 0); // else revert: object already exists
         vm.assume(entity2 > 0);
         vm.assume(entity1 != entity2);
         vm.assume(depositAmount > 5); // else revert: _internalMint: mint zero tokens, note: > 5 to ensure the externalDepositAmount isn't 0, see code below
-        nayms.createEntity(entity1, signer1Id, initEntity(weth, collateralRatio_500, maxCapital_3000eth, totalLimit_2000eth, true), "entity test hash");
-        nayms.createEntity(entity2, signer2Id, initEntity(weth, collateralRatio_500, maxCapital_3000eth, totalLimit_2000eth, true), "entity test hash");
+        bytes32 signer1Id = LibHelpers._getIdForAddress(signer1);
+        bytes32 signer2Id = LibHelpers._getIdForAddress(signer2);
 
-        writeTokenBalance(account0, naymsAddress, wethAddress, depositAmount);
+        vm.assume(signer1 != address(0));
+        vm.assume(signer2 != address(0));
+        vm.assume(signer1 != signer2);
+        vm.label(signer1, "bob");
+        vm.label(signer2, "charlie");
+
+        // force entity creation
+        require(!nayms.isObject(entity1), "entity1 is already an object, pick a different ID");
+        require(!nayms.isObject(entity2), "entity2 is already an object, pick a different ID");
+        nayms.createEntity(entity1, signer1Id, initEntity(weth, collateralRatio_500, maxCapital_3000eth, totalLimit_2000eth, true), "entity test hash");
+
+        nayms.createEntity(entity2, signer2Id, initEntity(weth, collateralRatio_500, maxCapital_3000eth, totalLimit_2000eth, true), "entity test hash");
 
         uint256 externalDepositAmount = depositAmount / 5;
 
         // note: deposits must be an exisiting entity: s.existingEntities[_receiverId]
+        vm.startPrank(address(999999));
+        writeTokenBalance(address(999999), naymsAddress, wethAddress, depositAmount);
+
         vm.expectRevert("extDeposit: invalid receiver");
-        nayms.externalDepositToEntity(dividendBankId, wethAddress, 1);
+        nayms.externalDeposit(wethAddress, depositAmount);
+        vm.stopPrank();
 
         // deposit to entity1
-        nayms.externalDeposit(entity1, wethAddress, externalDepositAmount);
-        assertEq(weth.balanceOf(account0), depositAmount - externalDepositAmount, "account0 WETH balance after externalDeposit should DECREASE (transfer)");
+        vm.startPrank(signer1);
+        writeTokenBalance(signer1, naymsAddress, wethAddress, depositAmount);
+        nayms.externalDeposit(wethAddress, externalDepositAmount);
+        vm.stopPrank();
+
+        assertEq(weth.balanceOf(signer1), depositAmount - externalDepositAmount, "signer1 WETH balance after externalDeposit should DECREASE (transfer)");
         assertEq(weth.balanceOf(naymsAddress), externalDepositAmount, "nayms WETH balance after externalDeposit should INCREASE (transfer)");
         assertEq(nayms.internalBalanceOf(entity1, nWETH), externalDepositAmount, "entity1 nWETH balance should INCREASE (1:1 internal mint)");
         assertEq(nayms.internalTokenSupply(nWETH), externalDepositAmount, "nWETH total supply should INCREASE (1:1 internal mint)");
 
         // deposit to entity2
-        nayms.externalDeposit(entity2, wethAddress, externalDepositAmount);
-        assertEq(weth.balanceOf(account0), depositAmount - externalDepositAmount * 2, "account0 WETH balance after externalDeposit should DECREASE (transfer)");
+        vm.startPrank(address(signer2));
+        writeTokenBalance(signer2, naymsAddress, wethAddress, depositAmount);
+        nayms.externalDeposit(wethAddress, externalDepositAmount);
+        assertEq(weth.balanceOf(signer2), depositAmount - externalDepositAmount, "signer2 WETH balance after externalDeposit should DECREASE (transfer)");
         assertEq(weth.balanceOf(naymsAddress), externalDepositAmount * 2, "nayms WETH balance after externalDeposit should INCREASE (transfer)");
         assertEq(nayms.internalBalanceOf(entity2, nWETH), externalDepositAmount, "entity2 nWETH balance should INCREASE (1:1 internal mint)");
         assertEq(nayms.internalTokenSupply(nWETH), externalDepositAmount * 2, "nWETH total supply should INCREASE (1:1 internal mint)");
@@ -179,14 +206,12 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         bytes32 acc0EntityId = nayms.getEntity(account0Id);
         console2.logBytes32(acc0EntityId);
 
-        uint256 balanceAcc0 = nayms.internalBalanceOf(account0Id, nWETH);
-        console2.log(balanceAcc0);
-        assertEq(nayms.internalBalanceOf(account0Id, nWETH), 0, "account0Id nWETH balance should start at 0");
+        assertEq(nayms.internalBalanceOf(acc0EntityId, nWETH), 0, "acc0EntityId nWETH balance should start at 0");
 
         writeTokenBalance(account0, naymsAddress, wethAddress, depositAmount);
 
-        nayms.externalDeposit(account0Id, wethAddress, 1 ether);
-        assertEq(nayms.internalBalanceOf(account0Id, nWETH), 1 ether, "account0Id nWETH balance should INCREASE (1:1 internal mint)");
+        nayms.externalDeposit(wethAddress, 1 ether);
+        assertEq(nayms.internalBalanceOf(acc0EntityId, nWETH), 1 ether, "acc0EntityId nWETH balance should INCREASE (1:1 internal mint)");
         assertEq(nayms.internalTokenSupply(nWETH), 1 ether, "nWETH total supply should INCREASE (1:1 internal mint)");
 
         // note internalTransfer() transfers from the msg.sender's Id to the bytes32 Id given
@@ -205,7 +230,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         writeTokenBalance(account0, naymsAddress, wethAddress, depositAmount);
 
         // note Depositing to account0's associated entity
-        nayms.externalDepositToEntity(acc0EntityId, wethAddress, 1 ether);
+        nayms.externalDeposit(wethAddress, 1 ether);
         assertEq(nayms.internalBalanceOf(acc0EntityId, nWETH), 1 ether, "account0's entityId (account0's parent) nWETH balance should INCREASE (1:1 internal mint)");
         assertEq(nayms.internalTokenSupply(nWETH), 1 ether, "nWETH total supply should INCREASE (1:1 internal mint)");
 
@@ -241,7 +266,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
 
         writeTokenBalance(account0, naymsAddress, wethAddress, depositAmount);
 
-        nayms.externalDeposit(acc0EntityId, wethAddress, 1 ether);
+        nayms.externalDeposit(wethAddress, 1 ether);
         assertEq(nayms.internalBalanceOf(acc0EntityId, nWETH), 1 ether, "account0Id nWETH balance should INCREASE (mint)");
 
         uint256 withdrawableDiv = nayms.getWithdrawableDividend(account0Id, nWETH, nWETH);
@@ -263,14 +288,13 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
     function testPayDividendsWithNonZeroParticipationTokenSupply() public {
         bytes32 acc0EntityId = nayms.getEntity(account0Id);
 
-        assertEq(nayms.internalBalanceOf(account0Id, nWETH), 0, "account0Id nWETH balance should start at 0");
+        assertEq(nayms.internalBalanceOf(account0Id, nWETH), 0, "acc0EntityId nWETH balance should start at 0");
 
         writeTokenBalance(account0, naymsAddress, wethAddress, depositAmount);
 
-        nayms.externalDeposit(account0Id, wethAddress, 1 ether);
-        assertEq(nayms.internalBalanceOf(account0Id, nWETH), 1 ether, "account0Id nWETH balance should INCREASE (mint)");
-
         // note Depositing to account0's associated entity
+        nayms.externalDeposit(wethAddress, 1 ether);
+        assertEq(nayms.internalBalanceOf(acc0EntityId, nWETH), 1 ether, "acc0EntityId nWETH balance should INCREASE (mint)");
 
         uint256 withdrawableDiv = nayms.getWithdrawableDividend(account0Id, nWETH, nWETH);
         // No withdrawable dividends.
@@ -283,13 +307,10 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         assertEq(nayms.internalTokenSupply(acc0EntityId), 1 ether, "");
         bytes32 randomGuid = bytes32("0x1");
 
-        nayms.externalDepositToEntity(acc0EntityId, wethAddress, 1 ether);
-
         nayms.payDividendFromEntity(randomGuid, 1 ether);
         // note:When the participation token supply is non zero,
         assertEq(nayms.internalBalanceOf(acc0EntityId, nWETH), 0, "acc0EntityId nWETH balance should DECREASE (transfer)");
-        assertEq(nayms.internalBalanceOf(account0Id, nWETH), 1 ether, "account0Id nWETH balance should STAY THE SAME");
-        assertEq(nayms.internalTokenSupply(nWETH), 2 ether, "nWETH total supply should STAY THE SAME");
+        assertEq(nayms.internalTokenSupply(nWETH), 1 ether, "nWETH total supply should STAY THE SAME");
 
         assertEq(
             nayms.internalBalanceOf(dividendBankId, nWETH),
@@ -298,18 +319,18 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         );
 
         assertEq(nayms.internalBalanceOf(signer1Id, nWETH), 0, "");
-        nayms.externalDeposit(signer1Id, wethAddress, 1 ether);
-        assertEq(nayms.internalBalanceOf(signer1Id, nWETH), 1 ether, "");
 
-        vm.prank(signer1);
+        vm.startPrank(signer1);
+        writeTokenBalance(signer1, naymsAddress, wethAddress, depositAmount);
+
         bytes32 signer1EntityId = nayms.getEntity(signer1Id);
 
         // give signer1's entity nWETH
-        nayms.externalDeposit(signer1EntityId, wethAddress, 2 ether);
+        nayms.externalDeposit(wethAddress, 2 ether);
+        vm.stopPrank();
         assertEq(nayms.internalBalanceOf(signer1EntityId, nWETH), 2 ether, "signer1EntityId nWETH balance should INCREASE (mint)");
-        assertEq(nayms.internalBalanceOf(signer1Id, nWETH), 1 ether, "signer1Id nWETH balance should STAY THE SAME");
         assertEq(nayms.internalBalanceOf(dividendBankId, nWETH), 1 ether, "dividendBankId nWETH balance should STAY THE SAME");
-        assertEq(nayms.internalTokenSupply(nWETH), 5 ether, "nWETH total supply should INCREASE (mint)");
+        assertEq(nayms.internalTokenSupply(nWETH), 3 ether, "nWETH total supply should INCREASE (mint)");
 
         // the taker's buy amount
         uint256 takerBuyAmount = 1 ether;
@@ -367,7 +388,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         assertEq(nayms.internalBalanceOf(eAlice, eAlice), 1e18, "eAlice's eAlice balance should INCREASE (mint)");
 
         bytes32 randomGuid = bytes32("0x1");
-        nayms.externalDepositToEntity(eAlice, wethAddress, 1 ether);
+        nayms.externalDeposit(wethAddress, 1 ether);
         assertEq(nayms.internalTokenSupply(nWETH), 1 ether, "nWETH token supply should INCREASE (mint)");
         assertEq(nayms.internalBalanceOf(eAlice, nWETH), 1 ether, "eAlice's nWETH balance should INCREASE (deposit)");
 
@@ -385,11 +406,13 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
 
         TradingCommissions memory tc = nayms.calculateTradingCommissions(takerBuyAmount);
 
-        nayms.externalDepositToEntity(eBob, wethAddress, 1 ether + tc.totalCommissions);
+        vm.startPrank(bob);
+        writeTokenBalance(bob, naymsAddress, wethAddress, depositAmount);
+        nayms.externalDeposit(wethAddress, 1 ether + tc.totalCommissions);
         assertEq(nayms.internalBalanceOf(eBob, nWETH), 1 ether + tc.totalCommissions, "eBob's nWETH balance should INCREASE");
 
-        vm.prank(bob);
         nayms.executeLimitOffer(nWETH, 1 ether, eAlice, 1e18);
+        vm.stopPrank();
 
         assertEq(nayms.internalBalanceOf(eBob, nWETH), 0, "eBob's nWETH balance should DECREASE");
         assertEq(nayms.internalBalanceOf(eAlice, nWETH), 2 ether, "eAlice's nWETH balance should INCREASE");
@@ -402,7 +425,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         assertEq(nayms.internalBalanceOf(stakingId, nWETH), tc.commissionSTM, "balance of stakingId should have INCREASED (trading commissions)");
     }
 
-    function testMultipleDepositDividendWithdraw() public {
+    function testMultipleDepositDividendWithdraw2() public {
         address alice = account0;
         bytes32 eAlice = nayms.getEntity(account0Id);
         address bob = signer1;
@@ -412,12 +435,20 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
 
         writeTokenBalance(alice, naymsAddress, wethAddress, depositAmount);
 
-        nayms.externalDepositToEntity(eAlice, wethAddress, 80_000); // to be used for dividend payments
+        nayms.externalDeposit(wethAddress, 80_000); // to be used for dividend payments
 
-        nayms.externalDepositToEntity(eBob, wethAddress, 3_000 + nayms.calculateTradingCommissions(3_000).totalCommissions);
-        nayms.externalDepositToEntity(eCharlie, wethAddress, 17_000 + nayms.calculateTradingCommissions(17_000).totalCommissions);
+        vm.startPrank(bob);
+        writeTokenBalance(bob, naymsAddress, wethAddress, depositAmount);
+        nayms.externalDeposit(wethAddress, 3_000 + nayms.calculateTradingCommissions(3_000).totalCommissions);
+        vm.stopPrank();
 
         assertEq(nayms.internalBalanceOf(eBob, nWETH), 3_000 + nayms.calculateTradingCommissions(3_000).totalCommissions);
+
+        vm.startPrank(charlie);
+        writeTokenBalance(charlie, naymsAddress, wethAddress, depositAmount);
+        nayms.externalDeposit(wethAddress, 17_000 + nayms.calculateTradingCommissions(17_000).totalCommissions);
+        vm.stopPrank();
+
         // note: starting a token sale which mints participation tokens
         nayms.startTokenSale(eAlice, 20_000, 20_000);
 
@@ -508,7 +539,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         writeTokenBalance(alice, naymsAddress, wethAddress, type(uint256).max);
 
         // --- Deposit WETH to eAlice --- //
-        nayms.externalDepositToEntity(eAlice, wethAddress, type(uint256).max);
+        nayms.externalDeposit(wethAddress, type(uint256).max);
 
         // --- Internal transfer nWETH from eAlice to eBob ---/
         nayms.internalTransferFromEntity(eBob, nWETH, bobWethDepositAmount + nayms.calculateTradingCommissions(bobWethDepositAmount).totalCommissions);
@@ -572,13 +603,32 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         writeTokenBalance(alice, naymsAddress, wethAddress, depositAmount);
         writeTokenBalance(alice, naymsAddress, wbtcAddress, depositAmount);
 
-        nayms.externalDepositToEntity(eAlice, wethAddress, 80_000); // to be used for dividend payments
-        nayms.externalDepositToEntity(eDavid, wbtcAddress, 80_000); // to be used for dividend payments
+        nayms.externalDeposit(wethAddress, 80_000); // to be used for dividend payments
 
-        nayms.externalDepositToEntity(eBob, wethAddress, 3_000 + nayms.calculateTradingCommissions(3_000).totalCommissions);
-        nayms.externalDepositToEntity(eCharlie, wethAddress, 17_000 + nayms.calculateTradingCommissions(17_000).totalCommissions);
-        nayms.externalDepositToEntity(eEmily, wbtcAddress, 3_000 + nayms.calculateTradingCommissions(3_000).totalCommissions);
-        nayms.externalDepositToEntity(eFaith, wbtcAddress, 17_000 + nayms.calculateTradingCommissions(17_000).totalCommissions);
+        vm.startPrank(bob);
+        writeTokenBalance(bob, naymsAddress, wethAddress, depositAmount);
+        nayms.externalDeposit(wethAddress, 3_000 + nayms.calculateTradingCommissions(3_000).totalCommissions);
+        vm.stopPrank();
+
+        vm.startPrank(charlie);
+        writeTokenBalance(charlie, naymsAddress, wethAddress, depositAmount);
+        nayms.externalDeposit(wethAddress, 17_000 + nayms.calculateTradingCommissions(17_000).totalCommissions);
+        vm.stopPrank();
+
+        vm.startPrank(david);
+        writeTokenBalance(david, naymsAddress, wbtcAddress, depositAmount);
+        nayms.externalDeposit(wbtcAddress, 80_000); // to be used for dividend payments
+        vm.stopPrank();
+
+        vm.startPrank(emily);
+        writeTokenBalance(emily, naymsAddress, wbtcAddress, depositAmount);
+        nayms.externalDeposit(wbtcAddress, 3_000 + nayms.calculateTradingCommissions(3_000).totalCommissions);
+        vm.stopPrank();
+
+        vm.startPrank(faith);
+        writeTokenBalance(faith, naymsAddress, wbtcAddress, depositAmount);
+        nayms.externalDeposit(wbtcAddress, 17_000 + nayms.calculateTradingCommissions(17_000).totalCommissions);
+        vm.stopPrank();
 
         assertEq(nayms.internalBalanceOf(eBob, nWETH), 3_000 + nayms.calculateTradingCommissions(3_000).totalCommissions);
         assertEq(nayms.internalBalanceOf(eEmily, nWBTC), 3_000 + nayms.calculateTradingCommissions(3_000).totalCommissions);
@@ -680,10 +730,17 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
 
         writeTokenBalance(alice, naymsAddress, wethAddress, depositAmount);
 
-        nayms.externalDepositToEntity(eAlice, wethAddress, 80_000); // to be used for dividend payments
+        nayms.externalDeposit(wethAddress, 80_000); // to be used for dividend payments
 
-        nayms.externalDepositToEntity(eBob, wethAddress, 3_000 + nayms.calculateTradingCommissions(3_000).totalCommissions);
-        nayms.externalDepositToEntity(eCharlie, wethAddress, 17_000 + nayms.calculateTradingCommissions(17_000).totalCommissions);
+        vm.startPrank(bob);
+        writeTokenBalance(bob, naymsAddress, wethAddress, depositAmount);
+        nayms.externalDeposit(wethAddress, 3_000 + nayms.calculateTradingCommissions(3_000).totalCommissions);
+        vm.stopPrank();
+
+        vm.startPrank(charlie);
+        writeTokenBalance(charlie, naymsAddress, wethAddress, depositAmount);
+        nayms.externalDeposit(wethAddress, 17_000 + nayms.calculateTradingCommissions(17_000).totalCommissions);
+        vm.stopPrank();
 
         assertEq(nayms.internalBalanceOf(eBob, nWETH), 3_000 + nayms.calculateTradingCommissions(3_000).totalCommissions);
         // note: starting a token sale which mints participation tokens
@@ -796,7 +853,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         // fund entity0 to distribute as dividends
         writeTokenBalance(account0, naymsAddress, wethAddress, _dividendAmount * 2);
         assertEq(nayms.internalBalanceOf(entity0Id, nWETH), 0, "entity0 nWETH balance should start at 0");
-        nayms.externalDeposit(entity0Id, wethAddress, _dividendAmount);
+        nayms.externalDeposit(wethAddress, _dividendAmount);
         assertEq(nayms.internalBalanceOf(entity0Id, nWETH), _dividendAmount, "entity0 nWETH balance should INCREASE (mint)");
 
         // distribute dividends to entity0 shareholders
@@ -814,8 +871,10 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         // fund entity1 to by par-tokens
         uint256 takeAmount = (_parTokenSupply * _holdersShare) / 100;
         uint256 commissionAmount = (takeAmount * c.tradingCommissionTotalBP) / 1000;
-        writeTokenBalance(account0, naymsAddress, wethAddress, takeAmount + commissionAmount);
-        nayms.externalDeposit(entity1Id, wethAddress, takeAmount + commissionAmount);
+        vm.startPrank(signer1);
+        writeTokenBalance(signer1, naymsAddress, wethAddress, takeAmount + commissionAmount);
+        nayms.externalDeposit(wethAddress, takeAmount + commissionAmount);
+        vm.stopPrank();
         assertEq(nayms.internalBalanceOf(entity1Id, nWETH), takeAmount + commissionAmount, "entity1 nWETH balance should INCREASE (mint)");
         console2.log(" -- e1 balance: ", nayms.internalBalanceOf(entity1Id, nWETH));
 

--- a/test/T03TokenizedVault.t.sol
+++ b/test/T03TokenizedVault.t.sol
@@ -202,26 +202,6 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         assertEq(nayms.internalTokenSupply(nWETH), externalDepositAmount * 2, "nWETH total supply should INCREASE (1:1 internal mint)");
     }
 
-    function testSingleInternalTransfer() public {
-        bytes32 acc0EntityId = nayms.getEntity(account0Id);
-        console2.logBytes32(acc0EntityId);
-
-        assertEq(nayms.internalBalanceOf(acc0EntityId, nWETH), 0, "acc0EntityId nWETH balance should start at 0");
-
-        writeTokenBalance(account0, naymsAddress, wethAddress, depositAmount);
-
-        nayms.externalDeposit(wethAddress, 1 ether);
-        assertEq(nayms.internalBalanceOf(acc0EntityId, nWETH), 1 ether, "acc0EntityId nWETH balance should INCREASE (1:1 internal mint)");
-        assertEq(nayms.internalTokenSupply(nWETH), 1 ether, "nWETH total supply should INCREASE (1:1 internal mint)");
-
-        // note internalTransfer() transfers from the msg.sender's Id to the bytes32 Id given
-
-        nayms.internalTransfer(entity1, nWETH, 1 ether);
-        assertEq(nayms.internalBalanceOf(account0Id, nWETH), 1 ether - 1 ether, "account0Id nWETH balance should DECREASE (transfer to entityId)");
-        assertEq(nayms.internalBalanceOf(entity1, nWETH), 1 ether, "entity1Id nWETH balance should INCREASE (transfer from account0Id)");
-        assertEq(nayms.internalTokenSupply(nWETH), 1 ether, "nWETH total supply should STAY THE SAME (transfer)");
-    }
-
     function testSingleInternalTransferFromEntity() public {
         bytes32 acc0EntityId = nayms.getEntity(account0Id);
 
@@ -234,8 +214,8 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         assertEq(nayms.internalBalanceOf(acc0EntityId, nWETH), 1 ether, "account0's entityId (account0's parent) nWETH balance should INCREASE (1:1 internal mint)");
         assertEq(nayms.internalTokenSupply(nWETH), 1 ether, "nWETH total supply should INCREASE (1:1 internal mint)");
 
-        // from parent of sender (address(this)) to
-        nayms.internalTransferFromEntity(account0Id, nWETH, 1 ether);
+        // from parent of sender address(this)
+        nayms.internalTransfer(account0Id, nWETH, 1 ether);
         assertEq(nayms.internalBalanceOf(acc0EntityId, nWETH), 1 ether - 1 ether, "account0's entityId (account0's parent) nWETH balance should DECREASE (transfer to account0Id)");
         assertEq(nayms.internalBalanceOf(account0Id, nWETH), 1 ether, "account0Id nWETH balance should INCREASE (transfer from acc0EntityId)");
 
@@ -542,7 +522,8 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         nayms.externalDeposit(wethAddress, type(uint256).max);
 
         // --- Internal transfer nWETH from eAlice to eBob ---/
-        nayms.internalTransferFromEntity(eBob, nWETH, bobWethDepositAmount + nayms.calculateTradingCommissions(bobWethDepositAmount).totalCommissions);
+        vm.prank(bob);
+        nayms.internalTransfer(eBob, nWETH, bobWethDepositAmount + nayms.calculateTradingCommissions(bobWethDepositAmount).totalCommissions);
 
         assertEq(nayms.internalBalanceOf(eBob, nWETH), bobWethDepositAmount + nayms.calculateTradingCommissions(bobWethDepositAmount).totalCommissions);
 

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -117,7 +117,7 @@ contract T04EntityTest is D03ProtocolDefaults {
         weth.approve(naymsAddress, 10000);
         writeTokenBalance(account0, naymsAddress, wethAddress, 10000);
         assertEq(weth.balanceOf(account0), 10000);
-        nayms.externalDeposit(entityId1, wethAddress, 10000);
+        nayms.externalDeposit(wethAddress, 10000);
         assertEq(nayms.internalBalanceOf(entityId1, wethId), 10000);
     }
 
@@ -247,7 +247,7 @@ contract T04EntityTest is D03ProtocolDefaults {
         weth.approve(naymsAddress, 10000);
         writeTokenBalance(account0, naymsAddress, wethAddress, 100000);
         assertEq(weth.balanceOf(account0), 100000);
-        nayms.externalDeposit(entityId1, wethAddress, 100000);
+        nayms.externalDeposit(wethAddress, 100000);
         assertEq(nayms.internalBalanceOf(entityId1, wethId), 100000);
 
         // start date too early
@@ -429,10 +429,10 @@ contract T04EntityTest is D03ProtocolDefaults {
         nayms.paySimplePremium(policyId1, 0);
 
         // fund the insured party entity
-        weth.approve(naymsAddress, 100000);
-        writeTokenBalance(account0, naymsAddress, wethAddress, 100000);
-        assertEq(weth.balanceOf(account0), 100000);
-        nayms.externalDeposit(DEFAULT_INSURED_PARTY_ENTITY_ID, wethAddress, 100000);
+        vm.startPrank(signer4);
+        writeTokenBalance(signer4, naymsAddress, wethAddress, 100000);
+        nayms.externalDeposit(wethAddress, 100000);
+        vm.stopPrank();
         assertEq(nayms.internalBalanceOf(DEFAULT_INSURED_PARTY_ENTITY_ID, wethId), 100000);
 
         // test commissions

--- a/test/T04Market.t.sol
+++ b/test/T04Market.t.sol
@@ -197,7 +197,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         // try transfering nEntity1 from entity1 to entity0 - this should REVERT!
         vm.startPrank(signer1);
         vm.expectRevert("_internalTransferFrom: tokens for sale in mkt");
-        nayms.internalTransferFromEntity(DEFAULT_ACCOUNT0_ENTITY_ID, entity1, 1);
+        nayms.internalTransfer(DEFAULT_ACCOUNT0_ENTITY_ID, entity1, 1);
         vm.stopPrank();
 
         assertTrue(nayms.isActiveOffer(1), "Token sale offer should be active");


### PR DESCRIPTION
External deposits now always go to the user's entity.
Removed `externalDepositToEntity()`

Should we remove internalTransfer() (rename internalTransferFromEntity() to internalTransfer())?