### PR TITLE
Custom fee schedule IDs can be assigned to an entity ID

### DIFF
--- a/src/diamonds/nayms/AppStorage.sol
+++ b/src/diamonds/nayms/AppStorage.sol
@@ -78,6 +78,8 @@ struct AppStorage {
     mapping(address => bytes32) objectTokenWrapperId; // reverse mapping token wrapper address => object ID
     mapping(string => bytes32) tokenSymbolObjectId; // reverse mapping token symbol => object ID, to ensure symbol uniqueness
     mapping(uint256 => FeeReceiver[]) feeSchedules; // fee schedule ID => array of FeeReceiver struct
+    mapping(bytes32 => uint256) customPremiumFeeScheduleId; // entity ID => custom policy premium fee schedule ID
+    mapping(bytes32 => uint256) customMarketFeeScheduleId; // entity ID => custom market premium fee schedule ID
 }
 
 struct FunctionLockedStorage {

--- a/src/diamonds/nayms/facets/AdminFacet.sol
+++ b/src/diamonds/nayms/facets/AdminFacet.sol
@@ -96,4 +96,12 @@ contract AdminFacet is IAdminFacet, Modifiers {
     function addFeeSchedule(uint256 _feeScheduleId, FeeReceiver[] calldata _feeReceivers) external assertSysAdmin {
         LibFeeRouter._addFeeSchedule(_feeScheduleId, _feeReceivers);
     }
+
+    function setCustomPremiumFeeScheduleIdForEntity(bytes32 _entityId, uint256 _feeScheduleId) external assertSysAdmin {
+        LibFeeRouter._setCustomPremiumFeeScheduleIdForEntity(_entityId, _feeScheduleId);
+    }
+
+    function setCustomMarketFeeScheduleIdForEntity(bytes32 _entityId, uint256 _feeScheduleId) external assertSysAdmin {
+        LibFeeRouter._setCustomMarketFeeScheduleIdForEntity(_entityId, _feeScheduleId);
+    }
 }

--- a/src/diamonds/nayms/facets/EntityFacet.sol
+++ b/src/diamonds/nayms/facets/EntityFacet.sol
@@ -126,6 +126,6 @@ contract EntityFacet is IEntityFacet, Modifiers, ReentrancyGuard {
     }
 
     function getTradingFeeScheduleId(bytes32 _entityId) external view returns (uint256 feeScheduleId_) {
-        feeScheduleId_ = LibFeeRouter._getTradingFeeScheduleId(_entityId);
+        feeScheduleId_ = LibFeeRouter._getMarketFeeScheduleId(_entityId);
     }
 }

--- a/src/diamonds/nayms/facets/MarketFacet.sol
+++ b/src/diamonds/nayms/facets/MarketFacet.sol
@@ -116,7 +116,7 @@ contract MarketFacet is IMarketFacet, Modifiers, ReentrancyGuard {
      * @return cf CalculatedFees struct
      */
     function calculateTradingFees(bytes32 _buyer, uint256 _buyAmount) external view returns (CalculatedFees memory cf) {
-        cf = LibFeeRouter._calculateTradingFees(_buyer, _buyAmount);
+        cf = LibFeeRouter._calculateMarketFees(_buyer, _buyAmount);
     }
 
     function getMakerBP() external view returns (uint16) {

--- a/src/diamonds/nayms/interfaces/IAdminFacet.sol
+++ b/src/diamonds/nayms/interfaces/IAdminFacet.sol
@@ -86,4 +86,8 @@ interface IAdminFacet {
     function replaceMakerBP(uint16 _newMakerBP) external;
 
     function addFeeSchedule(uint256 _feeScheduleId, FeeReceiver[] calldata _feeReceivers) external;
+
+    function setCustomPremiumFeeScheduleIdForEntity(bytes32 _entityId, uint256 _feeScheduleId) external;
+
+    function setCustomMarketFeeScheduleIdForEntity(bytes32 _entityId, uint256 _feeScheduleId) external;
 }

--- a/src/diamonds/nayms/libs/LibConstants.sol
+++ b/src/diamonds/nayms/libs/LibConstants.sol
@@ -58,10 +58,6 @@ library LibConstants {
     /// @dev Default Premium Fee Schedule ID
     uint256 internal constant PREMIUM_FEE_SCHEDULE_DEFAULT = 4;
 
-    /// @dev The value used to derive the storage slot for the custom market fees schedule ID.
-    /// note: The custom premium fee schedule ID is stored in the slot equal to the policy's parent ID without any offset.
-    uint256 internal constant STORAGE_OFFSET_FOR_CUSTOM_MARKET_FEES = 1;
-
     /*///////////////////////////////////////////////////////////////////////////
                         MARKET OFFER STATES
     ///////////////////////////////////////////////////////////////////////////*/

--- a/src/diamonds/nayms/libs/LibMarket.sol
+++ b/src/diamonds/nayms/libs/LibMarket.sol
@@ -270,7 +270,7 @@ library LibMarket {
             if (s.offers[_offerId].feeSchedule == LibConstants.MARKET_FEE_SCHEDULE_INITIAL_OFFER || _feeSchedule == LibConstants.MARKET_FEE_SCHEDULE_INITIAL_OFFER) {
                 feeSchedule = LibConstants.MARKET_FEE_SCHEDULE_INITIAL_OFFER;
             } else {
-                feeSchedule = LibFeeRouter._getTradingFeeScheduleId(_takerId);
+                feeSchedule = LibFeeRouter._getMarketFeeScheduleId(_takerId);
             }
 
             bytes32 buyer;
@@ -283,10 +283,10 @@ library LibMarket {
             // _takeExternalToken == true means the creator is selling an external token
             if (_takeExternalToken) {
                 // sellToken is external supported token, commissions are paid on top of _buyAmount in sellToken
-                commissionsPaid_ = LibFeeRouter._payTradingFees(feeSchedule, buyer, s.offers[_offerId].creator, _takerId, s.offers[_offerId].sellToken, _buyAmount);
+                commissionsPaid_ = LibFeeRouter._payMarketFees(feeSchedule, buyer, s.offers[_offerId].creator, _takerId, s.offers[_offerId].sellToken, _buyAmount);
             } else {
                 // sellToken is internal/participation token, commissions are paid from _sellAmount in buyToken
-                commissionsPaid_ = LibFeeRouter._payTradingFees(feeSchedule, buyer, s.offers[_offerId].creator, _takerId, s.offers[_offerId].buyToken, _sellAmount);
+                commissionsPaid_ = LibFeeRouter._payMarketFees(feeSchedule, buyer, s.offers[_offerId].creator, _takerId, s.offers[_offerId].buyToken, _sellAmount);
             }
             s.lockedBalances[s.offers[_offerId].creator][s.offers[_offerId].sellToken] -= _buyAmount;
 


### PR DESCRIPTION
** Motivation **

Assign a custom {marketplace, premium} fee schedule ID to an entity ID. If the custom fee schedule ID is 0, return the default {marketplace, premium} fee schedule ID.

A custom fee schedule only need to be set once to a fee schedule ID, and this custom fee schedule can be used via its ID by an entity.