### PR TITLE
Lock utilised capacity

### DIFF
--- a/docs/facets/ITokenizedVaultFacet.md
+++ b/docs/facets/ITokenizedVaultFacet.md
@@ -157,3 +157,23 @@ Transfer dividends to the entity
 |`guid` | bytes32 | Globally unique identifier of a dividend distribution.
 |`amount` | uint256 | the mamount of the dividend token to be distributed to NAYMS token holders.|
 <br></br>
+### getLockedBalance
+Get the amount of tokens that an entity has for sale in the marketplace.
+```solidity
+  function getLockedBalance(
+    bytes32 _entityId,
+    bytes32 _tokenId
+  ) external returns (uint256 amount)
+```
+#### Arguments:
+| Argument | Type | Description |
+| --- | --- | --- |
+|`_entityId` | bytes32 |  Unique platform ID of the entity.
+|`_tokenId` | bytes32 | The ID assigned to an external token.
+|
+<br></br>
+#### Returns:
+| Type | Description |
+| --- | --- |
+|`amount` | of tokens that the entity has for sale in the marketplace.|
+<br></br>

--- a/docs/facets/IUserFacet.md
+++ b/docs/facets/IUserFacet.md
@@ -72,23 +72,3 @@ Gets the entity related to the user
 | --- | --- |
 |`entityId` | Unique platform ID of the entity|
 <br></br>
-### getBalanceOfTokensForSale
-Get the amount of tokens that an entity has for sale in the marketplace.
-```solidity
-  function getBalanceOfTokensForSale(
-    bytes32 _entityId,
-    bytes32 _tokenId
-  ) external returns (uint256 amount)
-```
-#### Arguments:
-| Argument | Type | Description |
-| --- | --- | --- |
-|`_entityId` | bytes32 |  Unique platform ID of the entity.
-|`_tokenId` | bytes32 | The ID assigned to an external token.
-|
-<br></br>
-#### Returns:
-| Type | Description |
-| --- | --- |
-|`amount` | of tokens that the entity has for sale in the marketplace.|
-<br></br>

--- a/src/diamonds/nayms/AppStorage.sol
+++ b/src/diamonds/nayms/AppStorage.sol
@@ -127,7 +127,7 @@ struct AppStorage {
     uint16 premiumCommissionSTMBP;
     // A policy can pay out additional commissions on premiums to entities having a variety of roles on the policy
 
-    mapping(bytes32 => mapping(bytes32 => uint256)) marketLockedBalances; // to keep track of an owner's tokens that are on sale in the marketplace, ownerId => lockedTokenId => amount
+    mapping(bytes32 => mapping(bytes32 => uint256)) lockedBalances; // keep track of token balance that is locked, ownerId => tokenId => lockedAmount
 }
 
 library LibAppStorage {

--- a/src/diamonds/nayms/facets/TokenizedVaultFacet.sol
+++ b/src/diamonds/nayms/facets/TokenizedVaultFacet.sol
@@ -113,4 +113,14 @@ contract TokenizedVaultFacet is Modifiers {
 
         LibTokenizedVault._payDividend(guid, entityId, entityId, dividendTokenId, amount);
     }
+
+    /**
+     * @notice Get the amount of tokens that an entity has for sale in the marketplace.
+     * @param _entityId  Unique platform ID of the entity.
+     * @param _tokenId The ID assigned to an external token.
+     * @return amount of tokens that the entity has for sale in the marketplace.
+     */
+    function getLockedBalance(bytes32 _entityId, bytes32 _tokenId) external view returns (uint256 amount) {
+        amount = LibTokenizedVault._getLockedBalance(_entityId, _tokenId);
+    }
 }

--- a/src/diamonds/nayms/facets/TokenizedVaultFacet.sol
+++ b/src/diamonds/nayms/facets/TokenizedVaultFacet.sol
@@ -5,6 +5,7 @@ import { Modifiers } from "../Modifiers.sol";
 import { LibConstants } from "../libs/LibConstants.sol";
 import { LibHelpers } from "../libs/LibHelpers.sol";
 import { LibTokenizedVault } from "../libs/LibTokenizedVault.sol";
+import { LibACL } from "../libs/LibACL.sol";
 import { LibObject } from "../libs/LibObject.sol";
 import { LibEntity } from "../libs/LibEntity.sol";
 import { ReentrancyGuard } from "../../../utils/ReentrancyGuard.sol";
