### PR TITLE
function lock for externalWithdrawFromEntity()

### DIFF
--- a/src/diamonds/nayms/AppStorage.sol
+++ b/src/diamonds/nayms/AppStorage.sol
@@ -76,11 +76,23 @@ struct AppStorage {
     uint256 sysAdmins; // counter for the number of sys admin accounts currently assigned
 }
 
+struct FunctionLockedStorage {
+    mapping(bytes4 => bool) locked; // function selector => is locked?
+}
+
 library LibAppStorage {
     bytes32 internal constant NAYMS_DIAMOND_STORAGE_POSITION = keccak256("diamond.standard.nayms.storage");
+    bytes32 internal constant FUNCTION_LOCK_STORAGE_POSITION = keccak256("diamond.function.lock.storage");
 
     function diamondStorage() internal pure returns (AppStorage storage ds) {
         bytes32 position = NAYMS_DIAMOND_STORAGE_POSITION;
+        assembly {
+            ds.slot := position
+        }
+    }
+
+    function functionLockStorage() internal pure returns (FunctionLockedStorage storage ds) {
+        bytes32 position = FUNCTION_LOCK_STORAGE_POSITION;
         assembly {
             ds.slot := position
         }

--- a/src/diamonds/nayms/Modifiers.sol
+++ b/src/diamonds/nayms/Modifiers.sol
@@ -16,6 +16,10 @@ import { LibACL } from "./libs/LibACL.sol";
  * @dev Function modifiers to control access
  */
 contract Modifiers {
+    modifier assertIsFunctionLocked(bytes4 functionSelector) {
+        require(!LibAdmin._isFunctionLocked(functionSelector), "function is locked");
+        _;
+    }
     modifier assertSysAdmin() {
         require(
             LibACL._isInGroup(LibHelpers._getIdForAddress(LibMeta.msgSender()), LibAdmin._getSystemId(), LibHelpers._stringToBytes32(LibConstants.GROUP_SYSTEM_ADMINS)),

--- a/src/diamonds/nayms/facets/AdminFacet.sol
+++ b/src/diamonds/nayms/facets/AdminFacet.sol
@@ -84,4 +84,16 @@ contract AdminFacet is IAdminFacet, Modifiers {
     function isObjectTokenizable(bytes32 _objectId) external view returns (bool) {
         return LibObject._isObjectTokenizable(_objectId);
     }
+
+    function lockFunction(bytes4 functionSelector) external assertSysAdmin {
+        LibAdmin._lockFunction(functionSelector);
+    }
+
+    function unlockFunction(bytes4 functionSelector) external assertSysAdmin {
+        LibAdmin._unlockFunction(functionSelector);
+    }
+
+    function isFunctionLocked(bytes4 functionSelector) external view returns (bool) {
+        return LibAdmin._isFunctionLocked(functionSelector);
+    }
 }

--- a/src/diamonds/nayms/facets/TokenizedVaultIOFacet.sol
+++ b/src/diamonds/nayms/facets/TokenizedVaultIOFacet.sol
@@ -45,7 +45,7 @@ contract TokenizedVaultIOFacet is ITokenizedVaultIOFacet, Modifiers, ReentrancyG
         address _receiver,
         address _externalTokenAddress,
         uint256 _amount
-    ) external assertEntityAdmin(_entityId) nonReentrant {
+    ) external assertEntityAdmin(_entityId) nonReentrant assertIsFunctionLocked(ITokenizedVaultIOFacet.externalWithdrawFromEntity.selector) {
         LibTokenizedVaultIO._externalWithdraw(_entityId, _receiver, _externalTokenAddress, _amount);
     }
 }

--- a/src/diamonds/nayms/interfaces/IAdminFacet.sol
+++ b/src/diamonds/nayms/interfaces/IAdminFacet.sol
@@ -63,4 +63,25 @@ interface IAdminFacet {
      * @param _objectId ID of the object
      */
     function isObjectTokenizable(bytes32 _objectId) external returns (bool);
+
+    /**
+     * @notice System Admin can lock a function
+     * @dev This toggles FunctionLockedStorage.lock to true
+     * @param functionSelector the bytes4 function selector
+     */
+    function lockFunction(bytes4 functionSelector) external;
+
+    /**
+     * @notice System Admin can unlock a function
+     * @dev This toggles FunctionLockedStorage.lock to false
+     * @param functionSelector the bytes4 function selector
+     */
+    function unlockFunction(bytes4 functionSelector) external;
+
+    /**
+     * @notice Check if a function has been locked by a system admin
+     * @dev This views FunctionLockedStorage.lock
+     * @param functionSelector the bytes4 function selector
+     */
+    function isFunctionLocked(bytes4 functionSelector) external view returns (bool);
 }

--- a/src/diamonds/nayms/libs/LibAdmin.sol
+++ b/src/diamonds/nayms/libs/LibAdmin.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import { AppStorage, LibAppStorage } from "../AppStorage.sol";
+import { AppStorage, FunctionLockedStorage, LibAppStorage } from "../AppStorage.sol";
 import { LibConstants } from "./LibConstants.sol";
 import { LibHelpers } from "./LibHelpers.sol";
 import { LibObject } from "./LibObject.sol";
@@ -65,5 +65,20 @@ library LibAdmin {
 
         // Supported tokens cannot be removed because they may exist in the system!
         return s.supportedExternalTokens;
+    }
+
+    function _lockFunction(bytes4 functionSelector) internal {
+        FunctionLockedStorage storage s = LibAppStorage.functionLockStorage();
+        s.locked[functionSelector] = true;
+    }
+
+    function _unlockFunction(bytes4 functionSelector) internal {
+        FunctionLockedStorage storage s = LibAppStorage.functionLockStorage();
+        s.locked[functionSelector] = false;
+    }
+
+    function _isFunctionLocked(bytes4 functionSelector) internal view returns (bool) {
+        FunctionLockedStorage storage s = LibAppStorage.functionLockStorage();
+        return s.locked[functionSelector];
     }
 }


### PR DESCRIPTION
The motivation behind this PR is to implement a freeze / unfreeze mechanism for the external withdraw (`externalWithdrawFromEntity`) method which a system admin can toggle.

Notes:
Separate diamond storage location for the lock / unlock data struct. Reasoning - instead of continuing to append to AppStorage struct, we can organize siloed variables in their own struct. 