### PR TITLE
Calculate the trading fee on matching offer(s) schedule

### DIFF
--- a/src/diamonds/nayms/facets/AdminFacet.sol
+++ b/src/diamonds/nayms/facets/AdminFacet.sol
@@ -98,7 +98,7 @@ contract AdminFacet is IAdminFacet, Modifiers {
         bytes32 _entityId,
         uint256 _feeScheduleType,
         bytes32[] calldata _receiver,
-        uint256[] calldata _basisPoints
+        uint16[] calldata _basisPoints
     ) external assertSysAdmin {
         LibFeeRouter._addFeeSchedule(_entityId, _feeScheduleType, _receiver, _basisPoints);
     }

--- a/src/diamonds/nayms/facets/MarketFacet.sol
+++ b/src/diamonds/nayms/facets/MarketFacet.sol
@@ -119,7 +119,12 @@ contract MarketFacet is IMarketFacet, Modifiers, ReentrancyGuard {
      * @return totalFees_ total fee to be payed
      * @return totalBP_ total basis points
      */
-    function calculateTradingFees(bytes32 _buyerId, bytes32 _sellToken, bytes32 _buyToken, uint256 _buyAmount) external view returns (uint256 totalFees_, uint256 totalBP_) {
+    function calculateTradingFees(
+        bytes32 _buyerId,
+        bytes32 _sellToken,
+        bytes32 _buyToken,
+        uint256 _buyAmount
+    ) external view returns (uint256 totalFees_, uint256 totalBP_) {
         (totalFees_, totalBP_) = LibFeeRouter._calculateTradingFees(_buyerId, _sellToken, _buyToken, _buyAmount);
     }
 

--- a/src/diamonds/nayms/facets/MarketFacet.sol
+++ b/src/diamonds/nayms/facets/MarketFacet.sol
@@ -112,11 +112,15 @@ contract MarketFacet is IMarketFacet, Modifiers, ReentrancyGuard {
 
     /**
      * @dev Calculate the trading fees based on a buy amount.
+     * @param _buyerId The account buying the asset.
+     * @param _sellToken The asset being sold.
+     * @param _buyToken The asset being bought.
      * @param _buyAmount The amount that the fees payments are calculated from.
-     * @return cf CalculatedFees struct
+     * @return totalFees_ total fee to be payed
+     * @return totalBP_ total basis points
      */
-    function calculateTradingFees(bytes32 _buyer, uint256 _buyAmount) external view returns (CalculatedFees memory cf) {
-        cf = LibFeeRouter._calculateTradingFees(_buyer, _buyAmount);
+    function calculateTradingFees(bytes32 _buyerId, bytes32 _sellToken, bytes32 _buyToken, uint256 _buyAmount) external view returns (uint256 totalFees_, uint256 totalBP_) {
+        (totalFees_, totalBP_) = LibFeeRouter._calculateTradingFees(_buyerId, _sellToken, _buyToken, _buyAmount);
     }
 
     function getMakerBP() external view returns (uint16) {

--- a/src/diamonds/nayms/interfaces/FreeStructs.sol
+++ b/src/diamonds/nayms/interfaces/FreeStructs.sol
@@ -85,7 +85,7 @@ struct StakingCheckpoint {
 
 struct FeeSchedule {
     bytes32[] receiver;
-    uint256[] basisPoints;
+    uint16[] basisPoints;
 }
 
 struct FeeAllocation {

--- a/src/diamonds/nayms/interfaces/IAdminFacet.sol
+++ b/src/diamonds/nayms/interfaces/IAdminFacet.sol
@@ -93,7 +93,7 @@ interface IAdminFacet {
         bytes32 entityId,
         uint256 _feeScheduleType,
         bytes32[] calldata _receiver,
-        uint256[] calldata _basisPoints
+        uint16[] calldata _basisPoints
     ) external;
 
     function removeFeeSchedule(bytes32 _entityId, uint256 _feeScheduleType) external;

--- a/src/diamonds/nayms/interfaces/IMarketFacet.sol
+++ b/src/diamonds/nayms/interfaces/IMarketFacet.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import { MarketInfo, CalculatedFees } from "./FreeStructs.sol";
+import { MarketInfo } from "./FreeStructs.sol";
 
 /**
  * @title Matching Market (inspired by MakerOTC: https://github.com/nayms/maker-otc/blob/master/contracts/matching_market.sol)
@@ -80,10 +80,19 @@ interface IMarketFacet {
     function isActiveOffer(uint256 _offerId) external view returns (bool);
 
     /**
-     * @dev Calculate the trading commissions based on a buy amount.
-     * @param _buyAmount The amount that the commissions payments are calculated from.
+     * @dev Calculate the trading fees based on a buy amount.
+     * @param _buyerId The account buying the asset.
+     * @param _sellToken The asset being sold.
+     * @param _buyToken The asset being bought.
+     * @param _buyAmount The amount that the fees payments are calculated from.
+     * @return totalFees_ total fee to be payed
+     * @return totalBP_ total basis points
      */
-    function calculateTradingFees(bytes32 _buyer, uint256 _buyAmount) external view returns (CalculatedFees memory cf);
+    function calculateTradingFees(bytes32 _buyerId, bytes32 _sellToken, bytes32 _buyToken, uint256 _buyAmount) external view returns (uint256 totalFees_, uint256 totalBP_);
 
+    /**
+     * @dev Get the maker commission basis points.
+     * @return maker fee BP
+     */
     function getMakerBP() external view returns (uint16);
 }

--- a/src/diamonds/nayms/interfaces/IMarketFacet.sol
+++ b/src/diamonds/nayms/interfaces/IMarketFacet.sol
@@ -88,7 +88,12 @@ interface IMarketFacet {
      * @return totalFees_ total fee to be payed
      * @return totalBP_ total basis points
      */
-    function calculateTradingFees(bytes32 _buyerId, bytes32 _sellToken, bytes32 _buyToken, uint256 _buyAmount) external view returns (uint256 totalFees_, uint256 totalBP_);
+    function calculateTradingFees(
+        bytes32 _buyerId,
+        bytes32 _sellToken,
+        bytes32 _buyToken,
+        uint256 _buyAmount
+    ) external view returns (uint256 totalFees_, uint256 totalBP_);
 
     /**
      * @dev Get the maker commission basis points.

--- a/src/diamonds/nayms/libs/LibFeeRouter.sol
+++ b/src/diamonds/nayms/libs/LibFeeRouter.sol
@@ -1,13 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-// solhint-disable no-console
-import { console2 } from "forge-std/console2.sol";
-
 import { AppStorage, LibAppStorage, CalculatedFees, FeeAllocation, FeeSchedule } from "../AppStorage.sol";
 import { LibObject } from "./LibObject.sol";
 import { LibConstants } from "./LibConstants.sol";
-import { LibHelpers } from "./LibHelpers.sol";
 import { LibTokenizedVault } from "./LibTokenizedVault.sol";
 import { FeeBasisPointsExceedHalfMax } from "src/diamonds/nayms/interfaces/CustomErrors.sol";
 

--- a/src/diamonds/nayms/libs/LibFeeRouter.sol
+++ b/src/diamonds/nayms/libs/LibFeeRouter.sol
@@ -109,13 +109,13 @@ library LibFeeRouter {
             FeeSchedule memory feeSchedule = _getFeeSchedule(_buyerId, feeType);
 
             uint256 amount = s.offers[offerId].sellAmount == 0 || remainingBuyAmount < s.offers[offerId].sellAmount ? remainingBuyAmount : s.offers[offerId].sellAmount;
-            
+
             remainingBuyAmount -= amount;
 
             for (uint256 i; i < feeSchedule.basisPoints.length; i++) {
-                if(buyExternalToken && s.offers[offerId].sellAmount != 0) {
+                if (buyExternalToken && s.offers[offerId].sellAmount != 0) {
                     // normalize the amount for external tokens
-                    amount = amount * s.offers[offerId].buyAmount / s.offers[offerId].sellAmount;
+                    amount = (amount * s.offers[offerId].buyAmount) / s.offers[offerId].sellAmount;
                 }
                 totalFees_ += (amount * feeSchedule.basisPoints[i]) / LibConstants.BP_FACTOR;
                 totalBP_ += feeSchedule.basisPoints[i];

--- a/src/diamonds/nayms/libs/LibFeeRouter.sol
+++ b/src/diamonds/nayms/libs/LibFeeRouter.sol
@@ -85,22 +85,27 @@ library LibFeeRouter {
         }
     }
 
-    function _calculateTradingFees(bytes32 _buyerId, bytes32 _sellToken, bytes32 _buyToken, uint256 _buyAmount) internal view returns (uint256 totalFees_, uint256 totalBP_) {
+    function _calculateTradingFees(
+        bytes32 _buyerId,
+        bytes32 _sellToken,
+        bytes32 _buyToken,
+        uint256 _buyAmount
+    ) internal view returns (uint256 totalFees_, uint256 totalBP_) {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         uint256 offerId = s.bestOfferId[_buyToken][_sellToken];
         uint256 remainingBuyAmount = _buyAmount;
-        uint offerCounter;
-        
+        uint256 offerCounter;
+
         while (remainingBuyAmount > 0) {
             FeeSchedule memory feeSchedule = _getFeeSchedule(_buyerId, s.offers[offerId].feeSchedule);
-            if(s.offers[offerId].sellAmount == 0) {
+            if (s.offers[offerId].sellAmount == 0) {
                 revert("not enough liquidity");
             }
             uint256 amount = remainingBuyAmount < s.offers[offerId].sellAmount ? remainingBuyAmount : s.offers[offerId].sellAmount;
             remainingBuyAmount -= amount;
 
-            for(uint i; i < feeSchedule.basisPoints.length; i++) {
+            for (uint256 i; i < feeSchedule.basisPoints.length; i++) {
                 totalFees_ += (amount * feeSchedule.basisPoints[i]) / LibConstants.BP_FACTOR;
                 totalBP_ += feeSchedule.basisPoints[i];
             }
@@ -115,7 +120,6 @@ library LibFeeRouter {
         }
 
         totalBP_ /= offerCounter; // normalize total BP
-
     }
 
     /// @dev The total bp for a marketplace fee schedule cannot exceed LibConstants.BP_FACTOR since the maker BP and fee schedules are each checked to be less than LibConstants.BP_FACTOR / 2 when they are being set.

--- a/src/diamonds/nayms/libs/LibFeeRouter.sol
+++ b/src/diamonds/nayms/libs/LibFeeRouter.sol
@@ -98,8 +98,6 @@ library LibFeeRouter {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         uint256 offerId = s.bestOfferId[_buyToken][_sellToken];
-        bool buyExternalToken = LibHelpers._isAddress(_buyToken) && s.externalTokenSupported[LibHelpers._getAddressFromId(_buyToken)];
-
         uint256 remainingBuyAmount = _buyAmount;
         uint256 offerCounter;
 
@@ -113,10 +111,6 @@ library LibFeeRouter {
             remainingBuyAmount -= amount;
 
             for (uint256 i; i < feeSchedule.basisPoints.length; i++) {
-                if (buyExternalToken && s.offers[offerId].sellAmount != 0) {
-                    // normalize the amount for external tokens
-                    amount = (amount * s.offers[offerId].buyAmount) / s.offers[offerId].sellAmount;
-                }
                 totalFees_ += (amount * feeSchedule.basisPoints[i]) / LibConstants.BP_FACTOR;
                 totalBP_ += feeSchedule.basisPoints[i];
             }

--- a/src/diamonds/nayms/libs/LibFeeRouter.sol
+++ b/src/diamonds/nayms/libs/LibFeeRouter.sol
@@ -173,7 +173,7 @@ library LibFeeRouter {
         bytes32 _entityId,
         uint256 _feeScheduleType,
         bytes32[] calldata _receiver,
-        uint256[] calldata _basisPoints
+        uint16[] calldata _basisPoints
     ) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 

--- a/src/diamonds/nayms/libs/LibFeeRouter.sol
+++ b/src/diamonds/nayms/libs/LibFeeRouter.sol
@@ -85,37 +85,37 @@ library LibFeeRouter {
         }
     }
 
-    function _calculateTradingFees(bytes32 _buyer, uint256 _buyAmount) internal view returns (CalculatedFees memory cf) {
+    function _calculateTradingFees(bytes32 _buyerId, bytes32 _sellToken, bytes32 _buyToken, uint256 _buyAmount) internal view returns (uint256 totalFees_, uint256 totalBP_) {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
-        FeeSchedule memory feeSchedule = _getFeeSchedule(_buyer, LibConstants.FEE_TYPE_TRADING);
+        uint256 offerId = s.bestOfferId[_buyToken][_sellToken];
+        uint256 remainingBuyAmount = _buyAmount;
+        uint offerCounter;
+        
+        while (remainingBuyAmount > 0) {
+            FeeSchedule memory feeSchedule = _getFeeSchedule(_buyerId, s.offers[offerId].feeSchedule);
+            if(s.offers[offerId].sellAmount == 0) {
+                revert("not enough liquidity");
+            }
+            uint256 amount = remainingBuyAmount < s.offers[offerId].sellAmount ? remainingBuyAmount : s.offers[offerId].sellAmount;
+            remainingBuyAmount -= amount;
 
-        uint256 feeScheduleReceiversCount = feeSchedule.receiver.length;
-        uint256 totalReceiverCount = (s.tradingCommissionMakerBP > 0) ? feeScheduleReceiversCount + 1 : feeScheduleReceiversCount;
+            for(uint i; i < feeSchedule.basisPoints.length; i++) {
+                totalFees_ += (amount * feeSchedule.basisPoints[i]) / LibConstants.BP_FACTOR;
+                totalBP_ += feeSchedule.basisPoints[i];
+            }
 
-        cf.feeAllocations = new FeeAllocation[](totalReceiverCount);
+            if (s.tradingCommissionMakerBP > 0) {
+                totalFees_ += amount;
+                totalBP_ += s.tradingCommissionMakerBP;
+            }
 
-        uint256 receiverCount;
-        // Calculate fees for the market maker
-        if (s.tradingCommissionMakerBP > 0) {
-            cf.feeAllocations[0].to = _buyer;
-            cf.feeAllocations[0].basisPoints = s.tradingCommissionMakerBP;
-            cf.feeAllocations[0].fee = (_buyAmount * s.tradingCommissionMakerBP) / LibConstants.BP_FACTOR;
-
-            cf.totalFees += cf.feeAllocations[0].fee;
-            cf.totalBP += s.tradingCommissionMakerBP;
-
-            receiverCount++;
+            offerCounter++;
+            offerId = s.offers[offerId].rankPrev;
         }
 
-        for (uint256 i; i < feeScheduleReceiversCount; i++) {
-            cf.feeAllocations[receiverCount + i].to = feeSchedule.receiver[i];
-            cf.feeAllocations[receiverCount + i].basisPoints = feeSchedule.basisPoints[i];
-            cf.feeAllocations[receiverCount + i].fee = (_buyAmount * feeSchedule.basisPoints[i]) / LibConstants.BP_FACTOR;
+        totalBP_ /= offerCounter; // normalize total BP
 
-            cf.totalFees += cf.feeAllocations[receiverCount + i].fee;
-            cf.totalBP += feeSchedule.basisPoints[i];
-        }
     }
 
     /// @dev The total bp for a marketplace fee schedule cannot exceed LibConstants.BP_FACTOR since the maker BP and fee schedules are each checked to be less than LibConstants.BP_FACTOR / 2 when they are being set.

--- a/src/diamonds/nayms/libs/LibMarket.sol
+++ b/src/diamonds/nayms/libs/LibMarket.sol
@@ -37,7 +37,6 @@ library LibMarket {
 
     function _getBestOfferId(bytes32 _sellToken, bytes32 _buyToken) internal view returns (uint256) {
         AppStorage storage s = LibAppStorage.diamondStorage();
-
         return s.bestOfferId[_sellToken][_buyToken];
     }
 
@@ -179,6 +178,7 @@ library LibMarket {
 
                 // (For a breakdown on the matching algorithm see https://hiddentao.com/archives/2019/09/08/maker-otc-on-chain-orderbook-deep-dive)
                 // note: We have removed the "optimistic" matching.
+                // if maker price is higher, then stop
                 if (makerBuyAmount * result.remainingBuyAmount > makerSellAmount * result.remainingSellAmount) {
                     break; // no matching price, bail out
                 }

--- a/test/NewFees.t.sol
+++ b/test/NewFees.t.sol
@@ -128,8 +128,6 @@ contract NewFeesTest is D03ProtocolDefaults {
     }
 
     function test_calculateTradingFees_SingleReceiver() public {
-        nayms.startTokenSale(acc1.entityId, 1000 ether, 1000 ether);
-
         bytes32[] memory customRecipient = b32Array1(NAYMS_LTD_IDENTIFIER);
         uint256[] memory customFeeBP = u256Array1(900);
         FeeSchedule memory customFeeSchedule = feeSched(customRecipient, customFeeBP);
@@ -157,9 +155,6 @@ contract NewFeesTest is D03ProtocolDefaults {
     }
 
     function test_calculateTradingFees_MultipleReceivers() public {
-        uint256 saleAmount = 1000 ether;
-        nayms.startTokenSale(acc1.entityId, saleAmount, saleAmount);
-
         bytes32[] memory customRecipient = b32Array3(NAYMS_LTD_IDENTIFIER, NDF_IDENTIFIER, STM_IDENTIFIER);
         uint256[] memory customFeeBP = u256Array3(150, 75, 75);
         FeeSchedule memory customFeeSchedule = feeSched(customRecipient, customFeeBP);

--- a/test/NewFees.t.sol
+++ b/test/NewFees.t.sol
@@ -145,6 +145,18 @@ contract NewFeesTest is D03ProtocolDefaults {
         assertEq(totalBP_, customFeeSchedule.basisPoints[0], "total bp is incorrect");
     }
 
+    function test_calculateTradingFees_BuyExternal() public {
+        uint256 _buyAmount = 10 ether;
+        (uint256 totalFees_, uint256 totalBP_) = nayms.calculateTradingFees(acc2.entityId, acc1.entityId, wethId, _buyAmount);
+
+        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(acc2.entityId, LibConstants.FEE_TYPE_TRADING);
+        uint256 expectedValue = (_buyAmount * feeSchedule.basisPoints[0]) / LibConstants.BP_FACTOR;
+
+        assertEq(totalFees_, expectedValue, "total fees is incorrect");
+        assertEq(totalBP_, feeSchedule.basisPoints[0], "total bp is incorrect");
+
+    }
+
     function test_calculateTradingFees_MultipleReceivers() public {
         uint256 saleAmount = 1000 ether;
         nayms.startTokenSale(acc1.entityId, saleAmount, saleAmount);
@@ -410,9 +422,7 @@ contract NewFeesTest is D03ProtocolDefaults {
         libFeeRouterFixture.exposed_calculatePremiumFees(bytes32("policy11"), 1e17);
         libFeeRouterFixture.exposed_payPremiumFees(bytes32("policy11"), 1e17);
 
-        vm.expectRevert("not enough liquidity");
         libFeeRouterFixture.exposed_calculateTradingFees(acc2.entityId, acc1.entityId, wethId, 1 ether);
-        
         libFeeRouterFixture.exposed_payTradingFees(bytes32("entity11"), bytes32("entity11"), bytes32("entity21"), bytes32("entity21"), 1e17);
     }
 

--- a/test/NewFees.t.sol
+++ b/test/NewFees.t.sol
@@ -154,7 +154,6 @@ contract NewFeesTest is D03ProtocolDefaults {
 
         assertEq(totalFees_, expectedValue, "total fees is incorrect");
         assertEq(totalBP_, feeSchedule.basisPoints[0], "total bp is incorrect");
-
     }
 
     function test_calculateTradingFees_MultipleReceivers() public {
@@ -390,8 +389,8 @@ contract NewFeesTest is D03ProtocolDefaults {
         uint256 singleSaleAmount = 1 ether;
 
         uint256 defaultTotalBP = 30;
-        fundEntityWeth(acc2, totalAmount + (totalAmount * defaultTotalBP / LibConstants.BP_FACTOR));
-        
+        fundEntityWeth(acc2, totalAmount + ((totalAmount * defaultTotalBP) / LibConstants.BP_FACTOR));
+
         changePrank(acc2.addr);
         nayms.executeLimitOffer(wethId, singleOrderAmount, acc1.entityId, singleOrderAmount);
         nayms.executeLimitOffer(wethId, singleOrderAmount, acc1.entityId, singleOrderAmount);

--- a/test/NewFees.t.sol
+++ b/test/NewFees.t.sol
@@ -68,7 +68,7 @@ contract NewFeesTest is D03ProtocolDefaults {
         FeeSchedule memory defaultFeeSchedule = nayms.getFeeSchedule(entityId, LibConstants.FEE_TYPE_PREMIUM);
 
         bytes32[] memory customRecipient = b32Array1("recipient");
-        uint256[] memory customFeeBP = u256Array1(42);
+        uint16[] memory customFeeBP = u16Array1(42);
 
         nayms.addFeeSchedule(entityId, LibConstants.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
 
@@ -95,7 +95,7 @@ contract NewFeesTest is D03ProtocolDefaults {
         assertEq(feeSchedule, premiumFeeScheduleDefault);
 
         bytes32[] memory customRecipient = b32Array1(NAYMS_LTD_IDENTIFIER);
-        uint256[] memory customFeeBP = u256Array1(301);
+        uint16[] memory customFeeBP = u16Array1(301);
 
         nayms.addFeeSchedule(entityWithCustom, LibConstants.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
 
@@ -117,7 +117,7 @@ contract NewFeesTest is D03ProtocolDefaults {
         assertEq(feeSchedule, tradingFeeScheduleDefault);
 
         bytes32[] memory customRecipient = b32Array1(NAYMS_LTD_IDENTIFIER);
-        uint256[] memory customFeeBP = u256Array1(31);
+        uint16[] memory customFeeBP = u16Array1(31);
 
         nayms.addFeeSchedule(entityWithCustom, LibConstants.FEE_TYPE_TRADING, customRecipient, customFeeBP);
 
@@ -129,7 +129,7 @@ contract NewFeesTest is D03ProtocolDefaults {
 
     function test_calculateTradingFees_SingleReceiver() public {
         bytes32[] memory customRecipient = b32Array1(NAYMS_LTD_IDENTIFIER);
-        uint256[] memory customFeeBP = u256Array1(900);
+        uint16[] memory customFeeBP = u16Array1(900);
         FeeSchedule memory customFeeSchedule = feeSched(customRecipient, customFeeBP);
 
         nayms.addFeeSchedule(acc2.entityId, LibConstants.FEE_TYPE_INITIAL_SALE, customRecipient, customFeeBP);
@@ -156,7 +156,7 @@ contract NewFeesTest is D03ProtocolDefaults {
 
     function test_calculateTradingFees_MultipleReceivers() public {
         bytes32[] memory customRecipient = b32Array3(NAYMS_LTD_IDENTIFIER, NDF_IDENTIFIER, STM_IDENTIFIER);
-        uint256[] memory customFeeBP = u256Array3(150, 75, 75);
+        uint16[] memory customFeeBP = u16Array3(150, 75, 75);
         FeeSchedule memory customFeeSchedule = feeSched(customRecipient, customFeeBP);
 
         nayms.addFeeSchedule(acc2.entityId, LibConstants.FEE_TYPE_INITIAL_SALE, customRecipient, customFeeBP);
@@ -171,7 +171,7 @@ contract NewFeesTest is D03ProtocolDefaults {
 
         // Update the same fee schedule: 3 receivers to 1 receiver
         customRecipient = b32Array1(NAYMS_LTD_IDENTIFIER);
-        customFeeBP = u256Array1(300);
+        customFeeBP = u16Array1(300);
         customFeeSchedule = feeSched(customRecipient, customFeeBP);
 
         nayms.addFeeSchedule(acc2.entityId, LibConstants.FEE_TYPE_INITIAL_SALE, customRecipient, customFeeBP);
@@ -201,10 +201,10 @@ contract NewFeesTest is D03ProtocolDefaults {
         assertEq(totalBP_, totalBP, "total bp is incorrect");
     }
 
-    function test_calculatePremiumFees_SingleReceiver(uint256 _fee) public {
+    function test_calculatePremiumFees_SingleReceiver(uint16 _fee) public {
         vm.assume(0 <= _fee && _fee <= LibConstants.BP_FACTOR / 2);
         bytes32[] memory customRecipient = b32Array1(NAYMS_LTD_IDENTIFIER);
-        uint256[] memory customFeeBP = u256Array1(_fee);
+        uint16[] memory customFeeBP = u16Array1(_fee);
         nayms.addFeeSchedule(acc1.entityId, LibConstants.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
 
         fundEntityWeth(acc1, 1 ether);
@@ -224,17 +224,17 @@ contract NewFeesTest is D03ProtocolDefaults {
     }
 
     function test_calculatePremiumFees_MultipleReceivers(
-        uint256 _fee,
-        uint256 _fee1,
-        uint256 _fee2,
-        uint256 _fee3
+        uint16 _fee,
+        uint16 _fee1,
+        uint16 _fee2,
+        uint16 _fee3
     ) public {
         vm.assume(0 <= _fee && _fee <= LibConstants.BP_FACTOR / 2);
         vm.assume(_fee1 < LibConstants.BP_FACTOR / 2 && _fee2 < LibConstants.BP_FACTOR / 2 && _fee3 < LibConstants.BP_FACTOR / 2);
         vm.assume(0 <= (_fee1 + _fee2 + _fee3) && (_fee1 + _fee2 + _fee3) <= LibConstants.BP_FACTOR / 2);
 
         bytes32[] memory customRecipient = b32Array3(NAYMS_LTD_IDENTIFIER, NDF_IDENTIFIER, STM_IDENTIFIER);
-        uint256[] memory customFeeBP = u256Array3(_fee1, _fee2, _fee3);
+        uint16[] memory customFeeBP = u16Array3(_fee1, _fee2, _fee3);
         nayms.addFeeSchedule(acc1.entityId, LibConstants.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
 
         fundEntityWeth(acc1, 1 ether);
@@ -254,7 +254,7 @@ contract NewFeesTest is D03ProtocolDefaults {
 
         // Update the same fee schedule: 3 receivers to 1 receiver
         customRecipient = b32Array1(NAYMS_LTD_IDENTIFIER);
-        customFeeBP = u256Array1(_fee);
+        customFeeBP = u16Array1(_fee);
         nayms.addFeeSchedule(acc1.entityId, LibConstants.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
 
         cf = nayms.calculatePremiumFees(policyId, _premiumPaid);
@@ -267,7 +267,7 @@ contract NewFeesTest is D03ProtocolDefaults {
     }
 
     function test_zeroPremiumFees() public {
-        nayms.addFeeSchedule(acc1.entityId, LibConstants.FEE_TYPE_PREMIUM, b32Array1(NAYMS_LTD_IDENTIFIER), u256Array1(0));
+        nayms.addFeeSchedule(acc1.entityId, LibConstants.FEE_TYPE_PREMIUM, b32Array1(NAYMS_LTD_IDENTIFIER), u16Array1(0));
 
         fundEntityWeth(acc1, 1 ether);
 
@@ -278,7 +278,7 @@ contract NewFeesTest is D03ProtocolDefaults {
         uint256 premiumAmount = 1 ether;
         CalculatedFees memory cf = nayms.calculatePremiumFees(policyId, premiumAmount);
 
-        uint256 expectedTotalPremiumFeeBP = totalPremiumFeeBP(simplePolicy, u256Array1(0));
+        uint256 expectedTotalPremiumFeeBP = totalPremiumFeeBP(simplePolicy, u16Array1(0));
         uint256 expectedValue = (premiumAmount * expectedTotalPremiumFeeBP) / LibConstants.BP_FACTOR;
 
         assertEq(cf.totalFees, expectedValue, "Invalid total fees!");
@@ -288,7 +288,7 @@ contract NewFeesTest is D03ProtocolDefaults {
         assertEq(feeSchedule.basisPoints[0], 0);
     }
 
-    function totalPremiumFeeBP(SimplePolicy memory simplePolicy, uint256[] memory customFeeBP) private returns (uint256 totalBP_) {
+    function totalPremiumFeeBP(SimplePolicy memory simplePolicy, uint16[] memory customFeeBP) private returns (uint256 totalBP_) {
         for (uint256 i; i < simplePolicy.commissionBasisPoints.length; i++) {
             totalBP_ += simplePolicy.commissionBasisPoints[i];
         }
@@ -428,7 +428,7 @@ contract NewFeesTest is D03ProtocolDefaults {
         nayms.startTokenSale(acc1.entityId, saleAmount, saleAmount);
         assertEq(nayms.internalBalanceOf(acc1.entityId, acc1.entityId), saleAmount, "entity selling par balance is incorrect");
 
-        nayms.addFeeSchedule(acc2.entityId, LibConstants.FEE_TYPE_INITIAL_SALE, b32Array1(NAYMS_LTD_IDENTIFIER), u256Array1(0));
+        nayms.addFeeSchedule(acc2.entityId, LibConstants.FEE_TYPE_INITIAL_SALE, b32Array1(NAYMS_LTD_IDENTIFIER), u16Array1(0));
 
         fundEntityWeth(acc2, saleAmount);
 

--- a/test/T03TokenizedVault.t.sol
+++ b/test/T03TokenizedVault.t.sol
@@ -751,15 +751,14 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
 
         changePrank(bob);
         writeTokenBalance(bob, naymsAddress, wethAddress, depositAmount);
-        uint256 totalFees = defaultTradingFeeBP * 3_000 / LibConstants.BP_FACTOR;
+        uint256 totalFees = (defaultTradingFeeBP * 3_000) / LibConstants.BP_FACTOR;
         nayms.externalDeposit(wethAddress, 3_000 + totalFees);
         assertEq(nayms.internalBalanceOf(eBob, nWETH), 3_000 + totalFees);
 
         changePrank(charlie);
         writeTokenBalance(charlie, naymsAddress, wethAddress, depositAmount);
-        totalFees = defaultTradingFeeBP * 17_000 / LibConstants.BP_FACTOR;
+        totalFees = (defaultTradingFeeBP * 17_000) / LibConstants.BP_FACTOR;
         nayms.externalDeposit(wethAddress, 17_000 + totalFees);
-
 
         // note: starting a token sale which mints participation tokens
         changePrank(systemAdmin);

--- a/test/T03TokenizedVault.t.sol
+++ b/test/T03TokenizedVault.t.sol
@@ -742,6 +742,8 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         address charlie = signer2;
         bytes32 eCharlie = nayms.getEntity(signer2Id);
 
+        uint256 defaultTradingFeeBP = 30;
+
         changePrank(alice);
         writeTokenBalance(alice, naymsAddress, wethAddress, depositAmount);
 
@@ -749,15 +751,15 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
 
         changePrank(bob);
         writeTokenBalance(bob, naymsAddress, wethAddress, depositAmount);
-        (uint256 totalFees_, ) = nayms.calculateTradingFees(eBob, wethId, eAlice, 3_000);
-        nayms.externalDeposit(wethAddress, 3_000 + totalFees_);
+        uint256 totalFees = defaultTradingFeeBP * 3_000 / LibConstants.BP_FACTOR;
+        nayms.externalDeposit(wethAddress, 3_000 + totalFees);
+        assertEq(nayms.internalBalanceOf(eBob, nWETH), 3_000 + totalFees);
 
         changePrank(charlie);
         writeTokenBalance(charlie, naymsAddress, wethAddress, depositAmount);
-        (totalFees_, ) = nayms.calculateTradingFees(eCharlie, wethId, eAlice, 17_000);
-        nayms.externalDeposit(wethAddress, 17_000 + totalFees_);
+        totalFees = defaultTradingFeeBP * 17_000 / LibConstants.BP_FACTOR;
+        nayms.externalDeposit(wethAddress, 17_000 + totalFees);
 
-        assertEq(nayms.internalBalanceOf(eBob, nWETH), 3_000 + totalFees_);
 
         // note: starting a token sale which mints participation tokens
         changePrank(systemAdmin);

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -452,7 +452,7 @@ contract T04EntityTest is D03ProtocolDefaults {
         // fee schedule receivers
         // change fee schedule to one that does not have any receivers
         bytes32[] memory r;
-        uint256[] memory bp;
+        uint16[] memory bp;
 
         nayms.addFeeSchedule(LibConstants.DEFAULT_FEE_SCHEDULE, LibConstants.FEE_TYPE_PREMIUM, r, bp);
         vm.expectRevert("must have fee schedule receivers");
@@ -460,7 +460,7 @@ contract T04EntityTest is D03ProtocolDefaults {
 
         // add back fee receiver
         r = b32Array1(NAYMS_LTD_IDENTIFIER);
-        bp = u256Array1(300);
+        bp = u16Array1(300);
         nayms.addFeeSchedule(LibConstants.DEFAULT_FEE_SCHEDULE, LibConstants.FEE_TYPE_PREMIUM, r, bp);
 
         vm.expectRevert("number of commissions don't match");

--- a/test/T04Market.t.sol
+++ b/test/T04Market.t.sol
@@ -192,6 +192,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         uint256[] memory customBasisPoints = u256Array3(150, 75, 75);
 
         nayms.addFeeSchedule(LibConstants.DEFAULT_FEE_SCHEDULE, LibConstants.FEE_TYPE_INITIAL_SALE, customReceivers, customBasisPoints);
+        nayms.addFeeSchedule(LibConstants.DEFAULT_FEE_SCHEDULE, LibConstants.FEE_TYPE_TRADING, customReceivers, customBasisPoints);
 
         nayms.createEntity(entity2, signer2Id, initEntity(wethId, collateralRatio_500, maxCapital_2000eth, true), "test");
         nayms.createEntity(entity3, signer3Id, initEntity(wethId, collateralRatio_500, maxCapital_2000eth, true), "test");

--- a/test/T04Market.t.sol
+++ b/test/T04Market.t.sol
@@ -189,7 +189,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         // 0.075% to stm
 
         bytes32[] memory customReceivers = b32Array3(NAYMS_LTD_IDENTIFIER, NDF_IDENTIFIER, STM_IDENTIFIER);
-        uint256[] memory customBasisPoints = u256Array3(150, 75, 75);
+        uint16[] memory customBasisPoints = u16Array3(150, 75, 75);
 
         nayms.addFeeSchedule(LibConstants.DEFAULT_FEE_SCHEDULE, LibConstants.FEE_TYPE_INITIAL_SALE, customReceivers, customBasisPoints);
         nayms.addFeeSchedule(LibConstants.DEFAULT_FEE_SCHEDULE, LibConstants.FEE_TYPE_TRADING, customReceivers, customBasisPoints);
@@ -246,7 +246,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
                 keccak256("RANDOM FEE RECEIVER"), 
                 keccak256("RANDOM FEE RECEIVER 2"), 
                 keccak256("RANDOM FEE RECEIVER 3"));
-        uint256[] memory basisPoints = u256Array3(150, 75, 75);
+        uint16[] memory basisPoints = u16Array3(150, 75, 75);
 
         changePrank(systemAdmin);
         nayms.addFeeSchedule(entity2, LibConstants.FEE_TYPE_TRADING, receivers, basisPoints);

--- a/test/T05TokenWrapper.t.sol
+++ b/test/T05TokenWrapper.t.sol
@@ -67,7 +67,8 @@ contract T05TokenWrapper is D03ProtocolDefaults {
 
         // fund signer2
         changePrank(signer2);
-        uint256 amountWithFees = tokenAmount + nayms.calculateTradingFees(entityId1, tokenAmount).totalFees;
+        (uint256 totalFees_, ) = nayms.calculateTradingFees(entityId2, wethId, entityId1, tokenAmount);
+        uint256 amountWithFees = tokenAmount + totalFees_;
         writeTokenBalance(signer2, naymsAddress, wethAddress, amountWithFees);
         nayms.externalDeposit(wethAddress, amountWithFees);
 

--- a/test/defaults/D03ProtocolDefaults.sol
+++ b/test/defaults/D03ProtocolDefaults.sol
@@ -49,8 +49,8 @@ contract D03ProtocolDefaults is D02TestSetup {
     bytes32 public immutable USDC_IDENTIFIER = LibHelpers._getIdForAddress(USDC_ADDRESS);
 
     bytes32[] public defaultFeeRecipients;
-    uint256[] public defaultPremiumFeeBPs;
-    uint256[] public defaultTradingFeeBPs;
+    uint16[] public defaultPremiumFeeBPs;
+    uint16[] public defaultTradingFeeBPs;
 
     FeeSchedule premiumFeeScheduleDefault;
     FeeSchedule tradingFeeScheduleDefault;
@@ -90,8 +90,8 @@ contract D03ProtocolDefaults is D02TestSetup {
 
         // Setup fee schedules
         defaultFeeRecipients = b32Array1(NAYMS_LTD_IDENTIFIER);
-        defaultPremiumFeeBPs = u256Array1(300);
-        defaultTradingFeeBPs = u256Array1(30);
+        defaultPremiumFeeBPs = u16Array1(300);
+        defaultTradingFeeBPs = u16Array1(30);
 
         premiumFeeScheduleDefault = feeSched1(NAYMS_LTD_IDENTIFIER, 300);
         tradingFeeScheduleDefault = feeSched1(NAYMS_LTD_IDENTIFIER, 30);
@@ -124,6 +124,24 @@ contract D03ProtocolDefaults is D02TestSetup {
         return arr_;
     }
 
+    function u16Array1(uint16 _value) internal pure returns (uint16[] memory) {
+        uint16[] memory arr = new uint16[](1);
+        arr[0] = _value;
+        return arr;
+    }
+
+    function u16Array3(
+        uint16 _value1,
+        uint16 _value2,
+        uint16 _value3
+    ) internal pure returns (uint16[] memory) {
+        uint16[] memory arr = new uint16[](3);
+        arr[0] = _value1;
+        arr[1] = _value2;
+        arr[2] = _value3;
+        return arr;
+    }
+
     function u256Array1(uint256 _value) internal pure returns (uint256[] memory) {
         uint256[] memory arr = new uint256[](1);
         arr[0] = _value;
@@ -142,11 +160,11 @@ contract D03ProtocolDefaults is D02TestSetup {
         return arr;
     }
 
-    function feeSched1(bytes32 _receiver, uint256 _basisPoints) internal pure returns (FeeSchedule memory) {
-        return FeeSchedule({ receiver: b32Array1(_receiver), basisPoints: u256Array1(_basisPoints) });
+    function feeSched1(bytes32 _receiver, uint16 _basisPoints) internal pure returns (FeeSchedule memory) {
+        return FeeSchedule({ receiver: b32Array1(_receiver), basisPoints: u16Array1(_basisPoints) });
     }
 
-    function feeSched(bytes32[] memory _receiver, uint256[] memory _basisPoints) internal pure returns (FeeSchedule memory) {
+    function feeSched(bytes32[] memory _receiver, uint16[] memory _basisPoints) internal pure returns (FeeSchedule memory) {
         return FeeSchedule({ receiver: _receiver, basisPoints: _basisPoints });
     }
 

--- a/test/fixtures/LibFeeRouterFixture.sol
+++ b/test/fixtures/LibFeeRouterFixture.sol
@@ -15,7 +15,7 @@ contract LibFeeRouterFixture {
         LibFeeRouter._payPremiumFees(_policyId, _premiumPaid);
     }
 
-    function exposed_calculateTradingFees(bytes32 _buyer, uint256 _buyAmount) external view returns (CalculatedFees memory cf) {
+    function exposed_calculateTradingFees(bytes32 _buyer, uint256 _buyAmount) external view returns (uint256 totalFees_, uint256 totalBP_) {
         return LibFeeRouter._calculateTradingFees(_buyer, _buyAmount);
     }
 

--- a/test/fixtures/LibFeeRouterFixture.sol
+++ b/test/fixtures/LibFeeRouterFixture.sol
@@ -15,8 +15,13 @@ contract LibFeeRouterFixture {
         LibFeeRouter._payPremiumFees(_policyId, _premiumPaid);
     }
 
-    function exposed_calculateTradingFees(bytes32 _buyer, uint256 _buyAmount) external view returns (uint256 totalFees_, uint256 totalBP_) {
-        return LibFeeRouter._calculateTradingFees(_buyer, _buyAmount);
+    function exposed_calculateTradingFees(
+        bytes32 _buyerId,
+        bytes32 _sellToken,
+        bytes32 _buyToken,
+        uint256 _buyAmount
+    ) external view returns (uint256 totalFees_, uint256 totalBP_) {
+        return LibFeeRouter._calculateTradingFees(_buyerId, _sellToken, _buyToken, _buyAmount);
     }
 
     function exposed_payTradingFees(


### PR DESCRIPTION
When calculating trading fees, the algorithm must take into account the assigned fee schedule type, for each of the matching orders. To do that, additional inputs are required, such as the taker and the trading pair.

- Taker is needed in case there is a custom fee schedule defined for him. 
- Trading pair is needed to traverse the order book and see the fee schedule type assigned to individual orders.

Consulting with the stakeholders, it has been agreed upon that we will default to the higher fee schedule (type: _initial sale_)  when there is not enough liquidity in the market. Fee will be presented with the disclaimer, saying it is an approximation and the actual fee might be lower (i.e in case of secondary trading).