@@ -124,6 +125,7 @@ contract TokenizedVaultFacet is Modifiers, ReentrancyGuard {
         bytes32 entityId = LibObject._getParent(senderId);
         bytes32 dividendTokenId = LibEntity._getEntityInfo(entityId).assetId;
 
+        require(LibACL._isInGroup(senderId, entityId, LibHelpers._stringToBytes32(LibConstants.GROUP_ENTITY_ADMINS)), "payDividendFromEntity: not the entity's admin");
         require(LibTokenizedVault._internalBalanceOf(entityId, dividendTokenId) >= amount, "payDividendFromEntity: insufficient balance");
 
         LibTokenizedVault._payDividend(guid, entityId, entityId, dividendTokenId, amount);

--- a/src/diamonds/nayms/facets/UserFacet.sol
+++ b/src/diamonds/nayms/facets/UserFacet.sol
@@ -52,14 +52,4 @@ contract UserFacet is Modifiers {
     function getEntity(bytes32 _userId) external view returns (bytes32 entityId) {
         entityId = LibObject._getParent(_userId);
     }
-
-    /**
-     * @notice Get the amount of tokens that an entity has for sale in the marketplace.
-     * @param _entityId  Unique platform ID of the entity.
-     * @param _tokenId The ID assigned to an external token.
-     * @return amount of tokens that the entity has for sale in the marketplace.
-     */
-    function getBalanceOfTokensForSale(bytes32 _entityId, bytes32 _tokenId) external view returns (uint256 amount) {
-        amount = LibMarket._getBalanceOfTokensForSale(_entityId, _tokenId);
-    }
 }

--- a/src/diamonds/nayms/interfaces/ITokenizedVaultFacet.sol
+++ b/src/diamonds/nayms/interfaces/ITokenizedVaultFacet.sol
@@ -81,4 +81,12 @@ interface ITokenizedVaultFacet {
      * @param amount the mamount of the dividend token to be distributed to NAYMS token holders.
      */
     function payDividendFromEntity(bytes32 guid, uint256 amount) external;
+
+    /**
+     * @notice Get the amount of tokens that an entity has for sale in the marketplace.
+     * @param _entityId  Unique platform ID of the entity.
+     * @param _tokenId The ID assigned to an external token.
+     * @return amount of tokens that the entity has for sale in the marketplace.
+     */
+    function getLockedBalance(bytes32 _entityId, bytes32 _tokenId) external view returns (uint256 amount);
 }

--- a/src/diamonds/nayms/interfaces/IUserFacet.sol
+++ b/src/diamonds/nayms/interfaces/IUserFacet.sol
@@ -38,12 +38,4 @@ interface IUserFacet {
      * @return entityId Unique platform ID of the entity
      */
     function getEntity(bytes32 _userId) external view returns (bytes32 entityId);
-
-    /**
-     * @notice Get the amount of tokens that an entity has for sale in the marketplace.
-     * @param _entityId  Unique platform ID of the entity.
-     * @param _tokenId The ID assigned to an external token.
-     * @return amount of tokens that the entity has for sale in the marketplace.
-     */
-    function getBalanceOfTokensForSale(bytes32 _entityId, bytes32 _tokenId) external view returns (uint256 amount);
 }

--- a/src/diamonds/nayms/libs/LibEntity.sol
+++ b/src/diamonds/nayms/libs/LibEntity.sol
@@ -25,6 +25,7 @@ library LibEntity {
     event EntityUpdated(bytes32 entityId);
     event SimplePolicyCreated(bytes32 indexed id, bytes32 entityId);
     event TokenSaleStarted(bytes32 indexed entityId, uint256 offerId, string tokenSymbol, string tokenName);
+    event CollateralRatioUpdated(bytes32 indexed entityId, uint256 collateralRatio, uint256 utilizedCapacity);
 
     /**
      * @dev If an entity passes their checks to create a policy, ensure that the entity's capacity is appropriately decreased by the amount of capital that will be tied to the new policy being created.
@@ -176,6 +177,8 @@ library LibEntity {
             s.entities[_entityId].utilizedCapacity = (oldUtilizedCapacity * _entity.collateralRatio) / oldCollateralRatio;
             // lock updated utilized capacity
             s.lockedBalances[_entityId][_entity.assetId] += s.entities[_entityId].utilizedCapacity;
+
+            emit CollateralRatioUpdated(_entityId, _entity.collateralRatio, s.entities[_entityId].utilizedCapacity);
         }
 
         emit EntityUpdated(_entityId);

--- a/src/diamonds/nayms/libs/LibMarket.sol
+++ b/src/diamonds/nayms/libs/LibMarket.sol
@@ -378,7 +378,7 @@ library LibMarket {
 
         // note: add restriction to not be able to sell tokens that are already for sale
         // maker must own sell amount and it must not be locked
-        require(s.tokenBalances[_sellToken][_entityId] - s.lockedBalances[_entityId][_sellToken] >= _sellAmount, "tokens locked in market");
+        require(s.tokenBalances[_sellToken][_entityId] - s.lockedBalances[_entityId][_sellToken] >= _sellAmount, "tokens locked");
 
         // must have a valid fee schedule
         require(_feeSchedule == LibConstants.FEE_SCHEDULE_PLATFORM_ACTION || _feeSchedule == LibConstants.FEE_SCHEDULE_STANDARD, "fee schedule invalid");

--- a/src/diamonds/nayms/libs/LibMarket.sol
+++ b/src/diamonds/nayms/libs/LibMarket.sol
@@ -249,7 +249,7 @@ library LibMarket {
             marketInfo.state = LibConstants.OFFER_STATE_ACTIVE;
 
             // lock tokens!
-            s.marketLockedBalances[_creator][_sellToken] += _sellAmount;
+            s.lockedBalances[_creator][_sellToken] += _sellAmount;
         }
 
         s.offers[lastOfferId] = marketInfo;
@@ -282,7 +282,7 @@ library LibMarket {
             }
         }
 
-        s.marketLockedBalances[s.offers[_offerId].creator][s.offers[_offerId].sellToken] -= _buyAmount;
+        s.lockedBalances[s.offers[_offerId].creator][s.offers[_offerId].sellToken] -= _buyAmount;
 
         LibTokenizedVault._internalTransfer(s.offers[_offerId].creator, _takerId, s.offers[_offerId].sellToken, _buyAmount);
         LibTokenizedVault._internalTransfer(_takerId, s.offers[_offerId].creator, s.offers[_offerId].buyToken, _sellAmount);
@@ -335,7 +335,7 @@ library LibMarket {
         // unlock the remaining sell amount back to creator
         if (marketInfo.sellAmount > 0) {
             // note nothing is transferred since tokens for sale are UN-escrowed. Just unlock!
-            s.marketLockedBalances[s.offers[_offerId].creator][s.offers[_offerId].sellToken] -= marketInfo.sellAmount;
+            s.lockedBalances[s.offers[_offerId].creator][s.offers[_offerId].sellToken] -= marketInfo.sellAmount;
         }
 
         // don't emit event stating market order is canceled if the market order was executed and fulfilled
@@ -378,7 +378,7 @@ library LibMarket {
 
         // note: add restriction to not be able to sell tokens that are already for sale
         // maker must own sell amount and it must not be locked
-        require(s.tokenBalances[_sellToken][_entityId] - s.marketLockedBalances[_entityId][_sellToken] >= _sellAmount, "tokens locked in market");
+        require(s.tokenBalances[_sellToken][_entityId] - s.lockedBalances[_entityId][_sellToken] >= _sellAmount, "tokens locked in market");
 
         // must have a valid fee schedule
         require(_feeSchedule == LibConstants.FEE_SCHEDULE_PLATFORM_ACTION || _feeSchedule == LibConstants.FEE_SCHEDULE_STANDARD, "fee schedule invalid");
@@ -440,6 +440,6 @@ library LibMarket {
 
     function _getBalanceOfTokensForSale(bytes32 _entityId, bytes32 _tokenId) internal view returns (uint256 amount) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        return s.marketLockedBalances[_entityId][_tokenId];
+        return s.lockedBalances[_entityId][_tokenId];
     }
 }

--- a/src/diamonds/nayms/libs/LibMarket.sol
+++ b/src/diamonds/nayms/libs/LibMarket.sol
@@ -437,9 +437,4 @@ library LibMarket {
         AppStorage storage s = LibAppStorage.diamondStorage();
         return s.offers[_offerId].state == LibConstants.OFFER_STATE_ACTIVE;
     }
-
-    function _getBalanceOfTokensForSale(bytes32 _entityId, bytes32 _tokenId) internal view returns (uint256 amount) {
-        AppStorage storage s = LibAppStorage.diamondStorage();
-        return s.lockedBalances[_entityId][_tokenId];
-    }
 }

--- a/src/diamonds/nayms/libs/LibSimplePolicy.sol
+++ b/src/diamonds/nayms/libs/LibSimplePolicy.sol
@@ -97,8 +97,9 @@ library LibSimplePolicy {
         SimplePolicy storage simplePolicy = s.simplePolicies[_policyId];
         Entity storage entity = s.entities[entityId];
 
-        entity.utilizedCapacity -= simplePolicy.limit;
-        s.lockedBalances[entityId][entity.assetId] -= simplePolicy.limit;
+        uint256 policyLockedAmount = (simplePolicy.limit * entity.collateralRatio) / LibConstants.BP_FACTOR;
+        entity.utilizedCapacity -= policyLockedAmount;
+        s.lockedBalances[entityId][entity.assetId] -= policyLockedAmount;
 
         simplePolicy.fundsLocked = false;
     }

--- a/src/diamonds/nayms/libs/LibSimplePolicy.sol
+++ b/src/diamonds/nayms/libs/LibSimplePolicy.sol
@@ -92,10 +92,14 @@ library LibSimplePolicy {
 
     function releaseFunds(bytes32 _policyId) private {
         AppStorage storage s = LibAppStorage.diamondStorage();
+        bytes32 entityId = LibObject._getParent(_policyId);
+
         SimplePolicy storage simplePolicy = s.simplePolicies[_policyId];
-        Entity storage entity = s.entities[LibObject._getParent(_policyId)];
+        Entity storage entity = s.entities[entityId];
 
         entity.utilizedCapacity -= simplePolicy.limit;
+        s.lockedBalances[entityId][entity.assetId] -= simplePolicy.limit;
+
         simplePolicy.fundsLocked = false;
     }
 }

--- a/src/diamonds/nayms/libs/LibTokenizedVault.sol
+++ b/src/diamonds/nayms/libs/LibTokenizedVault.sol
@@ -74,7 +74,7 @@ library LibTokenizedVault {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         if (s.lockedBalances[_from][_tokenId] > 0) {
-            require(s.tokenBalances[_tokenId][_from] - s.lockedBalances[_from][_tokenId] >= _amount, "_internalTransferFrom: tokens for sale in mkt");
+            require(s.tokenBalances[_tokenId][_from] - s.lockedBalances[_from][_tokenId] >= _amount, "_internalTransferFrom: tokens locked");
         } else {
             require(s.tokenBalances[_tokenId][_from] >= _amount, "_internalTransferFrom: must own the funds");
         }
@@ -148,7 +148,7 @@ library LibTokenizedVault {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         if (s.lockedBalances[_from][_tokenId] > 0) {
-            require(s.tokenBalances[_tokenId][_from] - s.lockedBalances[_from][_tokenId] >= _amount, "_internalBurn: tokens for sale in mkt");
+            require(s.tokenBalances[_tokenId][_from] - s.lockedBalances[_from][_tokenId] >= _amount, "_internalBurn: tokens locked");
         } else {
             require(s.tokenBalances[_tokenId][_from] >= _amount, "_internalBurn: must own the funds");
         }

--- a/src/diamonds/nayms/libs/LibTokenizedVault.sol
+++ b/src/diamonds/nayms/libs/LibTokenizedVault.sol
@@ -277,4 +277,9 @@ library LibTokenizedVault {
             _dividendDeduction += 1;
         }
     }
+
+    function _getLockedBalance(bytes32 _accountId, bytes32 _tokenId) internal view returns (uint256 amount) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        return s.lockedBalances[_accountId][_tokenId];
+    }
 }

--- a/src/diamonds/nayms/libs/LibTokenizedVault.sol
+++ b/src/diamonds/nayms/libs/LibTokenizedVault.sol
@@ -73,8 +73,8 @@ library LibTokenizedVault {
     ) internal returns (bool success) {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
-        if (s.marketLockedBalances[_from][_tokenId] > 0) {
-            require(s.tokenBalances[_tokenId][_from] - s.marketLockedBalances[_from][_tokenId] >= _amount, "_internalTransferFrom: tokens for sale in mkt");
+        if (s.lockedBalances[_from][_tokenId] > 0) {
+            require(s.tokenBalances[_tokenId][_from] - s.lockedBalances[_from][_tokenId] >= _amount, "_internalTransferFrom: tokens for sale in mkt");
         } else {
             require(s.tokenBalances[_tokenId][_from] >= _amount, "_internalTransferFrom: must own the funds");
         }
@@ -147,8 +147,8 @@ library LibTokenizedVault {
     ) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
-        if (s.marketLockedBalances[_from][_tokenId] > 0) {
-            require(s.tokenBalances[_tokenId][_from] - s.marketLockedBalances[_from][_tokenId] >= _amount, "_internalBurn: tokens for sale in mkt");
+        if (s.lockedBalances[_from][_tokenId] > 0) {
+            require(s.tokenBalances[_tokenId][_from] - s.lockedBalances[_from][_tokenId] >= _amount, "_internalBurn: tokens for sale in mkt");
         } else {
             require(s.tokenBalances[_tokenId][_from] >= _amount, "_internalBurn: must own the funds");
         }

--- a/test/T02User.t.sol
+++ b/test/T02User.t.sol
@@ -30,15 +30,4 @@ contract T02UserTest is D03ProtocolDefaults, MockAccounts {
         nayms.setEntity(signer1Id, entityId);
         assertEq(nayms.getEntity(signer1Id), entityId);
     }
-
-    function testGetBalanceOfTokensForSale() public {
-        bytes32 entityId = createTestEntity(account0Id);
-
-        // nothing at first
-        assertEq(nayms.getBalanceOfTokensForSale(entityId, entityId), 0);
-
-        // now start token sale to create an offer
-        nayms.startTokenSale(entityId, 100, 100);
-        assertEq(nayms.getBalanceOfTokensForSale(entityId, entityId), 100);
-    }
 }

--- a/test/T03TokenizedVault.t.sol
+++ b/test/T03TokenizedVault.t.sol
@@ -95,6 +95,17 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         return abi.decode(result, (TradingCommissionsConfig));
     }
 
+    function testGetLockedBalance() public {
+        bytes32 entityId = createTestEntity(account0Id);
+
+        // nothing at first
+        assertEq(nayms.getLockedBalance(entityId, entityId), 0);
+
+        // now start token sale to create an offer
+        nayms.startTokenSale(entityId, 100, 100);
+        assertEq(nayms.getLockedBalance(entityId, entityId), 100);
+    }
+
     function testBasisPoints() public {
         TradingCommissionsBasisPoints memory bp = nayms.getTradingCommissionsBasisPoints();
 
@@ -382,7 +393,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
         );
 
         uint256 takerBuyAmount = 1e18;
-        console2.log(nayms.getBalanceOfTokensForSale(eAlice, eAlice));
+        console2.log(nayms.getLockedBalance(eAlice, eAlice));
 
         TradingCommissions memory tc = nayms.calculateTradingCommissions(takerBuyAmount);
 

--- a/test/T03TokenizedVault.t.sol
+++ b/test/T03TokenizedVault.t.sol
@@ -291,6 +291,15 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults {
 
         bytes32 randomGuid = bytes32("0x1");
 
+        address nonAdminAddress = vm.addr(0xACC9);
+        bytes32 nonAdminId = LibHelpers._getIdForAddress(nonAdminAddress);
+        nayms.setEntity(nonAdminId, acc0EntityId);
+
+        vm.startPrank(nonAdminAddress);
+        vm.expectRevert("payDividendFromEntity: not the entity's admin");
+        nayms.payDividendFromEntity(randomGuid, 10 ether);
+        vm.stopPrank();
+
         vm.expectRevert("payDividendFromEntity: insufficient balance");
         nayms.payDividendFromEntity(randomGuid, 10 ether);
 

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -12,11 +12,7 @@ import { LibTokenizedVault } from "src/diamonds/nayms/libs/LibTokenizedVault.sol
 import { LibFeeRouterFixture } from "test/fixtures/LibFeeRouterFixture.sol";
 import { SimplePolicyFixture } from "test/fixtures/SimplePolicyFixture.sol";
 
-import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-
 contract T04EntityTest is D03ProtocolDefaults {
-    bytes32 internal wethId;
-
     bytes32 internal entityId1 = "0xe1";
     bytes32 internal policyId1 = "0xC0FFEE";
 
@@ -28,49 +24,8 @@ contract T04EntityTest is D03ProtocolDefaults {
     address internal account9;
     bytes32 internal account9Id;
 
-    function initPolicy(bytes32 policyId) internal returns (Stakeholders memory policyStakeholders, SimplePolicy memory policy) {
-        bytes32[] memory roles = new bytes32[](4);
-        roles[0] = LibHelpers._stringToBytes32(LibConstants.ROLE_UNDERWRITER);
-        roles[1] = LibHelpers._stringToBytes32(LibConstants.ROLE_BROKER);
-        roles[2] = LibHelpers._stringToBytes32(LibConstants.ROLE_CAPITAL_PROVIDER);
-        roles[3] = LibHelpers._stringToBytes32(LibConstants.ROLE_INSURED_PARTY);
-
-        bytes32[] memory entityIds = new bytes32[](4);
-        entityIds[0] = DEFAULT_UNDERWRITER_ENTITY_ID;
-        entityIds[1] = DEFAULT_BROKER_ENTITY_ID;
-        entityIds[2] = DEFAULT_CAPITAL_PROVIDER_ENTITY_ID;
-        entityIds[3] = DEFAULT_INSURED_PARTY_ENTITY_ID;
-
-        bytes[] memory signatures = new bytes[](4);
-        signatures[0] = initSig(0xACC1, policyId);
-        signatures[1] = initSig(0xACC2, policyId);
-        signatures[2] = initSig(0xACC3, policyId);
-        signatures[3] = initSig(0xACC4, policyId);
-
-        policyStakeholders = Stakeholders(roles, entityIds, signatures);
-
-        bytes32[] memory commissionReceivers = new bytes32[](3);
-        commissionReceivers[0] = DEFAULT_UNDERWRITER_ENTITY_ID;
-        commissionReceivers[1] = DEFAULT_BROKER_ENTITY_ID;
-        commissionReceivers[2] = DEFAULT_CAPITAL_PROVIDER_ENTITY_ID;
-
-        uint256[] memory commissions = new uint256[](3);
-        commissions[0] = 10;
-        commissions[1] = 10;
-        commissions[2] = 10;
-
-        policy.startDate = 1000;
-        policy.maturationDate = 10000;
-        policy.asset = wethId;
-        policy.commissionReceivers = commissionReceivers;
-        policy.commissionBasisPoints = commissions;
-        policy.limit = 10000;
-    }
-
     function setUp() public virtual override {
         super.setUp();
-
-        wethId = LibHelpers._getIdForAddress(wethAddress);
 
         account9 = vm.addr(0xACC9);
         account9Id = LibHelpers._getIdForAddress(account9);
@@ -98,11 +53,6 @@ contract T04EntityTest is D03ProtocolDefaults {
     function updateSimplePolicy(bytes32 _policyId, SimplePolicy memory simplePolicy) internal {
         (bool success, ) = address(nayms).call(abi.encodeWithSelector(simplePolicyFixture.update.selector, _policyId, simplePolicy));
         require(success, "Should update simple policy in app storage");
-    }
-
-    function initSig(uint256 account, bytes32 policyId) internal returns (bytes memory sig_) {
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(account, ECDSA.toEthSignedMessageHash(policyId));
-        sig_ = abi.encodePacked(r, s, v);
     }
 
     function getReadyToCreatePolicies() public {

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -134,6 +134,21 @@ contract T04EntityTest is D03ProtocolDefaults {
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, "test");
         uint256 expectedLockedBalance = (simplePolicy.limit * 5000) / LibConstants.BP_FACTOR;
         assertEq(nayms.getLockedBalance(entityId1, wethId), expectedLockedBalance, "funds SHOULD BE locked");
+
+        Entity memory entity1 = nayms.getEntityInfo(entityId1);
+        assertEq(entity1.utilizedCapacity, (simplePolicy.limit * 5000) / LibConstants.BP_FACTOR, "utilized capacity should increase");
+
+        entity1.collateralRatio = 7_000;
+        nayms.updateEntity(entityId1, entity1);
+        assertEq(nayms.getLockedBalance(entityId1, wethId), (simplePolicy.limit * 7000) / LibConstants.BP_FACTOR, "locked balance SHOULD increase");
+
+        Entity memory entity1AfterUpdate = nayms.getEntityInfo(entityId1);
+        assertEq(entity1AfterUpdate.utilizedCapacity, (simplePolicy.limit * 7000) / LibConstants.BP_FACTOR, "utilized capacity should increase");
+
+        nayms.cancelSimplePolicy(policyId1);
+        assertEq(nayms.getLockedBalance(entityId1, wethId), 0, "locked balance SHOULD ne released");
+        Entity memory entity1After2ndUpdate = nayms.getEntityInfo(entityId1);
+        assertEq(entity1After2ndUpdate.utilizedCapacity, 0, "utilized capacity should increase");
     }
 
     function testUpdateAllowSimplePolicy() public {

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -121,9 +121,9 @@ contract T04EntityTest is D03ProtocolDefaults {
         vm.recordLogs();
         nayms.updateEntity(entityId1, initEntity(weth, LibConstants.BP_FACTOR, LibConstants.BP_FACTOR, 0, false));
         Vm.Log[] memory entries = vm.getRecordedLogs();
-        assertEq(entries[0].topics.length, 1);
-        assertEq(entries[0].topics[0], keccak256("EntityUpdated(bytes32)"));
-        bytes32 id = abi.decode(entries[0].data, (bytes32));
+        assertEq(entries[1].topics.length, 1);
+        assertEq(entries[1].topics[0], keccak256("EntityUpdated(bytes32)"));
+        bytes32 id = abi.decode(entries[1].data, (bytes32));
         assertEq(id, entityId1);
     }
 

--- a/test/T04Market.t.sol
+++ b/test/T04Market.t.sol
@@ -6,7 +6,7 @@ import { Vm } from "forge-std/Vm.sol";
 
 import { MockAccounts } from "./utils/users/MockAccounts.sol";
 
-import { Entity, FeeRatio, MarketInfo, TradingCommissions } from "src/diamonds/nayms/interfaces/FreeStructs.sol";
+import { Entity, FeeRatio, MarketInfo, TradingCommissions, SimplePolicy, SimplePolicyInfo, Stakeholders } from "src/diamonds/nayms/interfaces/FreeStructs.sol";
 import { INayms, IDiamondCut } from "src/diamonds/nayms/INayms.sol";
 import { IERC20 } from "src/erc20/IERC20.sol";
 
@@ -15,7 +15,7 @@ import { TradingCommissionsFixture, TradingCommissionsConfig } from "test/fixtur
 
 /* 
     Terminology:
-    nWETH: bytes32 ID of WETH
+    wethId: bytes32 ID of WETH
     nENTITYx: bytes32 ID of entityx when referring to entityx's token (nENTITYx == entityx)
     entityx: bytes32 ID of entity
     nEntity0: nEntity0 == DEFAULT_ACCOUNT0_ENTITY_ID
@@ -37,8 +37,6 @@ struct TestInfo {
 }
 
 contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
-    bytes32 internal nWETH;
-    bytes32 internal nWBTC;
     bytes32 internal dividendBankId;
 
     bytes32 internal entity1 = bytes32("e5");
@@ -77,10 +75,6 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
 
     function setUp() public virtual override {
         super.setUp();
-
-        // init token IDs
-        nWETH = LibHelpers._getIdForAddress(wethAddress);
-        nWBTC = LibHelpers._getIdForAddress(wbtcAddress);
 
         // whitelist tokens
         nayms.addSupportedExternalToken(wethAddress);
@@ -125,12 +119,12 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         nayms.externalDeposit(wethAddress, dt.entity1ExternalDepositAmt);
         vm.stopPrank();
 
-        // start a token sale: sell entity tokens for nWETH
+        // start a token sale: sell entity tokens for WETH
         // when a token sale starts: entity tokens are minted to the entity,
         // 2nd param is the sell amount, 3rd param is the buy amount
         vm.recordLogs();
         // putting an offer on behalf of entity1 to sell their nENTITY1 for the entity's associated asset
-        // 500 nENTITY1 for 500 nWETH, 1:1 ratio
+        // 500 nENTITY1 for 500 WETH, 1:1 ratio
         nayms.startTokenSale(entity1, dt.entity1MintAndSaleAmt, dt.entity1SalePrice);
         Vm.Log[] memory entries = vm.getRecordedLogs();
 
@@ -162,7 +156,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
 
         assertEq(sellAmount, dt.entity1MintAndSaleAmt, "OrderAdded: invalid sell amount");
         assertEq(sellAmountInitial, dt.entity1MintAndSaleAmt, "OrderAdded: invalid initial sell amount");
-        assertEq(buyToken, nWETH, "OrderAdded: invalid buy token");
+        assertEq(buyToken, wethId, "OrderAdded: invalid buy token");
         assertEq(buyAmount, dt.entity1SalePrice, "OrderAdded: invalid buy amount");
         assertEq(buyAmountInitial, dt.entity1SalePrice, "OrderAdded: invalid initial buy amount");
         assertEq(state, LibConstants.OFFER_STATE_ACTIVE, "OrderAdded: invalid offer state");
@@ -185,14 +179,14 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         assertEq(marketInfo1.sellToken, entity1);
         assertEq(marketInfo1.sellAmount, dt.entity1MintAndSaleAmt);
         assertEq(marketInfo1.sellAmountInitial, dt.entity1MintAndSaleAmt);
-        assertEq(marketInfo1.buyToken, nWETH);
+        assertEq(marketInfo1.buyToken, wethId);
         assertEq(marketInfo1.buyAmount, dt.entity1SalePrice);
         assertEq(marketInfo1.buyAmountInitial, dt.entity1SalePrice);
         assertEq(marketInfo1.state, LibConstants.OFFER_STATE_ACTIVE);
 
         // a user should NOT be able to transfer / withdraw their tokens for sale
         // transfer to invalid entity check?
-        assertEq(nayms.getBalanceOfTokensForSale(entity1, entity1), dt.entity1MintAndSaleAmt, "entity1 nEntity1 balance of tokens for sale should INCREASE (lock)");
+        assertEq(nayms.getLockedBalance(entity1, entity1), dt.entity1MintAndSaleAmt, "entity1 nEntity1 balance of tokens for sale should INCREASE (lock)");
 
         // try transfering nEntity1 from entity1 to entity0 - this should REVERT!
         vm.startPrank(signer1);
@@ -219,30 +213,30 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         nayms.externalDeposit(wethAddress, dt.entity3ExternalDepositAmt);
         vm.stopPrank();
 
-        uint256 naymsBalanceBeforeTrade = nayms.internalBalanceOf(LibHelpers._stringToBytes32(LibConstants.NAYMS_LTD_IDENTIFIER), nWETH);
+        uint256 naymsBalanceBeforeTrade = nayms.internalBalanceOf(LibHelpers._stringToBytes32(LibConstants.NAYMS_LTD_IDENTIFIER), wethId);
 
         vm.startPrank(signer2);
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt, entity1, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt, entity1, dt.entity1MintAndSaleAmt);
         assertEq(nayms.getLastOfferId(), 2, "lastOfferId should INCREASE after executeLimitOffer");
         vm.stopPrank();
 
-        assertEq(nayms.internalBalanceOf(entity1, nWETH), dt.entity1ExternalDepositAmt + dt.entity1MintAndSaleAmt, "Maker should not pay commisisons");
+        assertEq(nayms.internalBalanceOf(entity1, wethId), dt.entity1ExternalDepositAmt + dt.entity1MintAndSaleAmt, "Maker should not pay commisisons");
 
         // assert trading commisions payed
         uint256 totalCommissions = (dt.entity1MintAndSaleAmt * c.tradingCommissionTotalBP) / LibConstants.BP_FACTOR; // see AppStorage: 4 => s.tradingCommissionTotalBP
-        assertEq(nayms.internalBalanceOf(entity2, nWETH), dt.entity2ExternalDepositAmt - dt.entity1MintAndSaleAmt - totalCommissions, "Taker should pay commissions");
+        assertEq(nayms.internalBalanceOf(entity2, wethId), dt.entity2ExternalDepositAmt - dt.entity1MintAndSaleAmt - totalCommissions, "Taker should pay commissions");
 
         uint256 naymsBalanceAfterTrade = naymsBalanceBeforeTrade + ((totalCommissions * c.tradingCommissionNaymsLtdBP) / LibConstants.BP_FACTOR);
         uint256 ndfBalanceAfterTrade = naymsBalanceBeforeTrade + ((totalCommissions * c.tradingCommissionNDFBP) / LibConstants.BP_FACTOR);
         uint256 stmBalanceAfterTrade = naymsBalanceBeforeTrade + ((totalCommissions * c.tradingCommissionSTMBP) / LibConstants.BP_FACTOR);
         assertEq(
-            nayms.internalBalanceOf(LibHelpers._stringToBytes32(LibConstants.NAYMS_LTD_IDENTIFIER), nWETH),
+            nayms.internalBalanceOf(LibHelpers._stringToBytes32(LibConstants.NAYMS_LTD_IDENTIFIER), wethId),
             naymsBalanceAfterTrade,
             "Nayms should receive half of trading commissions"
         );
-        assertEq(nayms.internalBalanceOf(LibHelpers._stringToBytes32(LibConstants.NDF_IDENTIFIER), nWETH), ndfBalanceAfterTrade, "NDF should get a trading commission");
+        assertEq(nayms.internalBalanceOf(LibHelpers._stringToBytes32(LibConstants.NDF_IDENTIFIER), wethId), ndfBalanceAfterTrade, "NDF should get a trading commission");
         assertEq(
-            nayms.internalBalanceOf(LibHelpers._stringToBytes32(LibConstants.STM_IDENTIFIER), nWETH),
+            nayms.internalBalanceOf(LibHelpers._stringToBytes32(LibConstants.STM_IDENTIFIER), wethId),
             stmBalanceAfterTrade,
             "Staking mechanism should get a trading commission"
         );
@@ -251,19 +245,19 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         assertEq(nayms.internalBalanceOf(entity2, entity1), dt.entity1MintAndSaleAmt);
 
         // test commission payed by taker on "secondary market"
-        uint256 e2WethBeforeTrade = nayms.internalBalanceOf(entity2, nWETH);
-        uint256 e3WethBeforeTrade = nayms.internalBalanceOf(entity3, nWETH);
+        uint256 e2WethBeforeTrade = nayms.internalBalanceOf(entity2, wethId);
+        uint256 e3WethBeforeTrade = nayms.internalBalanceOf(entity3, wethId);
 
         vm.startPrank(signer2);
-        nayms.executeLimitOffer(entity1, dt.entity1MintAndSaleAmt, nWETH, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(entity1, dt.entity1MintAndSaleAmt, wethId, dt.entity1MintAndSaleAmt);
         vm.stopPrank();
 
         vm.startPrank(signer3);
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt, entity1, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt, entity1, dt.entity1MintAndSaleAmt);
         vm.stopPrank();
 
-        assertEq(nayms.internalBalanceOf(entity2, nWETH), e2WethBeforeTrade + dt.entity1MintAndSaleAmt, "Maker pays no commissions, on secondary market");
-        assertEq(nayms.internalBalanceOf(entity3, nWETH), e3WethBeforeTrade - dt.entity1MintAndSaleAmt - totalCommissions, "Taker should pay commissions, on secondary market");
+        assertEq(nayms.internalBalanceOf(entity2, wethId), e2WethBeforeTrade + dt.entity1MintAndSaleAmt, "Maker pays no commissions, on secondary market");
+        assertEq(nayms.internalBalanceOf(entity3, wethId), e3WethBeforeTrade - dt.entity1MintAndSaleAmt - totalCommissions, "Taker should pay commissions, on secondary market");
     }
 
     function testMatchMakerPriceWithTakerBuyAmount() public {
@@ -276,7 +270,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         writeTokenBalance(signer2, naymsAddress, wethAddress, dt.entity2ExternalDepositAmt);
         nayms.externalDeposit(wethAddress, dt.entity2ExternalDepositAmt);
 
-        nayms.executeLimitOffer(nWETH, 1_000 ether, entity1, 500 ether);
+        nayms.executeLimitOffer(wethId, 1_000 ether, entity1, 500 ether);
         vm.stopPrank();
 
         assertEq(nayms.internalBalanceOf(entity2, entity1), 500 ether, "should match takers buy amount, not sell amount");
@@ -347,7 +341,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
             nayms.externalDeposit(wethAddress, e2Balance);
             vm.stopPrank();
 
-            // sell x nENTITY1 for y nWETH
+            // sell x nENTITY1 for y WETH
             nayms.startTokenSale(entity1, saleAmount, salePrice);
 
             MarketInfo memory marketInfo1 = nayms.getOffer(1);
@@ -355,15 +349,15 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
             assertEq(marketInfo1.sellToken, entity1, "sell token");
             assertEq(marketInfo1.sellAmount, saleAmount, "sell amount");
             assertEq(marketInfo1.sellAmountInitial, saleAmount, "sell amount initial");
-            assertEq(marketInfo1.buyToken, nWETH, "buy token");
+            assertEq(marketInfo1.buyToken, wethId, "buy token");
             assertEq(marketInfo1.buyAmount, salePrice, "buy amount");
             assertEq(marketInfo1.buyAmountInitial, salePrice, "buy amount initial");
             assertEq(marketInfo1.state, LibConstants.OFFER_STATE_ACTIVE, "state");
 
             vm.prank(signer2);
-            nayms.executeLimitOffer(nWETH, salePrice, entity1, saleAmount);
+            nayms.executeLimitOffer(wethId, salePrice, entity1, saleAmount);
 
-            assertOfferFilled(1, entity1, entity1, saleAmount, nWETH, salePrice);
+            assertOfferFilled(1, entity1, entity1, saleAmount, wethId, salePrice);
         }
     }
 
@@ -393,9 +387,9 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
             nayms.externalDeposit(wethAddress, salePrice);
             assertEq(nayms.internalBalanceOf(entity2, LibHelpers._getIdForAddress(wethAddress)), salePrice, "Entity2: invalid balance");
 
-            // buy x nENTITY1 for y nWETH
+            // buy x nENTITY1 for y WETH
 
-            nayms.executeLimitOffer(nWETH, salePrice, entity1, saleAmount);
+            nayms.executeLimitOffer(wethId, salePrice, entity1, saleAmount);
             vm.stopPrank();
 
             // taker needs balance for trading commissions
@@ -406,11 +400,11 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
             vm.stopPrank();
             assertEq(nayms.internalBalanceOf(entity1, LibHelpers._getIdForAddress(wethAddress)), e1Balance, "Entity1: invalid balance");
 
-            // sell x nENTITY1 for y nWETH
+            // sell x nENTITY1 for y WETH
             nayms.startTokenSale(entity1, saleAmount, salePrice);
 
-            assertOfferFilled(1, entity2, nWETH, salePrice, entity1, saleAmount);
-            assertOfferFilled(2, entity1, entity1, saleAmount, nWETH, salePrice);
+            assertOfferFilled(1, entity2, wethId, salePrice, entity1, saleAmount);
+            assertOfferFilled(2, entity1, entity1, saleAmount, wethId, salePrice);
         }
     }
 
@@ -425,7 +419,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         writeTokenBalance(signer2, naymsAddress, wethAddress, 1_000 ether);
         nayms.externalDeposit(wethAddress, 1_000 ether);
 
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt - 200 ether, entity1, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt - 200 ether, entity1, dt.entity1MintAndSaleAmt);
 
         vm.expectRevert("_internalBurn: tokens locked");
         nayms.externalWithdrawFromEntity(entity2, signer2, wethAddress, 500 ether);
@@ -437,12 +431,12 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         assertEq(offer.state, LibConstants.OFFER_STATE_CANCELLED);
 
         nayms.externalWithdrawFromEntity(entity2, signer2, wethAddress, 500 ether);
-        uint256 balanceAfterWithdraw = nayms.internalBalanceOf(entity2, nWETH);
+        uint256 balanceAfterWithdraw = nayms.internalBalanceOf(entity2, wethId);
         assertEq(balanceAfterWithdraw, 500 ether);
     }
 
     function testGetBestOfferId() public {
-        assertEq(nayms.getBestOfferId(nWETH, entity1), 0, "invalid best offer, when no offer exists");
+        assertEq(nayms.getBestOfferId(wethId, entity1), 0, "invalid best offer, when no offer exists");
 
         testStartTokenSale();
 
@@ -468,21 +462,21 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         vm.stopPrank();
 
         vm.startPrank(signer2);
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt - 200 ether, entity1, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt - 200 ether, entity1, dt.entity1MintAndSaleAmt);
         vm.stopPrank();
 
         vm.startPrank(signer3);
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt - 150 ether, entity1, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt - 150 ether, entity1, dt.entity1MintAndSaleAmt);
         vm.stopPrank();
         // last offer at this point will be the actual best offer
         uint256 bestOfferID = nayms.getLastOfferId();
 
         vm.startPrank(signer4);
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt - 190 ether, entity1, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt - 190 ether, entity1, dt.entity1MintAndSaleAmt);
         vm.stopPrank();
 
         // confirm best offer
-        assertEq(bestOfferID, nayms.getBestOfferId(nWETH, entity1), "Not the best offer");
+        assertEq(bestOfferID, nayms.getBestOfferId(wethId, entity1), "Not the best offer");
     }
 
     function testOfferValidation() public {
@@ -490,7 +484,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
 
         vm.startPrank(account9);
         vm.expectRevert("must belong to entity to make an offer");
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt, entity1, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt, entity1, dt.entity1MintAndSaleAmt);
         vm.stopPrank();
 
         // init taker entity
@@ -502,33 +496,33 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         nayms.externalDeposit(wethAddress, 1_000 ether);
 
         vm.expectRevert("sell amount exceeds uint128 limit");
-        nayms.executeLimitOffer(nWETH, 2**128 + 1000, entity1, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, 2**128 + 1000, entity1, dt.entity1MintAndSaleAmt);
 
         vm.expectRevert("buy amount exceeds uint128 limit");
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt, entity1, 2**128 + 1000);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt, entity1, 2**128 + 1000);
 
         vm.expectRevert("sell amount must be >0");
-        nayms.executeLimitOffer(nWETH, 0, entity1, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, 0, entity1, dt.entity1MintAndSaleAmt);
 
         vm.expectRevert("buy amount must be >0");
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt, entity1, 0);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt, entity1, 0);
 
         vm.expectRevert("sell token must be valid");
         nayms.executeLimitOffer("", dt.entity1MintAndSaleAmt, entity1, dt.entity1MintAndSaleAmt);
 
         vm.expectRevert("buy token must be valid");
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt, "", dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt, "", dt.entity1MintAndSaleAmt);
 
         vm.expectRevert("must be one platform token"); // 2 non-platform tokens
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt, nWBTC, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt, wbtcId, dt.entity1MintAndSaleAmt);
 
         vm.expectRevert("cannot sell and buy same token");
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt, nWETH, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt, wethId, dt.entity1MintAndSaleAmt);
 
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt - 10 ether, entity1, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt - 10 ether, entity1, dt.entity1MintAndSaleAmt);
 
         vm.expectRevert("tokens locked");
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt, entity1, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt, entity1, dt.entity1MintAndSaleAmt);
 
         uint256 lastOfferId = nayms.getLastOfferId();
         nayms.cancelOffer(lastOfferId);
@@ -559,17 +553,17 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         writeTokenBalance(signer2, naymsAddress, wethAddress, dt.entity2ExternalDepositAmt * 2);
         nayms.externalDeposit(wethAddress, dt.entity2ExternalDepositAmt * 2);
 
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt * 2, entity1, dt.entity1MintAndSaleAmt * 2);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt * 2, entity1, dt.entity1MintAndSaleAmt * 2);
         vm.stopPrank();
 
-        assertOfferPartiallyFilled(2, entity2, nWETH, dt.entity1MintAndSaleAmt, dt.entity1MintAndSaleAmt * 2, entity1, dt.entity1MintAndSaleAmt, dt.entity1MintAndSaleAmt * 2);
+        assertOfferPartiallyFilled(2, entity2, wethId, dt.entity1MintAndSaleAmt, dt.entity1MintAndSaleAmt * 2, entity1, dt.entity1MintAndSaleAmt, dt.entity1MintAndSaleAmt * 2);
 
         // start another nENTITY1 token sale
         nayms.startTokenSale(entity1, dt.entity1MintAndSaleAmt, dt.entity1SalePrice);
 
-        assertOfferFilled(1, entity1, entity1, dt.entity1MintAndSaleAmt, nWETH, dt.entity1SalePrice);
-        assertOfferFilled(2, entity2, nWETH, dt.entity1MintAndSaleAmt * 2, entity1, dt.entity1SalePrice * 2);
-        assertOfferFilled(3, entity1, entity1, dt.entity1MintAndSaleAmt, nWETH, dt.entity1SalePrice);
+        assertOfferFilled(1, entity1, entity1, dt.entity1MintAndSaleAmt, wethId, dt.entity1SalePrice);
+        assertOfferFilled(2, entity2, wethId, dt.entity1MintAndSaleAmt * 2, entity1, dt.entity1SalePrice * 2);
+        assertOfferFilled(3, entity1, entity1, dt.entity1MintAndSaleAmt, wethId, dt.entity1SalePrice);
     }
 
     function testBestOffersWithCancel() public {
@@ -597,34 +591,34 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         vm.stopPrank();
 
         vm.startPrank(signer2);
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt - 200 ether, entity1, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt - 200 ether, entity1, dt.entity1MintAndSaleAmt);
         vm.stopPrank();
 
         vm.startPrank(signer3);
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt - 300 ether, entity1, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt - 300 ether, entity1, dt.entity1MintAndSaleAmt);
         vm.stopPrank();
 
         vm.startPrank(signer4);
-        nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt - 400 ether, entity1, dt.entity1MintAndSaleAmt);
+        nayms.executeLimitOffer(wethId, dt.entity1MintAndSaleAmt - 400 ether, entity1, dt.entity1MintAndSaleAmt);
         vm.stopPrank();
 
         vm.startPrank(signer4);
         nayms.cancelOffer(4);
         vm.stopPrank();
 
-        assertEq(nayms.getBestOfferId(nWETH, entity1), 2, "invalid best offer ID");
+        assertEq(nayms.getBestOfferId(wethId, entity1), 2, "invalid best offer ID");
 
         vm.startPrank(signer2);
         nayms.cancelOffer(2);
         vm.stopPrank();
 
-        assertEq(nayms.getBestOfferId(nWETH, entity1), 3, "invalid best offer ID");
+        assertEq(nayms.getBestOfferId(wethId, entity1), 3, "invalid best offer ID");
 
         vm.startPrank(signer3);
         nayms.cancelOffer(3);
         vm.stopPrank();
 
-        assertEq(nayms.getBestOfferId(nWETH, entity1), 0, "invalid best offer ID");
+        assertEq(nayms.getBestOfferId(wethId, entity1), 0, "invalid best offer ID");
     }
 
     function assertOfferFilled(
@@ -689,7 +683,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         testStartTokenSale();
         bytes32 makerId = account0Id;
         bytes32 takerId = entity1;
-        bytes32 tokenId = nWETH;
+        bytes32 tokenId = wethId;
         uint256 requestedBuyAmount = 10_000;
 
         (success, result) = address(nayms).call(abi.encodeWithSelector(libFeeRouterFixture.payTradingCommissions.selector, makerId, takerId, tokenId, requestedBuyAmount));
@@ -699,9 +693,9 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         bytes32 ndfId = LibHelpers._stringToBytes32(LibConstants.NDF_IDENTIFIER);
         bytes32 stakingId = LibHelpers._stringToBytes32(LibConstants.STM_IDENTIFIER);
 
-        // assertEq(nayms.internalBalanceOf(naymsLtdId, nWETH), tc.commissionNaymsLtd, "balance of naymsLtd should have INCREASED (trading commissions)");
-        // assertEq(nayms.internalBalanceOf(ndfId, nWETH), tc.commissionNDF, "balance of ndfId should have INCREASED (trading commissions)");
-        // assertEq(nayms.internalBalanceOf(stakingId, nWETH), tc.commissionSTM, "balance of stakingId should have INCREASED (trading commissions)");
+        assertEq(nayms.internalBalanceOf(naymsLtdId, wethId), tc.commissionNaymsLtd, "balance of naymsLtd should have INCREASED (trading commissions)");
+        assertEq(nayms.internalBalanceOf(ndfId, wethId), tc.commissionNDF, "balance of ndfId should have INCREASED (trading commissions)");
+        assertEq(nayms.internalBalanceOf(stakingId, wethId), tc.commissionSTM, "balance of stakingId should have INCREASED (trading commissions)");
 
         (success, result) = address(nayms).call(abi.encodeWithSelector(libFeeRouterFixture.getTradingCommissionsBasisPointsFixture.selector));
     }

--- a/test/T04Market.t.sol
+++ b/test/T04Market.t.sol
@@ -749,7 +749,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         (Stakeholders memory stakeholders, SimplePolicy memory policy) = initPolicyWithLimit(policyId1, policyLimit);
         nayms.createSimplePolicy(policyId1, entity1, stakeholders, policy, "test");
 
-        assertEq(nayms.getLockedBalance(entity1, wethId), policyLimit, "locked balance should increase");
+        assertEq(nayms.getLockedBalance(entity1, wethId), (policyLimit * collateralRatio_500) / LibConstants.BP_FACTOR, "locked balance should increase");
 
         vm.expectRevert("tokens locked");
         nayms.executeLimitOffer(entity1, salePrice, wethId, saleAmount);

--- a/test/T04Market.t.sol
+++ b/test/T04Market.t.sol
@@ -196,7 +196,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
 
         // try transfering nEntity1 from entity1 to entity0 - this should REVERT!
         vm.startPrank(signer1);
-        vm.expectRevert("_internalTransferFrom: tokens for sale in mkt");
+        vm.expectRevert("_internalTransferFrom: tokens locked");
         nayms.internalTransfer(DEFAULT_ACCOUNT0_ENTITY_ID, entity1, 1);
         vm.stopPrank();
 
@@ -427,7 +427,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
 
         nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt - 200 ether, entity1, dt.entity1MintAndSaleAmt);
 
-        vm.expectRevert("_internalBurn: tokens for sale in mkt");
+        vm.expectRevert("_internalBurn: tokens locked");
         nayms.externalWithdrawFromEntity(entity2, signer2, wethAddress, 500 ether);
 
         uint256 lastOfferId = nayms.getLastOfferId();
@@ -527,7 +527,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
 
         nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt - 10 ether, entity1, dt.entity1MintAndSaleAmt);
 
-        vm.expectRevert("tokens locked in market");
+        vm.expectRevert("tokens locked");
         nayms.executeLimitOffer(nWETH, dt.entity1MintAndSaleAmt, entity1, dt.entity1MintAndSaleAmt);
 
         uint256 lastOfferId = nayms.getLastOfferId();

--- a/test/defaults/D02TestSetup.sol
+++ b/test/defaults/D02TestSetup.sol
@@ -12,16 +12,23 @@ contract D02TestSetup is D01Deployment {
     //// test tokens ////
     MockERC20 public weth;
     address public wethAddress;
+    bytes32 public wethId;
 
     MockERC20 public wbtc;
     address public wbtcAddress;
+    bytes32 public wbtcId;
 
     function setUp() public virtual override {
         super.setUp();
+
         weth = new MockERC20("Wrapped ETH", "WETH", 18);
-        wbtc = new MockERC20("Wrapped BTC", "WBTC", 18);
         wethAddress = address(weth);
+        wethId = LibHelpers._getIdForAddress(wethAddress);
+
+        wbtc = new MockERC20("Wrapped BTC", "WBTC", 18);
         wbtcAddress = address(wbtc);
+        wbtcId = LibHelpers._getIdForAddress(wbtcAddress);
+
         vm.label(wethAddress, "WETH");
         vm.label(wbtcAddress, "WBTC");
     }


### PR DESCRIPTION
When creating a policy, funds should be locked in the entity's balance. One of the reasons for this is, so that the collateral cannot be used for trading or withdrawing while there are active policies that could potentially require these funds as a collateral for the claims.

Few other things are included in this pull-requests:
- Funds locked and utilised capacity are factored with the collateral ratio, not necessarily the entire amount gets locked/utilised
- Only entity administrator can pay out the dividends
- Refactor tests, pull in `initPolicy` into `D03ProtocolDefaults` and few other small improvements

ClickUp: [CU-320z296](https://app.clickup.com/t/320z296)