### PR TITLE
ID to address conversion fix

### DIFF
--- a/src/diamonds/nayms/libs/LibHelpers.sol
+++ b/src/diamonds/nayms/libs/LibHelpers.sol
@@ -15,7 +15,7 @@ library LibHelpers {
         return _getIdForAddress(msg.sender);
     }
 
-    function _checkBottom12BytesAreEmpty(bytes32 value) public pure returns (bool) {
+    function _checkBottom12BytesAreEmpty(bytes32 value) internal pure returns (bool) {
         bytes32 mask = 0x0000000000000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF;
         bytes32 bottom12Bytes = value & mask;
 
@@ -40,7 +40,7 @@ library LibHelpers {
         return address(bytes20(_id));
     }
 
-    function _isAddress(bytes32 _id) internal pure returns(bool) {
+    function _isAddress(bytes32 _id) internal pure returns (bool) {
         return _id & 0x0000000000000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF == 0;
     }
 

--- a/src/diamonds/nayms/libs/LibHelpers.sol
+++ b/src/diamonds/nayms/libs/LibHelpers.sol
@@ -40,6 +40,10 @@ library LibHelpers {
         return address(bytes20(_id));
     }
 
+    function _isAddress(bytes32 _id) internal pure returns(bool) {
+        return _id & 0x0000000000000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF == 0;
+    }
+
     // Conversion Utilities
 
     /**

--- a/src/diamonds/nayms/libs/LibMarket.sol
+++ b/src/diamonds/nayms/libs/LibMarket.sol
@@ -365,9 +365,9 @@ library LibMarket {
         // The platform also does not allow entities to trade external tokens (cannot trade an external token for another external token).
 
         bool isSellTokenAParticipationToken = s.existingEntities[_sellToken];
-        bool isSellTokenASupportedExternalToken = s.externalTokenSupported[LibHelpers._getAddressFromId(_sellToken)];
+        bool isSellTokenASupportedExternalToken = LibHelpers._isAddress(_sellToken) && s.externalTokenSupported[LibHelpers._getAddressFromId(_sellToken)];
         bool isBuyTokenAParticipationToken = s.existingEntities[_buyToken];
-        bool isBuyTokenASupportedExternalToken = s.externalTokenSupported[LibHelpers._getAddressFromId(_buyToken)];
+        bool isBuyTokenASupportedExternalToken = LibHelpers._isAddress(_buyToken) && s.externalTokenSupported[LibHelpers._getAddressFromId(_buyToken)];
 
         _assertAmounts(_sellAmount, _buyAmount);
 

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -17,9 +17,9 @@ import "src/diamonds/nayms/interfaces/CustomErrors.sol";
 
 // solhint-disable no-console
 contract T04EntityTest is D03ProtocolDefaults {
-    bytes32 internal entityId1 = "0xe1";
-    bytes32 internal policyId1 = "0xC0FFEE";
-    bytes32 public testPolicyDataHash = "test";
+    bytes32 internal entityId1 = 0xe10d947335abff84f4d0ebc75f32f3a549614348ab29e220c4b20b0acbd1fa38;
+    bytes32 internal policyId1 = 0x1ea6c707069e49cdc3a4ad357dbe9f52e3a3679636e37698a9ca254b9cb33869;
+    bytes32 public testPolicyDataHash = 0x00a420601de63bf726c0be38414e9255d301d74ad0d820d633f3ab75effd6f5b;
     bytes32 public policyHashedTypedData;
 
     SimplePolicyFixture internal simplePolicyFixture;
@@ -206,7 +206,7 @@ contract T04EntityTest is D03ProtocolDefaults {
         assertEq(nayms.getLockedBalance(entityId1, wethId), 0, "NO FUNDS should be locked");
 
         changePrank(systemAdmin);
-        nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, "test");
+        nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
         uint256 expectedLockedBalance = (simplePolicy.limit * 5_000) / LibConstants.BP_FACTOR;
         assertEq(nayms.getLockedBalance(entityId1, wethId), expectedLockedBalance, "funds SHOULD BE locked");
 


### PR DESCRIPTION
When using a non-address ID, conversion throws an error. This is needed in start token sale flow. Workaround is provided with this PR.