### PR TITLE
Reintroduce `SimplePolicyInfo` struct

### DIFF
--- a/src/diamonds/nayms/facets/SimplePolicyFacet.sol
+++ b/src/diamonds/nayms/facets/SimplePolicyFacet.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 import { Modifiers } from "../Modifiers.sol";
-import { Entity, SimplePolicy, PolicyCommissionsBasisPoints } from "../AppStorage.sol";
+import { Entity, SimplePolicy, SimplePolicyInfo, PolicyCommissionsBasisPoints } from "../AppStorage.sol";
 import { LibObject } from "../libs/LibObject.sol";
 import { LibHelpers } from "../libs/LibHelpers.sol";
 import { LibSimplePolicy } from "../libs/LibSimplePolicy.sol";
@@ -48,8 +48,19 @@ contract SimplePolicyFacet is ISimplePolicyFacet, Modifiers {
      * @param _policyId Id of the simple policy
      * @return Simple policy metadata
      */
-    function getSimplePolicyInfo(bytes32 _policyId) external view returns (SimplePolicy memory) {
-        return LibSimplePolicy._getSimplePolicyInfo(_policyId);
+    function getSimplePolicyInfo(bytes32 _policyId) external view returns (SimplePolicyInfo memory) {
+        SimplePolicy memory p = LibSimplePolicy._getSimplePolicyInfo(_policyId);
+        return
+            SimplePolicyInfo({
+                startDate: p.startDate,
+                maturationDate: p.maturationDate,
+                asset: p.asset,
+                limit: p.limit,
+                fundsLocked: p.fundsLocked,
+                cancelled: p.cancelled,
+                claimsPaid: p.claimsPaid,
+                premiumsPaid: p.premiumsPaid
+            });
     }
 
     function getPremiumCommissionBasisPoints() external view returns (PolicyCommissionsBasisPoints memory bp) {

--- a/src/diamonds/nayms/interfaces/FreeStructs.sol
+++ b/src/diamonds/nayms/interfaces/FreeStructs.sol
@@ -53,6 +53,17 @@ struct SimplePolicy {
     uint256[] commissionBasisPoints;
 }
 
+struct SimplePolicyInfo {
+    uint256 startDate;
+    uint256 maturationDate;
+    bytes32 asset;
+    uint256 limit;
+    bool fundsLocked;
+    bool cancelled;
+    uint256 claimsPaid;
+    uint256 premiumsPaid;
+}
+
 struct PolicyCommissionsBasisPoints {
     uint16 premiumCommissionNaymsLtdBP;
     uint16 premiumCommissionNDFBP;

--- a/src/diamonds/nayms/interfaces/ISimplePolicyFacet.sol
+++ b/src/diamonds/nayms/interfaces/ISimplePolicyFacet.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import { SimplePolicy, PolicyCommissionsBasisPoints } from "./FreeStructs.sol";
+import { SimplePolicyInfo, PolicyCommissionsBasisPoints } from "./FreeStructs.sol";
 
 /**
  * @title Simple Policies
@@ -52,7 +52,7 @@ interface ISimplePolicyFacet {
      * @param _id Id of the simple policy
      * @return Simple policy metadata
      */
-    function getSimplePolicyInfo(bytes32 _id) external view returns (SimplePolicy memory);
+    function getSimplePolicyInfo(bytes32 _id) external view returns (SimplePolicyInfo memory);
 
     /**
      * @notice Get the policy premium commissions basis points.

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.17;
 import { Vm } from "forge-std/Vm.sol";
 
 import { D03ProtocolDefaults, console2, LibConstants, LibHelpers, LibObject } from "./defaults/D03ProtocolDefaults.sol";
-import { Entity, MarketInfo, SimplePolicy, Stakeholders } from "src/diamonds/nayms/interfaces/FreeStructs.sol";
+import { Entity, MarketInfo, SimplePolicy, SimplePolicyInfo, Stakeholders } from "src/diamonds/nayms/interfaces/FreeStructs.sol";
 import { INayms, IDiamondCut } from "src/diamonds/nayms/INayms.sol";
 
 import { LibACL } from "src/diamonds/nayms/libs/LibACL.sol";
@@ -491,7 +491,7 @@ contract T04EntityTest is D03ProtocolDefaults {
         // create it successfully
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
 
-        SimplePolicy memory simplePolicyInfo = nayms.getSimplePolicyInfo(policyId1);
+        SimplePolicyInfo memory simplePolicyInfo = nayms.getSimplePolicyInfo(policyId1);
         assertEq(simplePolicyInfo.startDate, simplePolicy.startDate, "Start dates should match");
         assertEq(simplePolicyInfo.maturationDate, simplePolicy.maturationDate, "Maturation dates should match");
         assertEq(simplePolicyInfo.asset, simplePolicy.asset, "Assets should match");
@@ -999,7 +999,7 @@ contract T04EntityTest is D03ProtocolDefaults {
             "utilized capacity should change"
         );
 
-        SimplePolicy memory simplePolicyInfo = nayms.getSimplePolicyInfo(policyId1);
+        SimplePolicyInfo memory simplePolicyInfo = nayms.getSimplePolicyInfo(policyId1);
         assertEq(simplePolicyInfo.cancelled, true, "Simple policy should be cancelled");
 
         vm.expectRevert("Policy already cancelled");


### PR DESCRIPTION
Due to `web3j` compatibility issues, we need to reintroduce `SimplePolicyInfo` struct. There is an issue with smart contracts bindings for java, produced by `web3j`. An error breaks the execution flow, when we want to fetch a struct which contains an array as a member variable. Ultimately, this prevents processing of the `SimplePolicyPremiumPaid` event in backend and synchronisation of data between backend and blockchain.