### PR TITLE
Update access control part 1

### DIFF
--- a/src/diamonds/nayms/Modifiers.sol
+++ b/src/diamonds/nayms/Modifiers.sol
@@ -58,6 +58,7 @@ contract Modifiers {
         _;
     }
 
+    // todo delete this - replaced this modifier with assertPolicyHandler with assertPermissions(LC.GROUP_POLICY_HANDLERS, _policyId)
     modifier assertPolicyHandler(bytes32 _context) {
         require(LibACL._isInGroup(LibObject._getParentFromAddress(msg.sender), _context, LibHelpers._stringToBytes32(LC.GROUP_POLICY_HANDLERS)), "not a policy handler");
         _;

--- a/src/diamonds/nayms/Modifiers.sol
+++ b/src/diamonds/nayms/Modifiers.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.17;
 /// @notice modifiers
 
 import { LibAdmin } from "./libs/LibAdmin.sol";
-import { LibConstants } from "./libs/LibConstants.sol";
+import { LibConstants as LC } from "./libs/LibConstants.sol";
 import { LibHelpers } from "./libs/LibHelpers.sol";
 import { LibObject } from "./libs/LibObject.sol";
 import { LibACL } from "./libs/LibACL.sol";
@@ -15,33 +15,51 @@ import { LibACL } from "./libs/LibACL.sol";
  * @dev Function modifiers to control access
  */
 contract Modifiers {
+    using LibHelpers for *;
+    using LibACL for *;
+
+    error NotInternalUnderwriter(address msgSender);
+
+    /// @notice Error message for when a sender is not authorized to perform an action with their assigned role in a given context of a group
+    /// @param msgSenderId Id of the sender
+    /// @param context Context in which the sender is trying to perform an action
+    /// @param roleInContext Role of the sender in the context
+    /// @param group Tenant group ID (LibConstants.GROUP_TENANTS) displayed as type string
+    error InvalidRole(bytes32 msgSenderId, bytes32 context, string roleInContext, string group);
+
     modifier notLocked(bytes4 functionSelector) {
         require(!LibAdmin._isFunctionLocked(functionSelector), "function is locked");
         _;
     }
+
     modifier assertSysAdmin() {
-        require(
-            LibACL._isInGroup(LibHelpers._getIdForAddress(msg.sender), LibAdmin._getSystemId(), LibHelpers._stringToBytes32(LibConstants.GROUP_SYSTEM_ADMINS)),
-            "not a system admin"
-        );
+        require(msg.sender._getIdForAddress()._isInGroup(LibAdmin._getSystemId(), LibHelpers._stringToBytes32(LC.GROUP_SYSTEM_ADMINS)), "not a system admin");
+        _;
+    }
+
+    modifier assertInternalUW() {
+        if (!msg.sender._getIdForAddress()._isInGroup(LibAdmin._getSystemId(), LC.GROUP_INTERNAL_UNDERWRITERS._stringToBytes32())) revert NotInternalUnderwriter(msg.sender);
         _;
     }
 
     modifier assertSysMgr() {
-        require(
-            LibACL._isInGroup(LibHelpers._getIdForAddress(msg.sender), LibAdmin._getSystemId(), LibHelpers._stringToBytes32(LibConstants.GROUP_SYSTEM_MANAGERS)),
-            "not a system manager"
-        );
+        require(msg.sender._getIdForAddress()._isInGroup(LibAdmin._getSystemId(), LibHelpers._stringToBytes32(LC.GROUP_SYSTEM_MANAGERS)), "not a system manager");
+        _;
+    }
+
+    modifier assertPermissions(string memory _group, bytes32 _context) {
+        if (!msg.sender._getIdForAddress()._isInGroup(_context, _group._stringToBytes32()))
+            revert InvalidRole(msg.sender._getIdForAddress(), _context, abi.decode(msg.sender._getIdForAddress()._getRoleInContext(_context)._bytes32ToBytes(), (string)), _group);
         _;
     }
 
     modifier assertEntityAdmin(bytes32 _context) {
-        require(LibACL._isInGroup(LibHelpers._getIdForAddress(msg.sender), _context, LibHelpers._stringToBytes32(LibConstants.GROUP_ENTITY_ADMINS)), "not the entity's admin");
+        require(msg.sender._getIdForAddress()._isInGroup(_context, LibHelpers._stringToBytes32(LC.GROUP_ENTITY_ADMINS)), "not the entity's admin");
         _;
     }
 
     modifier assertPolicyHandler(bytes32 _context) {
-        require(LibACL._isInGroup(LibObject._getParentFromAddress(msg.sender), _context, LibHelpers._stringToBytes32(LibConstants.GROUP_POLICY_HANDLERS)), "not a policy handler");
+        require(LibACL._isInGroup(LibObject._getParentFromAddress(msg.sender), _context, LibHelpers._stringToBytes32(LC.GROUP_POLICY_HANDLERS)), "not a policy handler");
         _;
     }
 

--- a/src/diamonds/nayms/Modifiers.sol
+++ b/src/diamonds/nayms/Modifiers.sol
@@ -41,7 +41,16 @@ contract Modifiers {
 
     modifier assertHasGroupPrivilege(bytes32 _context, string memory _group) {
         if (!msg.sender._getIdForAddress()._hasGroupPrivilege(_context, _group._stringToBytes32()))
-            revert InvalidGroupPrivilege(msg.sender._getIdForAddress(), _context, string(msg.sender._getIdForAddress()._getRoleInContext(_context)._bytes32ToBytes()), _group);
+            /// Note: If the role returned by `_getRoleInContext` is empty (represented by bytes32(0)), we explicitly return an empty string.
+            /// This ensures the user doesn't receive a string that could potentially include unwanted data (like pointer and length) without any meaningful content.
+            revert InvalidGroupPrivilege(
+                msg.sender._getIdForAddress(),
+                _context,
+                (msg.sender._getIdForAddress()._getRoleInContext(_context) == bytes32(0))
+                    ? ""
+                    : string(msg.sender._getIdForAddress()._getRoleInContext(_context)._bytes32ToBytes()),
+                _group
+            );
         _;
     }
 

--- a/src/diamonds/nayms/Modifiers.sol
+++ b/src/diamonds/nayms/Modifiers.sol
@@ -25,7 +25,7 @@ contract Modifiers {
     }
 
     modifier assertSysAdmin() {
-        require(msg.sender._getIdForAddress()._isInGroup(LibAdmin._getSystemId(), LibHelpers._stringToBytes32(LC.GROUP_SYSTEM_ADMINS)), "not a system admin");
+        require(msg.sender._getIdForAddress()._isInGroup(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_ADMINS._stringToBytes32()), "not a system admin");
         _;
     }
 
@@ -35,7 +35,7 @@ contract Modifiers {
     }
 
     modifier assertSysMgr() {
-        require(msg.sender._getIdForAddress()._isInGroup(LibAdmin._getSystemId(), LibHelpers._stringToBytes32(LC.GROUP_SYSTEM_MANAGERS)), "not a system manager");
+        require(msg.sender._getIdForAddress()._isInGroup(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_MANAGERS._stringToBytes32()), "not a system manager");
         _;
     }
 

--- a/src/diamonds/nayms/Modifiers.sol
+++ b/src/diamonds/nayms/Modifiers.sol
@@ -41,12 +41,7 @@ contract Modifiers {
 
     modifier assertHasGroupPrivilege(bytes32 _context, string memory _group) {
         if (!msg.sender._getIdForAddress()._hasGroupPrivilege(_context, _group._stringToBytes32()))
-            revert InvalidGroupPrivilege(
-                msg.sender._getIdForAddress(),
-                _context,
-                abi.decode(msg.sender._getIdForAddress()._getRoleInContext(_context)._bytes32ToBytes(), (string)),
-                _group
-            );
+            revert InvalidGroupPrivilege(msg.sender._getIdForAddress(), _context, string(msg.sender._getIdForAddress()._getRoleInContext(_context)._bytes32ToBytes()), _group);
         _;
     }
 

--- a/src/diamonds/nayms/Modifiers.sol
+++ b/src/diamonds/nayms/Modifiers.sol
@@ -18,7 +18,7 @@ contract Modifiers {
     using LibHelpers for *;
     using LibACL for *;
 
-    error NotInternalUnderwriter(address msgSender);
+    error NotSystemUnderwriter(address msgSender);
 
     /// @notice Error message for when a sender is not authorized to perform an action with their assigned role in a given context of a group
     /// @param msgSenderId Id of the sender
@@ -37,8 +37,8 @@ contract Modifiers {
         _;
     }
 
-    modifier assertInternalUW() {
-        if (!msg.sender._getIdForAddress()._isInGroup(LibAdmin._getSystemId(), LC.GROUP_INTERNAL_UNDERWRITERS._stringToBytes32())) revert NotInternalUnderwriter(msg.sender);
+    modifier assertSystemUW() {
+        if (!msg.sender._getIdForAddress()._isInGroup(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_UNDERWRITERS._stringToBytes32())) revert NotSystemUnderwriter(msg.sender);
         _;
     }
 

--- a/src/diamonds/nayms/facets/ACLFacet.sol
+++ b/src/diamonds/nayms/facets/ACLFacet.sol
@@ -25,7 +25,7 @@ contract ACLFacet is Modifiers, IACLFacet {
         string memory _role
     ) external {
         bytes32 assignerId = LibHelpers._getIdForAddress(msg.sender);
-        require(LibACL._canAssign(assignerId, _objectId, _contextId, LibHelpers._stringToBytes32(_role)), "not in assigners group");
+        require(LibACL._canAssignRole(assignerId, _objectId, _contextId, LibHelpers._stringToBytes32(_role)), "not in assigners group");
         LibACL._assignRole(_objectId, _contextId, LibHelpers._stringToBytes32(_role));
     }
 
@@ -38,7 +38,7 @@ contract ACLFacet is Modifiers, IACLFacet {
     function unassignRole(bytes32 _objectId, bytes32 _contextId) external {
         bytes32 roleId = LibACL._getRoleInContext(_objectId, _contextId);
         bytes32 assignerId = LibHelpers._getIdForAddress(msg.sender);
-        require(LibACL._canAssign(assignerId, _objectId, _contextId, roleId), "not in assigners group");
+        require(LibACL._canAssignRole(assignerId, _objectId, _contextId, roleId), "not in assigners group");
         LibACL._unassignRole(_objectId, _contextId);
     }
 
@@ -89,7 +89,24 @@ contract ACLFacet is Modifiers, IACLFacet {
         bytes32 _contextId,
         string memory _role
     ) external view returns (bool) {
-        return LibACL._canAssign(_assignerId, _objectId, _contextId, LibHelpers._stringToBytes32(_role));
+        return LibACL._canAssignRole(_assignerId, _objectId, _contextId, LibHelpers._stringToBytes32(_role));
+    }
+
+    function canAssignRole(
+        bytes32 _assignerId,
+        bytes32 _objectId,
+        bytes32 _contextId,
+        string memory _role
+    ) external view returns (bool) {
+        return LibACL._canAssignRole(_assignerId, _objectId, _contextId, LibHelpers._stringToBytes32(_role));
+    }
+
+    function hasGroupPrivilege(
+        bytes32 _userId,
+        bytes32 _contextId,
+        bytes32 _groupId
+    ) external view returns (bool) {
+        return LibACL._hasGroupPrivilege(_userId, _contextId, _groupId);
     }
 
     /**

--- a/src/diamonds/nayms/facets/ACLFacet.sol
+++ b/src/diamonds/nayms/facets/ACLFacet.sol
@@ -25,7 +25,7 @@ contract ACLFacet is Modifiers, IACLFacet {
         string memory _role
     ) external {
         bytes32 assignerId = LibHelpers._getIdForAddress(msg.sender);
-        require(LibACL._canAssignRole(assignerId, _objectId, _contextId, LibHelpers._stringToBytes32(_role)), "not in assigners group");
+        require(LibACL._canAssign(assignerId, _objectId, _contextId, LibHelpers._stringToBytes32(_role)), "not in assigners group");
         LibACL._assignRole(_objectId, _contextId, LibHelpers._stringToBytes32(_role));
     }
 
@@ -38,7 +38,7 @@ contract ACLFacet is Modifiers, IACLFacet {
     function unassignRole(bytes32 _objectId, bytes32 _contextId) external {
         bytes32 roleId = LibACL._getRoleInContext(_objectId, _contextId);
         bytes32 assignerId = LibHelpers._getIdForAddress(msg.sender);
-        require(LibACL._canAssignRole(assignerId, _objectId, _contextId, roleId), "not in assigners group");
+        require(LibACL._canAssign(assignerId, _objectId, _contextId, roleId), "not in assigners group");
         LibACL._unassignRole(_objectId, _contextId);
     }
 
@@ -89,18 +89,15 @@ contract ACLFacet is Modifiers, IACLFacet {
         bytes32 _contextId,
         string memory _role
     ) external view returns (bool) {
-        return LibACL._canAssignRole(_assignerId, _objectId, _contextId, LibHelpers._stringToBytes32(_role));
+        return LibACL._canAssign(_assignerId, _objectId, _contextId, LibHelpers._stringToBytes32(_role));
     }
 
-    function canAssignRole(
-        bytes32 _assignerId,
-        bytes32 _objectId,
-        bytes32 _contextId,
-        string memory _role
-    ) external view returns (bool) {
-        return LibACL._canAssignRole(_assignerId, _objectId, _contextId, LibHelpers._stringToBytes32(_role));
-    }
-
+    /**
+     * @notice Check whether a user can call a specific function.
+     * @param _userId The object ID of the user who is calling the function.
+     * @param _contextId ID of the context in which permission is checked.
+     * @param _groupId ID of the group in which permission is checked.
+     */
     function hasGroupPrivilege(
         bytes32 _userId,
         bytes32 _contextId,

--- a/src/diamonds/nayms/facets/EntityFacet.sol
+++ b/src/diamonds/nayms/facets/EntityFacet.sol
@@ -5,7 +5,7 @@ import { Entity, SimplePolicy, Stakeholders, FeeSchedule } from "../AppStorage.s
 import { Modifiers } from "../Modifiers.sol";
 import { LibEntity } from "../libs/LibEntity.sol";
 import { LibObject } from "../libs/LibObject.sol";
-import { LibConstants } from "../libs/LibConstants.sol";
+import { LibConstants as LC } from "../libs/LibConstants.sol";
 import { ReentrancyGuard } from "../../../utils/ReentrancyGuard.sol";
 import { IEntityFacet } from "../interfaces/IEntityFacet.sol";
 import { LibEIP712 } from "src/diamonds/nayms/libs/LibEIP712.sol";
@@ -44,7 +44,7 @@ contract EntityFacet is IEntityFacet, Modifiers, ReentrancyGuard {
         Stakeholders calldata _stakeholders,
         SimplePolicy calldata _simplePolicy,
         bytes32 _dataHash
-    ) external assertSysMgr assertSimplePolicyEnabled(_entityId) {
+    ) external assertInternalUW assertSimplePolicyEnabled(_entityId) {
         LibEntity._createSimplePolicy(_policyId, _entityId, _stakeholders, _simplePolicy, _dataHash);
     }
 
@@ -87,7 +87,7 @@ contract EntityFacet is IEntityFacet, Modifiers, ReentrancyGuard {
         bytes32 _entityId,
         uint256 _amount,
         uint256 _totalPrice
-    ) external notLocked(msg.sig) nonReentrant assertSysMgr {
+    ) external notLocked(msg.sig) nonReentrant assertPermissions(LC.GROUP_START_TOKEN_SALE, LibObject._getParentFromAddress(msg.sender)) {
         LibEntity._startTokenSale(_entityId, _amount, _totalPrice);
     }
 

--- a/src/diamonds/nayms/facets/EntityFacet.sol
+++ b/src/diamonds/nayms/facets/EntityFacet.sol
@@ -44,7 +44,7 @@ contract EntityFacet is IEntityFacet, Modifiers, ReentrancyGuard {
         Stakeholders calldata _stakeholders,
         SimplePolicy calldata _simplePolicy,
         bytes32 _dataHash
-    ) external assertInternalUW assertSimplePolicyEnabled(_entityId) {
+    ) external assertSystemUW assertSimplePolicyEnabled(_entityId) {
         LibEntity._createSimplePolicy(_policyId, _entityId, _stakeholders, _simplePolicy, _dataHash);
     }
 
@@ -58,7 +58,7 @@ contract EntityFacet is IEntityFacet, Modifiers, ReentrancyGuard {
         bytes32 _objectId,
         string memory _symbol,
         string memory _name
-    ) external assertSysAdmin {
+    ) external assertSysMgr {
         LibObject._enableObjectTokenization(_objectId, _symbol, _name);
     }
 
@@ -72,7 +72,7 @@ contract EntityFacet is IEntityFacet, Modifiers, ReentrancyGuard {
         bytes32 _entityId,
         string memory _symbol,
         string memory _name
-    ) external assertSysAdmin {
+    ) external assertSysMgr {
         LibObject._updateTokenInfo(_entityId, _symbol, _name);
     }
 
@@ -87,7 +87,7 @@ contract EntityFacet is IEntityFacet, Modifiers, ReentrancyGuard {
         bytes32 _entityId,
         uint256 _amount,
         uint256 _totalPrice
-    ) external notLocked(msg.sig) nonReentrant assertPermissions(LC.GROUP_START_TOKEN_SALE, LibObject._getParentFromAddress(msg.sender)) {
+    ) external notLocked(msg.sig) nonReentrant assertPermissions(LC.GROUP_START_TOKEN_SALE, _entityId) {
         LibEntity._startTokenSale(_entityId, _amount, _totalPrice);
     }
 

--- a/src/diamonds/nayms/facets/EntityFacet.sol
+++ b/src/diamonds/nayms/facets/EntityFacet.sol
@@ -87,7 +87,7 @@ contract EntityFacet is IEntityFacet, Modifiers, ReentrancyGuard {
         bytes32 _entityId,
         uint256 _amount,
         uint256 _totalPrice
-    ) external notLocked(msg.sig) nonReentrant assertPermissions(LC.GROUP_START_TOKEN_SALE, _entityId) {
+    ) external notLocked(msg.sig) nonReentrant assertHasGroupPrivilege(_entityId, LC.GROUP_START_TOKEN_SALE) {
         LibEntity._startTokenSale(_entityId, _amount, _totalPrice);
     }
 

--- a/src/diamonds/nayms/facets/MarketFacet.sol
+++ b/src/diamonds/nayms/facets/MarketFacet.sol
@@ -32,7 +32,7 @@ contract MarketFacet is IMarketFacet, Modifiers, ReentrancyGuard {
      *
      * @param _offerId offer ID
      */
-    function cancelOffer(uint256 _offerId) external notLocked(msg.sig) nonReentrant assertPermissions(LC.GROUP_CANCEL_LIMIT_ORDERS, LibObject._getParentFromAddress(msg.sender)) {
+    function cancelOffer(uint256 _offerId) external notLocked(msg.sig) nonReentrant assertPermissions(LC.GROUP_CANCEL_OFFER, LibObject._getParentFromAddress(msg.sender)) {
         require(LibMarket._getOffer(_offerId).state == LC.OFFER_STATE_ACTIVE, "offer not active");
         bytes32 creator = LibMarket._getOffer(_offerId).creator;
         require(LibObject._getParent(LibHelpers._getIdForAddress(msg.sender)) == creator, "only member of entity can cancel");
@@ -59,7 +59,7 @@ contract MarketFacet is IMarketFacet, Modifiers, ReentrancyGuard {
         external
         notLocked(msg.sig)
         nonReentrant
-        assertPermissions(LC.GROUP_PLACE_LIMIT_ORDERS, LibObject._getParentFromAddress(msg.sender))
+        assertPermissions(LC.GROUP_EXECUTE_LIMIT_OFFER, LibObject._getParentFromAddress(msg.sender))
         returns (
             uint256 offerId_,
             uint256 buyTokenCommissionsPaid_,

--- a/src/diamonds/nayms/facets/MarketFacet.sol
+++ b/src/diamonds/nayms/facets/MarketFacet.sol
@@ -32,7 +32,7 @@ contract MarketFacet is IMarketFacet, Modifiers, ReentrancyGuard {
      *
      * @param _offerId offer ID
      */
-    function cancelOffer(uint256 _offerId) external notLocked(msg.sig) nonReentrant assertPermissions(LC.GROUP_CANCEL_OFFER, LibObject._getParentFromAddress(msg.sender)) {
+    function cancelOffer(uint256 _offerId) external notLocked(msg.sig) nonReentrant assertHasGroupPrivilege(LibObject._getParentFromAddress(msg.sender), LC.GROUP_CANCEL_OFFER) {
         require(LibMarket._getOffer(_offerId).state == LC.OFFER_STATE_ACTIVE, "offer not active");
         bytes32 creator = LibMarket._getOffer(_offerId).creator;
         require(LibObject._getParent(LibHelpers._getIdForAddress(msg.sender)) == creator, "only member of entity can cancel");
@@ -59,7 +59,7 @@ contract MarketFacet is IMarketFacet, Modifiers, ReentrancyGuard {
         external
         notLocked(msg.sig)
         nonReentrant
-        assertPermissions(LC.GROUP_EXECUTE_LIMIT_OFFER, LibObject._getParentFromAddress(msg.sender))
+        assertHasGroupPrivilege(LibObject._getParentFromAddress(msg.sender), LC.GROUP_EXECUTE_LIMIT_OFFER)
         returns (
             uint256 offerId_,
             uint256 buyTokenCommissionsPaid_,

--- a/src/diamonds/nayms/facets/MarketFacet.sol
+++ b/src/diamonds/nayms/facets/MarketFacet.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import { Modifiers } from "../Modifiers.sol";
 import { CalculatedFees, MarketInfo } from "../AppStorage.sol";
-import { LibConstants } from "../libs/LibConstants.sol";
+import { LibConstants as LC } from "../libs/LibConstants.sol";
 import { LibHelpers } from "../libs/LibHelpers.sol";
 import { LibMarket } from "../libs/LibMarket.sol";
 import { LibObject } from "../libs/LibObject.sol";
@@ -32,8 +32,8 @@ contract MarketFacet is IMarketFacet, Modifiers, ReentrancyGuard {
      *
      * @param _offerId offer ID
      */
-    function cancelOffer(uint256 _offerId) external notLocked(msg.sig) nonReentrant {
-        require(LibMarket._getOffer(_offerId).state == LibConstants.OFFER_STATE_ACTIVE, "offer not active");
+    function cancelOffer(uint256 _offerId) external notLocked(msg.sig) nonReentrant assertPermissions(LC.GROUP_CANCEL_LIMIT_ORDERS, LibObject._getParentFromAddress(msg.sender)) {
+        require(LibMarket._getOffer(_offerId).state == LC.OFFER_STATE_ACTIVE, "offer not active");
         bytes32 creator = LibMarket._getOffer(_offerId).creator;
         require(LibObject._getParent(LibHelpers._getIdForAddress(msg.sender)) == creator, "only member of entity can cancel");
         LibMarket._cancelOffer(_offerId);
@@ -59,6 +59,7 @@ contract MarketFacet is IMarketFacet, Modifiers, ReentrancyGuard {
         external
         notLocked(msg.sig)
         nonReentrant
+        assertPermissions(LC.GROUP_PLACE_LIMIT_ORDERS, LibObject._getParentFromAddress(msg.sender))
         returns (
             uint256 offerId_,
             uint256 buyTokenCommissionsPaid_,
@@ -68,7 +69,7 @@ contract MarketFacet is IMarketFacet, Modifiers, ReentrancyGuard {
         // Get the msg.sender's entityId. The parent is the entityId associated with the child, aka the msg.sender.
         // note: Only the entity associated with the msg.sender can make an offer on the market
         bytes32 parentId = LibObject._getParentFromAddress(msg.sender);
-        return LibMarket._executeLimitOffer(parentId, _sellToken, _sellAmount, _buyToken, _buyAmount, LibConstants.FEE_TYPE_TRADING);
+        return LibMarket._executeLimitOffer(parentId, _sellToken, _sellAmount, _buyToken, _buyAmount, LC.FEE_TYPE_TRADING);
     }
 
     /**

--- a/src/diamonds/nayms/facets/SimplePolicyFacet.sol
+++ b/src/diamonds/nayms/facets/SimplePolicyFacet.sol
@@ -21,14 +21,13 @@ contract SimplePolicyFacet is ISimplePolicyFacet, Modifiers {
      * @param _policyId Id of the simple policy
      * @param _amount Amount of the premium
      */
-    function paySimplePremium(bytes32 _policyId, uint256 _amount) external notLocked(msg.sig) assertPolicyHandler(_policyId) {
+    function paySimplePremium(bytes32 _policyId, uint256 _amount) external notLocked(msg.sig) assertPermissions(LC.GROUP_POLICY_HANDLERS, _policyId) {
         bytes32 senderId = LibHelpers._getIdForAddress(msg.sender);
         bytes32 payerEntityId = LibObject._getParent(senderId);
 
         LibSimplePolicy._payPremium(payerEntityId, _policyId, _amount);
     }
 
-    // todo replace assertPolicyHandler with assertPermissions(LC.GROUP_POLICY_HANDLERS, _policyId);
     /**
      * @dev Pay a claim of `_amount` for simple policy
      * @param _claimId Id of the simple policy claim
@@ -41,7 +40,7 @@ contract SimplePolicyFacet is ISimplePolicyFacet, Modifiers {
         bytes32 _policyId,
         bytes32 _insuredId,
         uint256 _amount
-    ) external notLocked(msg.sig) assertPermissions(LC.GROUP_PAY_CLAIMS, LibObject._getParentFromAddress(msg.sender)) {
+    ) external notLocked(msg.sig) assertPermissions(LC.GROUP_PAY_SIMPLE_CLAIM, LibObject._getParentFromAddress(msg.sender)) {
         LibSimplePolicy._payClaim(_claimId, _policyId, _insuredId, _amount);
     }
 

--- a/src/diamonds/nayms/facets/SimplePolicyFacet.sol
+++ b/src/diamonds/nayms/facets/SimplePolicyFacet.sol
@@ -21,7 +21,7 @@ contract SimplePolicyFacet is ISimplePolicyFacet, Modifiers {
      * @param _policyId Id of the simple policy
      * @param _amount Amount of the premium
      */
-    function paySimplePremium(bytes32 _policyId, uint256 _amount) external notLocked(msg.sig) assertPermissions(LC.GROUP_POLICY_HANDLERS, _policyId) {
+    function paySimplePremium(bytes32 _policyId, uint256 _amount) external notLocked(msg.sig) assertHasGroupPrivilege(_policyId, LC.GROUP_PAY_SIMPLE_PREMIUM) {
         bytes32 senderId = LibHelpers._getIdForAddress(msg.sender);
         bytes32 payerEntityId = LibObject._getParent(senderId);
 
@@ -40,7 +40,7 @@ contract SimplePolicyFacet is ISimplePolicyFacet, Modifiers {
         bytes32 _policyId,
         bytes32 _insuredId,
         uint256 _amount
-    ) external notLocked(msg.sig) assertPermissions(LC.GROUP_PAY_SIMPLE_CLAIM, LibObject._getParentFromAddress(msg.sender)) {
+    ) external notLocked(msg.sig) assertHasGroupPrivilege(LibObject._getParentFromAddress(msg.sender), LC.GROUP_PAY_SIMPLE_CLAIM) {
         LibSimplePolicy._payClaim(_claimId, _policyId, _insuredId, _amount);
     }
 

--- a/src/diamonds/nayms/facets/SimplePolicyFacet.sol
+++ b/src/diamonds/nayms/facets/SimplePolicyFacet.sol
@@ -8,6 +8,7 @@ import { LibHelpers } from "../libs/LibHelpers.sol";
 import { LibSimplePolicy } from "../libs/LibSimplePolicy.sol";
 import { LibFeeRouter } from "../libs/LibFeeRouter.sol";
 import { ISimplePolicyFacet } from "../interfaces/ISimplePolicyFacet.sol";
+import { LibConstants as LC } from "../libs/LibConstants.sol";
 
 /**
  * @title Simple Policies
@@ -39,7 +40,7 @@ contract SimplePolicyFacet is ISimplePolicyFacet, Modifiers {
         bytes32 _policyId,
         bytes32 _insuredId,
         uint256 _amount
-    ) external notLocked(msg.sig) assertSysMgr {
+    ) external notLocked(msg.sig) assertPermissions(LC.GROUP_PAY_CLAIMS, LibObject._getParentFromAddress(msg.sender)) {
         LibSimplePolicy._payClaim(_claimId, _policyId, _insuredId, _amount);
     }
 
@@ -74,7 +75,7 @@ contract SimplePolicyFacet is ISimplePolicyFacet, Modifiers {
      * @dev Cancel a simple policy
      * @param _policyId Id of the simple policy
      */
-    function cancelSimplePolicy(bytes32 _policyId) external assertSysMgr {
+    function cancelSimplePolicy(bytes32 _policyId) external assertInternalUW {
         LibSimplePolicy._cancel(_policyId);
     }
 

--- a/src/diamonds/nayms/facets/SimplePolicyFacet.sol
+++ b/src/diamonds/nayms/facets/SimplePolicyFacet.sol
@@ -28,6 +28,7 @@ contract SimplePolicyFacet is ISimplePolicyFacet, Modifiers {
         LibSimplePolicy._payPremium(payerEntityId, _policyId, _amount);
     }
 
+    // todo replace assertPolicyHandler with assertPermissions(LC.GROUP_POLICY_HANDLERS, _policyId);
     /**
      * @dev Pay a claim of `_amount` for simple policy
      * @param _claimId Id of the simple policy claim
@@ -75,7 +76,7 @@ contract SimplePolicyFacet is ISimplePolicyFacet, Modifiers {
      * @dev Cancel a simple policy
      * @param _policyId Id of the simple policy
      */
-    function cancelSimplePolicy(bytes32 _policyId) external assertInternalUW {
+    function cancelSimplePolicy(bytes32 _policyId) external assertSystemUW {
         LibSimplePolicy._cancel(_policyId);
     }
 

--- a/src/diamonds/nayms/facets/SystemFacet.sol
+++ b/src/diamonds/nayms/facets/SystemFacet.sol
@@ -28,7 +28,7 @@ contract SystemFacet is ISystemFacet, Modifiers, ReentrancyGuard {
         bytes32 _entityAdmin,
         Entity calldata _entityData,
         bytes32 _dataHash
-    ) external assertSysAdmin {
+    ) external assertSysMgr {
         LibEntity._createEntity(_entityId, _entityAdmin, _entityData, _dataHash);
     }
 

--- a/src/diamonds/nayms/facets/SystemFacet.sol
+++ b/src/diamonds/nayms/facets/SystemFacet.sol
@@ -28,7 +28,7 @@ contract SystemFacet is ISystemFacet, Modifiers, ReentrancyGuard {
         bytes32 _entityAdmin,
         Entity calldata _entityData,
         bytes32 _dataHash
-    ) external assertSysMgr {
+    ) external assertSysAdmin {
         LibEntity._createEntity(_entityId, _entityAdmin, _entityData, _dataHash);
     }
 
@@ -77,7 +77,7 @@ contract SystemFacet is ISystemFacet, Modifiers, ReentrancyGuard {
      * @notice Wrap an object token as ERC20
      * @param _objectId ID of the tokenized object
      */
-    function wrapToken(bytes32 _objectId) external nonReentrant assertSysMgr {
+    function wrapToken(bytes32 _objectId) external nonReentrant assertSysAdmin {
         LibObject._wrapToken(_objectId);
     }
 }

--- a/src/diamonds/nayms/facets/TokenizedVaultFacet.sol
+++ b/src/diamonds/nayms/facets/TokenizedVaultFacet.sol
@@ -49,7 +49,7 @@ contract TokenizedVaultFacet is ITokenizedVaultFacet, Modifiers, ReentrancyGuard
         bytes32 to,
         bytes32 tokenId,
         uint256 amount
-    ) external notLocked(msg.sig) nonReentrant assertPermissions(LC.GROUP_INTERNAL_TRANSFER_FROM_ENTITY, LibObject._getParentFromAddress(msg.sender)) {
+    ) external notLocked(msg.sig) nonReentrant assertHasGroupPrivilege(LibObject._getParentFromAddress(msg.sender), LC.GROUP_INTERNAL_TRANSFER_FROM_ENTITY) {
         bytes32 senderEntityId = LibObject._getParentFromAddress(msg.sender);
         LibTokenizedVault._internalTransfer(senderEntityId, to, tokenId, amount);
     }
@@ -129,7 +129,7 @@ contract TokenizedVaultFacet is ITokenizedVaultFacet, Modifiers, ReentrancyGuard
     function payDividendFromEntity(bytes32 guid, uint256 amount)
         external
         notLocked(msg.sig)
-        assertPermissions(LC.GROUP_PAY_DIVIDEND_FROM_ENTITY, LibObject._getParentFromAddress(msg.sender))
+        assertHasGroupPrivilege(LibObject._getParentFromAddress(msg.sender), LC.GROUP_PAY_DIVIDEND_FROM_ENTITY)
     {
         bytes32 entityId = LibObject._getParentFromAddress(msg.sender);
         bytes32 dividendTokenId = LibEntity._getEntityInfo(entityId).assetId;

--- a/src/diamonds/nayms/facets/TokenizedVaultFacet.sol
+++ b/src/diamonds/nayms/facets/TokenizedVaultFacet.sol
@@ -3,9 +3,7 @@ pragma solidity 0.8.17;
 
 import { Modifiers } from "../Modifiers.sol";
 import { LibConstants as LC } from "../libs/LibConstants.sol";
-import { LibHelpers } from "../libs/LibHelpers.sol";
 import { LibTokenizedVault } from "../libs/LibTokenizedVault.sol";
-import { LibACL } from "../libs/LibACL.sol";
 import { LibObject } from "../libs/LibObject.sol";
 import { LibEntity } from "../libs/LibEntity.sol";
 import { ITokenizedVaultFacet } from "../interfaces/ITokenizedVaultFacet.sol";
@@ -108,7 +106,7 @@ contract TokenizedVaultFacet is ITokenizedVaultFacet, Modifiers, ReentrancyGuard
         bytes32 ownerId,
         bytes32 tokenId,
         bytes32 dividendTokenId
-    ) external notLocked(msg.sig) assertPermissions(LC.GROUP_WITHDRAW_DIVIDEND, LibObject._getParentFromAddress(msg.sender)) {
+    ) external notLocked(msg.sig) {
         LibTokenizedVault._withdrawDividend(ownerId, tokenId, dividendTokenId);
     }
 
@@ -118,11 +116,7 @@ contract TokenizedVaultFacet is ITokenizedVaultFacet, Modifiers, ReentrancyGuard
      * @param ownerId Unique ID of the dividend receiver
      * @param tokenId Unique ID of token
      */
-    function withdrawAllDividends(bytes32 ownerId, bytes32 tokenId)
-        external
-        notLocked(msg.sig)
-        assertPermissions(LC.GROUP_WITHDRAW_ALL_DIVIDENDS, LibObject._getParentFromAddress(msg.sender))
-    {
+    function withdrawAllDividends(bytes32 ownerId, bytes32 tokenId) external notLocked(msg.sig) {
         LibTokenizedVault._withdrawAllDividends(ownerId, tokenId);
     }
 

--- a/src/diamonds/nayms/facets/TokenizedVaultFacet.sol
+++ b/src/diamonds/nayms/facets/TokenizedVaultFacet.sol
@@ -51,7 +51,7 @@ contract TokenizedVaultFacet is ITokenizedVaultFacet, Modifiers, ReentrancyGuard
         bytes32 to,
         bytes32 tokenId,
         uint256 amount
-    ) external notLocked(msg.sig) nonReentrant assertEntityAdmin(LibObject._getParentFromAddress(msg.sender)) {
+    ) external notLocked(msg.sig) nonReentrant assertPermissions(LC.GROUP_INTERNAL_TRANSFER_FROM_ENTITY, LibObject._getParentFromAddress(msg.sender)) {
         bytes32 senderEntityId = LibObject._getParentFromAddress(msg.sender);
         LibTokenizedVault._internalTransfer(senderEntityId, to, tokenId, amount);
     }
@@ -108,7 +108,7 @@ contract TokenizedVaultFacet is ITokenizedVaultFacet, Modifiers, ReentrancyGuard
         bytes32 ownerId,
         bytes32 tokenId,
         bytes32 dividendTokenId
-    ) external notLocked(msg.sig) {
+    ) external notLocked(msg.sig) assertPermissions(LC.GROUP_WITHDRAW_DIVIDEND, LibObject._getParentFromAddress(msg.sender)) {
         LibTokenizedVault._withdrawDividend(ownerId, tokenId, dividendTokenId);
     }
 
@@ -118,7 +118,11 @@ contract TokenizedVaultFacet is ITokenizedVaultFacet, Modifiers, ReentrancyGuard
      * @param ownerId Unique ID of the dividend receiver
      * @param tokenId Unique ID of token
      */
-    function withdrawAllDividends(bytes32 ownerId, bytes32 tokenId) external notLocked(msg.sig) {
+    function withdrawAllDividends(bytes32 ownerId, bytes32 tokenId)
+        external
+        notLocked(msg.sig)
+        assertPermissions(LC.GROUP_WITHDRAW_ALL_DIVIDENDS, LibObject._getParentFromAddress(msg.sender))
+    {
         LibTokenizedVault._withdrawAllDividends(ownerId, tokenId);
     }
 
@@ -131,7 +135,7 @@ contract TokenizedVaultFacet is ITokenizedVaultFacet, Modifiers, ReentrancyGuard
     function payDividendFromEntity(bytes32 guid, uint256 amount)
         external
         notLocked(msg.sig)
-        assertPermissions(LC.GROUP_PAY_DISTRIBUTIONS, LibObject._getParentFromAddress(msg.sender))
+        assertPermissions(LC.GROUP_PAY_DIVIDEND_FROM_ENTITY, LibObject._getParentFromAddress(msg.sender))
     {
         bytes32 entityId = LibObject._getParentFromAddress(msg.sender);
         bytes32 dividendTokenId = LibEntity._getEntityInfo(entityId).assetId;

--- a/src/diamonds/nayms/facets/TokenizedVaultFacet.sol
+++ b/src/diamonds/nayms/facets/TokenizedVaultFacet.sol
@@ -49,7 +49,7 @@ contract TokenizedVaultFacet is ITokenizedVaultFacet, Modifiers, ReentrancyGuard
         bytes32 to,
         bytes32 tokenId,
         uint256 amount
-    ) external notLocked(msg.sig) nonReentrant assertHasGroupPrivilege(LibObject._getParentFromAddress(msg.sender), LC.GROUP_INTERNAL_TRANSFER_FROM_ENTITY) {
+    ) external notLocked(msg.sig) nonReentrant {
         bytes32 senderEntityId = LibObject._getParentFromAddress(msg.sender);
         LibTokenizedVault._internalTransfer(senderEntityId, to, tokenId, amount);
     }

--- a/src/diamonds/nayms/facets/TokenizedVaultIOFacet.sol
+++ b/src/diamonds/nayms/facets/TokenizedVaultIOFacet.sol
@@ -8,6 +8,7 @@ import { LibAdmin } from "../libs/LibAdmin.sol";
 import { LibObject } from "../libs/LibObject.sol";
 import { ReentrancyGuard } from "../../../utils/ReentrancyGuard.sol";
 import { ITokenizedVaultIOFacet } from "../interfaces/ITokenizedVaultIOFacet.sol";
+import { LibConstants as LC } from "../libs/LibConstants.sol";
 
 /**
  * @title Token Vault IO
@@ -22,7 +23,12 @@ contract TokenizedVaultIOFacet is ITokenizedVaultIOFacet, Modifiers, ReentrancyG
      * @param _externalTokenAddress Token address
      * @param _amount deposit amount
      */
-    function externalDeposit(address _externalTokenAddress, uint256 _amount) external notLocked(msg.sig) nonReentrant {
+    function externalDeposit(address _externalTokenAddress, uint256 _amount)
+        external
+        notLocked(msg.sig)
+        nonReentrant
+        assertPermissions(LC.GROUP_TENANTS, LibObject._getParentFromAddress(msg.sender))
+    {
         // a user can only deposit an approved external ERC20 token
         require(LibAdmin._isSupportedExternalTokenAddress(_externalTokenAddress), "extDeposit: invalid ERC20 token");
         // a user can only deposit to their valid entity
@@ -45,7 +51,7 @@ contract TokenizedVaultIOFacet is ITokenizedVaultIOFacet, Modifiers, ReentrancyG
         address _receiver,
         address _externalTokenAddress,
         uint256 _amount
-    ) external notLocked(msg.sig) nonReentrant assertEntityAdmin(_entityId) {
+    ) external notLocked(msg.sig) nonReentrant assertPermissions(LC.GROUP_WITHDRAW_FUNDS, LibObject._getParentFromAddress(msg.sender)) {
         LibTokenizedVaultIO._externalWithdraw(_entityId, _receiver, _externalTokenAddress, _amount);
     }
 }

--- a/src/diamonds/nayms/facets/TokenizedVaultIOFacet.sol
+++ b/src/diamonds/nayms/facets/TokenizedVaultIOFacet.sol
@@ -27,7 +27,7 @@ contract TokenizedVaultIOFacet is ITokenizedVaultIOFacet, Modifiers, ReentrancyG
         external
         notLocked(msg.sig)
         nonReentrant
-        assertPermissions(LC.GROUP_TENANTS, LibObject._getParentFromAddress(msg.sender))
+        assertPermissions(LC.GROUP_EXTERNAL_DEPOSIT, LibObject._getParentFromAddress(msg.sender))
     {
         // a user can only deposit an approved external ERC20 token
         require(LibAdmin._isSupportedExternalTokenAddress(_externalTokenAddress), "extDeposit: invalid ERC20 token");
@@ -51,7 +51,7 @@ contract TokenizedVaultIOFacet is ITokenizedVaultIOFacet, Modifiers, ReentrancyG
         address _receiver,
         address _externalTokenAddress,
         uint256 _amount
-    ) external notLocked(msg.sig) nonReentrant assertPermissions(LC.GROUP_WITHDRAW_FUNDS, LibObject._getParentFromAddress(msg.sender)) {
+    ) external notLocked(msg.sig) nonReentrant assertPermissions(LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY, LibObject._getParentFromAddress(msg.sender)) {
         LibTokenizedVaultIO._externalWithdraw(_entityId, _receiver, _externalTokenAddress, _amount);
     }
 }

--- a/src/diamonds/nayms/facets/TokenizedVaultIOFacet.sol
+++ b/src/diamonds/nayms/facets/TokenizedVaultIOFacet.sol
@@ -27,7 +27,7 @@ contract TokenizedVaultIOFacet is ITokenizedVaultIOFacet, Modifiers, ReentrancyG
         external
         notLocked(msg.sig)
         nonReentrant
-        assertPermissions(LC.GROUP_EXTERNAL_DEPOSIT, LibObject._getParentFromAddress(msg.sender))
+        assertHasGroupPrivilege(LibObject._getParentFromAddress(msg.sender), LC.GROUP_EXTERNAL_DEPOSIT)
     {
         // a user can only deposit an approved external ERC20 token
         require(LibAdmin._isSupportedExternalTokenAddress(_externalTokenAddress), "extDeposit: invalid ERC20 token");
@@ -51,7 +51,7 @@ contract TokenizedVaultIOFacet is ITokenizedVaultIOFacet, Modifiers, ReentrancyG
         address _receiver,
         address _externalTokenAddress,
         uint256 _amount
-    ) external notLocked(msg.sig) nonReentrant assertPermissions(LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY, LibObject._getParentFromAddress(msg.sender)) {
+    ) external notLocked(msg.sig) nonReentrant assertHasGroupPrivilege(LibObject._getParentFromAddress(msg.sender), LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY) {
         LibTokenizedVaultIO._externalWithdraw(_entityId, _receiver, _externalTokenAddress, _amount);
     }
 }

--- a/src/diamonds/nayms/facets/UserFacet.sol
+++ b/src/diamonds/nayms/facets/UserFacet.sol
@@ -41,7 +41,7 @@ contract UserFacet is IUserFacet, Modifiers {
      * @param _userId Unique platform ID of the user account
      * @param _entityId Unique platform ID of the entity
      */
-    function setEntity(bytes32 _userId, bytes32 _entityId) external assertSysAdmin {
+    function setEntity(bytes32 _userId, bytes32 _entityId) external assertSysMgr {
         if (!LibEntity._isEntity(_entityId)) {
             revert EntityDoesNotExist(_entityId);
         }

--- a/src/diamonds/nayms/interfaces/CustomErrors.sol
+++ b/src/diamonds/nayms/interfaces/CustomErrors.sol
@@ -13,6 +13,7 @@ error AssignerGroupIsMissing();
 error NotSystemUnderwriter(address msgSender);
 
 /// @notice Error message for when a sender is not authorized to perform an action with their assigned role in a given context of a group
+/// @dev In the assertHasGroupPrivilege modifier, this error message returns the context and the role in the context, not the user's role in the system context.
 /// @param msgSenderId Id of the sender
 /// @param context Context in which the sender is trying to perform an action
 /// @param roleInContext Role of the sender in the context

--- a/src/diamonds/nayms/interfaces/CustomErrors.sol
+++ b/src/diamonds/nayms/interfaces/CustomErrors.sol
@@ -10,6 +10,15 @@ error RoleIsMissing();
 /// @dev Passing in a missing group when trying to assign a role to a group.
 error AssignerGroupIsMissing();
 
+error NotSystemUnderwriter(address msgSender);
+
+/// @notice Error message for when a sender is not authorized to perform an action with their assigned role in a given context of a group
+/// @param msgSenderId Id of the sender
+/// @param context Context in which the sender is trying to perform an action
+/// @param roleInContext Role of the sender in the context
+/// @param group Group to check the sender's role in
+error InvalidGroupPrivilege(bytes32 msgSenderId, bytes32 context, string roleInContext, string group);
+
 /// @dev Passing in a missing address when trying to add a token address to the supported external token list.
 error CannotAddNullSupportedExternalToken();
 
@@ -21,6 +30,7 @@ error CannotAddNullDiscountToken();
 
 /// @dev The entity does not exist when it should.
 error EntityDoesNotExist(bytes32 objectId);
+
 /// @dev Cannot create an entity that already exists.
 error CreatingEntityThatAlreadyExists(bytes32 entityId);
 

--- a/src/diamonds/nayms/interfaces/IACLFacet.sol
+++ b/src/diamonds/nayms/interfaces/IACLFacet.sol
@@ -72,6 +72,19 @@ interface IACLFacet {
         string memory _role
     ) external view returns (bool);
 
+    function canAssignRole(
+        bytes32 _assignerId,
+        bytes32 _objectId,
+        bytes32 _contextId,
+        string memory _role
+    ) external view returns (bool);
+
+    function hasGroupPrivilege(
+        bytes32 _userId,
+        bytes32 _contextId,
+        bytes32 _groupId
+    ) external view returns (bool);
+
     /**
      * @notice Get a user's (an objectId's) assigned role in a specific context
      * @param objectId ID of an object that is being checked for its assigned role in a specific context

--- a/src/diamonds/nayms/interfaces/IACLFacet.sol
+++ b/src/diamonds/nayms/interfaces/IACLFacet.sol
@@ -72,13 +72,12 @@ interface IACLFacet {
         string memory _role
     ) external view returns (bool);
 
-    function canAssignRole(
-        bytes32 _assignerId,
-        bytes32 _objectId,
-        bytes32 _contextId,
-        string memory _role
-    ) external view returns (bool);
-
+    /**
+     * @notice Check whether a user can call a specific function.
+     * @param _userId The object ID of the user who is calling the function.
+     * @param _contextId ID of the context in which permission is checked.
+     * @param _groupId ID of the group in which permission is checked.
+     */
     function hasGroupPrivilege(
         bytes32 _userId,
         bytes32 _contextId,

--- a/src/diamonds/nayms/libs/LibACL.sol
+++ b/src/diamonds/nayms/libs/LibACL.sol
@@ -133,6 +133,7 @@ library LibACL {
         // if account itself does not have the membership in given context, then having membership
         // in the system context grants him the privilege needed
         if (_isInGroup(_assignerId, LibAdmin._getSystemId(), assignerGroup)) return true;
+        return false;
     }
 
     function _hasGroupPrivilege(
@@ -143,6 +144,7 @@ library LibACL {
         if (_isParentInGroup(_userId, _contextId, _groupId)) return true;
         if (_isInGroup(_userId, _contextId, _groupId)) return true;
         if (_isInGroup(_userId, LibAdmin._getSystemId(), _groupId)) return true;
+        return false;
     }
 
     function _getRoleInContext(bytes32 _objectId, bytes32 _contextId) internal view returns (bytes32) {

--- a/src/diamonds/nayms/libs/LibACL.sol
+++ b/src/diamonds/nayms/libs/LibACL.sol
@@ -91,9 +91,8 @@ library LibACL {
         // Check for the role in the context
         bytes32 objectRoleInContext = s.roles[_objectId][_contextId];
 
-        if (objectRoleInContext != 0 && s.groups[objectRoleInContext][_groupId]) {
-            ret = true;
-        }
+        if (objectRoleInContext != 0 && s.groups[objectRoleInContext][_groupId]) return true;
+        return false;
     }
 
     function _isParentInGroup(

--- a/src/diamonds/nayms/libs/LibACL.sol
+++ b/src/diamonds/nayms/libs/LibACL.sol
@@ -114,7 +114,7 @@ library LibACL {
      * @param _roleId ID of a role being assigned
      * @return  true if allowed false otherwise
      */
-    function _canAssignRole(
+    function _canAssign(
         bytes32 _assignerId,
         bytes32 _objectId,
         bytes32 _contextId,

--- a/src/diamonds/nayms/libs/LibConstants.sol
+++ b/src/diamonds/nayms/libs/LibConstants.sol
@@ -18,25 +18,28 @@ library LibConstants {
     /// Roles
 
     string internal constant ROLE_SYSTEM_ADMIN = "System Admin";
-    string internal constant ROLE_SYSTEM_MANAGER = "System Manager"; // Segregated account manager
-    string internal constant ROLE_INTERNAL_UNDERWRITER = "Internal Underwriter";
+    string internal constant ROLE_SYSTEM_MANAGER = "System Manager";
+    string internal constant ROLE_SYSTEM_UNDERWRITER = "System Underwriter";
 
-    string internal constant ROLE_ACCOUNT_MANAGER = "Account Manager";
+    string internal constant ROLE_ENTITY_ADMIN = "Entity Admin";
+    string internal constant ROLE_ENTITY_MANAGER = "Entity Manager";
+    string internal constant ROLE_ENTITY_BROKER = "Broker";
+    string internal constant ROLE_ENTITY_INSURED = "Insured";
+    string internal constant ROLE_ENTITY_CP = "Capital Provider";
+    string internal constant ROLE_ENTITY_CONSULTANT = "Consultant"; // note NEW name for ROLE_SERVICE_PROVIDER
 
+    string internal constant ROLE_ENTITY_COMPTROLLER_COMBINED = "Comptroller Combined";
+    string internal constant ROLE_ENTITY_COMPTROLLER_WITHDRAW = "Comptroller Withdraw";
+    string internal constant ROLE_ENTITY_COMPTROLLER_CLAIM = "Comptroller Claim";
+    string internal constant ROLE_ENTITY_COMPTROLLER_DIVIDEND = "Comptroller Dividend";
+
+    /// old roles
     string internal constant ROLE_SPONSOR = "Sponsor";
     string internal constant ROLE_CAPITAL_PROVIDER = "Capital Provider";
     string internal constant ROLE_INSURED_PARTY = "Insured";
     string internal constant ROLE_BROKER = "Broker";
-    string internal constant ROLE_CONSULTANT = "Consultant"; // note NEW name for ROLE_SERVICE_PROVIDER
-    string internal constant ROLE_SERVICE_PROVIDER = "Service Provider"; // todo deprecate this
+    string internal constant ROLE_SERVICE_PROVIDER = "Service Provider";
 
-    string internal constant ROLE_COMPTROLLER_COMBINED = "Comptroller Combined";
-    string internal constant ROLE_COMPTROLLER_WITHDRAW = "Comptroller Withdraw";
-    string internal constant ROLE_COMPTROLLER_CLAIM = "Comptroller Claim";
-    string internal constant ROLE_COMPTROLLER_DIVIDEND = "Comptroller Dividend";
-
-    string internal constant ROLE_ENTITY_ADMIN = "Entity Admin";
-    string internal constant ROLE_ENTITY_MANAGER = "Entity Manager";
     string internal constant ROLE_UNDERWRITER = "Underwriter";
     string internal constant ROLE_CLAIMS_ADMIN = "Claims Admin";
     string internal constant ROLE_TRADER = "Trader";
@@ -46,17 +49,21 @@ library LibConstants {
 
     string internal constant GROUP_SYSTEM_ADMINS = "System Admins";
     string internal constant GROUP_SYSTEM_MANAGERS = "System Managers";
-    string internal constant GROUP_INTERNAL_UNDERWRITERS = "Internal Underwriters";
+    string internal constant GROUP_SYSTEM_UNDERWRITERS = "System Underwriters";
 
-    string internal constant GROUP_ACCOUNT_MANAGERS = "Account Managers";
     string internal constant GROUP_TENANTS = "Tenants";
 
-    string internal constant GROUP_START_TOKEN_SALE = "G start token sale";
-    string internal constant GROUP_PLACE_LIMIT_ORDERS = "G place limit orders";
-    string internal constant GROUP_CANCEL_LIMIT_ORDERS = "G cancel limit orders";
-    string internal constant GROUP_WITHDRAW_FUNDS = "G withdraw funds";
-    string internal constant GROUP_PAY_CLAIMS = "G pay claims";
-    string internal constant GROUP_PAY_DISTRIBUTIONS = "G pay dists";
+    string internal constant GROUP_START_TOKEN_SALE = "Start Token Sale";
+    string internal constant GROUP_EXECUTE_LIMIT_OFFER = "Execute Limit Offer";
+    string internal constant GROUP_CANCEL_OFFER = "Cancel Offer";
+    string internal constant GROUP_INTERNAL_TRANSFER_FROM_ENTITY = "Internal Transfer From Entity";
+    string internal constant GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY = "External Withdraw From Entity";
+    string internal constant GROUP_EXTERNAL_DEPOSIT = "External Deposit";
+    string internal constant GROUP_WITHDRAW_DIVIDEND = "Withdraw Dividend";
+    string internal constant GROUP_WITHDRAW_ALL_DIVIDENDS = "Withdraw All Dividends";
+    string internal constant GROUP_PAY_CLAIMS = "Pay Claims";
+    string internal constant GROUP_PAY_DIVIDEND_FROM_ENTITY = "Pay Dividend From Entity";
+
     string internal constant GROUP_POLICY_HANDLERS = "Policy Handlers";
 
     string internal constant GROUP_ENTITY_ADMINS = "Entity Admins";

--- a/src/diamonds/nayms/libs/LibConstants.sol
+++ b/src/diamonds/nayms/libs/LibConstants.sol
@@ -52,6 +52,7 @@ library LibConstants {
     string internal constant GROUP_SYSTEM_UNDERWRITERS = "System Underwriters";
 
     string internal constant GROUP_TENANTS = "Tenants";
+    string internal constant GROUP_MANAGERS = "Managers"; // a group of roles that can be assigned by both system and entity managers
 
     string internal constant GROUP_START_TOKEN_SALE = "Start Token Sale";
     string internal constant GROUP_EXECUTE_LIMIT_OFFER = "Execute Limit Offer";
@@ -59,12 +60,11 @@ library LibConstants {
     string internal constant GROUP_INTERNAL_TRANSFER_FROM_ENTITY = "Internal Transfer From Entity";
     string internal constant GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY = "External Withdraw From Entity";
     string internal constant GROUP_EXTERNAL_DEPOSIT = "External Deposit";
-    string internal constant GROUP_WITHDRAW_DIVIDEND = "Withdraw Dividend";
-    string internal constant GROUP_WITHDRAW_ALL_DIVIDENDS = "Withdraw All Dividends";
-    string internal constant GROUP_PAY_CLAIMS = "Pay Claims";
+    string internal constant GROUP_PAY_SIMPLE_CLAIM = "Pay Simple Claim";
+    string internal constant GROUP_PAY_SIMPLE_PREMIUM = "Pay Simple Premium";
     string internal constant GROUP_PAY_DIVIDEND_FROM_ENTITY = "Pay Dividend From Entity";
 
-    string internal constant GROUP_POLICY_HANDLERS = "Policy Handlers";
+    string internal constant GROUP_POLICY_HANDLERS = "Policy Handlers"; // note replaced with GROUP_PAY_SIMPLE_PREMIUM
 
     string internal constant GROUP_ENTITY_ADMINS = "Entity Admins";
     string internal constant GROUP_ENTITY_MANAGERS = "Entity Managers";

--- a/src/diamonds/nayms/libs/LibConstants.sol
+++ b/src/diamonds/nayms/libs/LibConstants.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.17;
  * @dev Settings keys.
  */
 library LibConstants {
-    //Reserved IDs
+    /// Reserved IDs
     string internal constant EMPTY_IDENTIFIER = "";
     string internal constant SYSTEM_IDENTIFIER = "System";
     string internal constant NDF_IDENTIFIER = "NDF";
@@ -15,15 +15,24 @@ library LibConstants {
     string internal constant DIVIDEND_BANK_IDENTIFIER = "Dividend Bank"; //This will hold all the dividends
     string internal constant NAYMS_LTD_IDENTIFIER = "Nayms Ltd";
 
-    //Roles
+    /// Roles
+
     string internal constant ROLE_SYSTEM_ADMIN = "System Admin";
+    string internal constant ROLE_INTERNAL_UNDERWRITER = "Internal Underwriter";
+
+    string internal constant ROLE_ACCOUNT_MANAGER = "Account Manager";
+    string internal constant ROLE_SPONSOR = "Sponsor";
+    string internal constant ROLE_CAPITAL_PROVIDER = "Capital Provider";
+    string internal constant ROLE_INSURED_PARTY = "Insured";
+    string internal constant ROLE_BROKER = "Broker";
+    string internal constant ROLE_CONSULTANT = "Consultant";
+
+    string internal constant ROLE_COMPTROLLER = "Comptroller";
+
     string internal constant ROLE_SYSTEM_MANAGER = "System Manager";
     string internal constant ROLE_ENTITY_ADMIN = "Entity Admin";
     string internal constant ROLE_ENTITY_MANAGER = "Entity Manager";
-    string internal constant ROLE_BROKER = "Broker";
-    string internal constant ROLE_INSURED_PARTY = "Insured";
     string internal constant ROLE_UNDERWRITER = "Underwriter";
-    string internal constant ROLE_CAPITAL_PROVIDER = "Capital Provider";
     string internal constant ROLE_CLAIMS_ADMIN = "Claims Admin";
     string internal constant ROLE_TRADER = "Trader";
     string internal constant ROLE_SEGREGATED_ACCOUNT = "Segregated Account";

--- a/src/diamonds/nayms/libs/LibConstants.sol
+++ b/src/diamonds/nayms/libs/LibConstants.sol
@@ -21,6 +21,8 @@ library LibConstants {
     string internal constant ROLE_SYSTEM_MANAGER = "System Manager"; // Segregated account manager
     string internal constant ROLE_INTERNAL_UNDERWRITER = "Internal Underwriter";
 
+    string internal constant ROLE_ACCOUNT_MANAGER = "Account Manager";
+
     string internal constant ROLE_SPONSOR = "Sponsor";
     string internal constant ROLE_CAPITAL_PROVIDER = "Capital Provider";
     string internal constant ROLE_INSURED_PARTY = "Insured";
@@ -46,6 +48,7 @@ library LibConstants {
     string internal constant GROUP_SYSTEM_MANAGERS = "System Managers";
     string internal constant GROUP_INTERNAL_UNDERWRITERS = "Internal Underwriters";
 
+    string internal constant GROUP_ACCOUNT_MANAGERS = "Account Managers";
     string internal constant GROUP_TENANTS = "Tenants";
 
     string internal constant GROUP_START_TOKEN_SALE = "G start token sale";

--- a/src/diamonds/nayms/libs/LibConstants.sol
+++ b/src/diamonds/nayms/libs/LibConstants.sol
@@ -18,29 +18,44 @@ library LibConstants {
     /// Roles
 
     string internal constant ROLE_SYSTEM_ADMIN = "System Admin";
+    string internal constant ROLE_SYSTEM_MANAGER = "System Manager"; // Segregated account manager
     string internal constant ROLE_INTERNAL_UNDERWRITER = "Internal Underwriter";
 
-    string internal constant ROLE_ACCOUNT_MANAGER = "Account Manager";
     string internal constant ROLE_SPONSOR = "Sponsor";
     string internal constant ROLE_CAPITAL_PROVIDER = "Capital Provider";
     string internal constant ROLE_INSURED_PARTY = "Insured";
     string internal constant ROLE_BROKER = "Broker";
-    string internal constant ROLE_CONSULTANT = "Consultant";
+    string internal constant ROLE_CONSULTANT = "Consultant"; // note NEW name for ROLE_SERVICE_PROVIDER
+    string internal constant ROLE_SERVICE_PROVIDER = "Service Provider"; // todo deprecate this
 
-    string internal constant ROLE_COMPTROLLER = "Comptroller";
+    string internal constant ROLE_COMPTROLLER_COMBINED = "Comptroller Combined";
+    string internal constant ROLE_COMPTROLLER_WITHDRAW = "Comptroller Withdraw";
+    string internal constant ROLE_COMPTROLLER_CLAIM = "Comptroller Claim";
+    string internal constant ROLE_COMPTROLLER_DIVIDEND = "Comptroller Dividend";
 
-    string internal constant ROLE_SYSTEM_MANAGER = "System Manager";
     string internal constant ROLE_ENTITY_ADMIN = "Entity Admin";
     string internal constant ROLE_ENTITY_MANAGER = "Entity Manager";
     string internal constant ROLE_UNDERWRITER = "Underwriter";
     string internal constant ROLE_CLAIMS_ADMIN = "Claims Admin";
     string internal constant ROLE_TRADER = "Trader";
     string internal constant ROLE_SEGREGATED_ACCOUNT = "Segregated Account";
-    string internal constant ROLE_SERVICE_PROVIDER = "Service Provider";
 
-    //Groups
+    /// Groups
+
     string internal constant GROUP_SYSTEM_ADMINS = "System Admins";
     string internal constant GROUP_SYSTEM_MANAGERS = "System Managers";
+    string internal constant GROUP_INTERNAL_UNDERWRITERS = "Internal Underwriters";
+
+    string internal constant GROUP_TENANTS = "Tenants";
+
+    string internal constant GROUP_START_TOKEN_SALE = "G start token sale";
+    string internal constant GROUP_PLACE_LIMIT_ORDERS = "G place limit orders";
+    string internal constant GROUP_CANCEL_LIMIT_ORDERS = "G cancel limit orders";
+    string internal constant GROUP_WITHDRAW_FUNDS = "G withdraw funds";
+    string internal constant GROUP_PAY_CLAIMS = "G pay claims";
+    string internal constant GROUP_PAY_DISTRIBUTIONS = "G pay dists";
+    string internal constant GROUP_POLICY_HANDLERS = "Policy Handlers";
+
     string internal constant GROUP_ENTITY_ADMINS = "Entity Admins";
     string internal constant GROUP_ENTITY_MANAGERS = "Entity Managers";
     string internal constant GROUP_APPROVED_USERS = "Approved Users";
@@ -52,7 +67,6 @@ library LibConstants {
     string internal constant GROUP_TRADERS = "Traders";
     string internal constant GROUP_SEGREGATED_ACCOUNTS = "Segregated Accounts";
     string internal constant GROUP_SERVICE_PROVIDERS = "Service Providers";
-    string internal constant GROUP_POLICY_HANDLERS = "Policy Handlers";
 
     /*///////////////////////////////////////////////////////////////////////////
                         Market and Premium Fee Schedules

--- a/src/diamonds/nayms/libs/LibEntity.sol
+++ b/src/diamonds/nayms/libs/LibEntity.sol
@@ -223,7 +223,7 @@ library LibEntity {
 
     function _createEntity(
         bytes32 _entityId,
-        bytes32 _entityAdmin,
+        bytes32 _accountAdmin,
         Entity calldata _entity,
         bytes32 _dataHash
     ) internal {
@@ -235,17 +235,17 @@ library LibEntity {
         validateEntity(_entity);
 
         LibObject._createObject(_entityId, _dataHash);
-        LibObject._setParent(_entityAdmin, _entityId);
+        LibObject._setParent(_accountAdmin, _entityId);
         s.existingEntities[_entityId] = true;
 
-        LibACL._assignRole(_entityAdmin, _entityId, LibHelpers._stringToBytes32(LibConstants.ROLE_ENTITY_ADMIN));
+        LibACL._assignRole(_accountAdmin, _entityId, LibHelpers._stringToBytes32(LibConstants.ROLE_ACCOUNT_MANAGER));
 
         // An entity starts without any capacity being utilized
         require(_entity.utilizedCapacity == 0, "utilized capacity starts at 0");
 
         s.entities[_entityId] = _entity;
 
-        emit EntityCreated(_entityId, _entityAdmin);
+        emit EntityCreated(_entityId, _accountAdmin);
     }
 
     /// @dev This currently updates a non cell type entity and a cell type entity, but

--- a/src/diamonds/nayms/libs/LibEntity.sol
+++ b/src/diamonds/nayms/libs/LibEntity.sol
@@ -238,7 +238,7 @@ library LibEntity {
         LibObject._setParent(_accountAdmin, _entityId);
         s.existingEntities[_entityId] = true;
 
-        LibACL._assignRole(_accountAdmin, _entityId, LibHelpers._stringToBytes32(LibConstants.ROLE_ACCOUNT_MANAGER));
+        LibACL._assignRole(_accountAdmin, _entityId, LibHelpers._stringToBytes32(LibConstants.ROLE_ENTITY_ADMIN));
 
         // An entity starts without any capacity being utilized
         require(_entity.utilizedCapacity == 0, "utilized capacity starts at 0");

--- a/src/diamonds/shared/libs/LibDiamond.sol
+++ b/src/diamonds/shared/libs/LibDiamond.sol
@@ -132,7 +132,7 @@ library LibDiamond {
         functionSelectors[0] = IERC173.transferOwnership.selector;
         functionSelectors[1] = IERC173.owner.selector;
         cut[2] = IDiamondCut.FacetCut({ facetAddress: _ownershipFacet, action: IDiamondCut.FacetCutAction.Add, functionSelectors: functionSelectors });
-        functionSelectors = new bytes4[](10);
+        functionSelectors = new bytes4[](12);
         functionSelectors[0] = IACLFacet.assignRole.selector;
         functionSelectors[1] = IACLFacet.unassignRole.selector;
         functionSelectors[2] = IACLFacet.isInGroup.selector;
@@ -143,6 +143,8 @@ library LibDiamond {
         functionSelectors[7] = IACLFacet.canGroupAssignRole.selector;
         functionSelectors[8] = IACLFacet.updateRoleAssigner.selector;
         functionSelectors[9] = IACLFacet.updateRoleGroup.selector;
+        functionSelectors[10] = IACLFacet.canAssignRole.selector;
+        functionSelectors[11] = IACLFacet.hasGroupPrivilege.selector;
         cut[3] = IDiamondCut.FacetCut({ facetAddress: _aclFacet, action: IDiamondCut.FacetCutAction.Add, functionSelectors: functionSelectors });
         functionSelectors = new bytes4[](6);
         functionSelectors[0] = IGovernanceFacet.isDiamondInitialized.selector;

--- a/src/diamonds/shared/libs/LibDiamond.sol
+++ b/src/diamonds/shared/libs/LibDiamond.sol
@@ -132,7 +132,7 @@ library LibDiamond {
         functionSelectors[0] = IERC173.transferOwnership.selector;
         functionSelectors[1] = IERC173.owner.selector;
         cut[2] = IDiamondCut.FacetCut({ facetAddress: _ownershipFacet, action: IDiamondCut.FacetCutAction.Add, functionSelectors: functionSelectors });
-        functionSelectors = new bytes4[](12);
+        functionSelectors = new bytes4[](11);
         functionSelectors[0] = IACLFacet.assignRole.selector;
         functionSelectors[1] = IACLFacet.unassignRole.selector;
         functionSelectors[2] = IACLFacet.isInGroup.selector;
@@ -143,8 +143,7 @@ library LibDiamond {
         functionSelectors[7] = IACLFacet.canGroupAssignRole.selector;
         functionSelectors[8] = IACLFacet.updateRoleAssigner.selector;
         functionSelectors[9] = IACLFacet.updateRoleGroup.selector;
-        functionSelectors[10] = IACLFacet.canAssignRole.selector;
-        functionSelectors[11] = IACLFacet.hasGroupPrivilege.selector;
+        functionSelectors[10] = IACLFacet.hasGroupPrivilege.selector;
         cut[3] = IDiamondCut.FacetCut({ facetAddress: _aclFacet, action: IDiamondCut.FacetCutAction.Add, functionSelectors: functionSelectors });
         functionSelectors = new bytes4[](6);
         functionSelectors[0] = IGovernanceFacet.isDiamondInitialized.selector;

--- a/test/NewFees.t.sol
+++ b/test/NewFees.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.17;
 // solhint-disable no-console
 import { console2 } from "forge-std/console2.sol";
 
-import { D03ProtocolDefaults, LibConstants } from "./defaults/D03ProtocolDefaults.sol";
+import { D03ProtocolDefaults, LC } from "./defaults/D03ProtocolDefaults.sol";
 import { Entity, FeeSchedule, CalculatedFees } from "../src/diamonds/nayms/AppStorage.sol";
 import { SimplePolicy, SimplePolicyInfo, Stakeholders } from "src/diamonds/nayms/interfaces/FreeStructs.sol";
 
@@ -28,7 +28,7 @@ contract NewFeesTest is D03ProtocolDefaults {
         // prettier-ignore
         entityInfo = Entity({ 
             assetId: wethId, 
-            collateralRatio: LibConstants.BP_FACTOR, 
+            collateralRatio: LC.BP_FACTOR, 
             maxCapacity: 1 ether, 
             utilizedCapacity: 0, 
             simplePolicyEnabled: true 
@@ -58,69 +58,69 @@ contract NewFeesTest is D03ProtocolDefaults {
         changePrank(address(0xdead));
 
         vm.expectRevert("not a system admin");
-        nayms.addFeeSchedule(LibConstants.DEFAULT_FEE_SCHEDULE, LibConstants.FEE_TYPE_PREMIUM, defaultFeeRecipients, defaultPremiumFeeBPs);
+        nayms.addFeeSchedule(LC.DEFAULT_FEE_SCHEDULE, LC.FEE_TYPE_PREMIUM, defaultFeeRecipients, defaultPremiumFeeBPs);
     }
 
     function test_removeFeeSchedule() public {
         bytes32 entityId = "anything";
-        FeeSchedule memory defaultFeeSchedule = nayms.getFeeSchedule(entityId, LibConstants.FEE_TYPE_PREMIUM);
+        FeeSchedule memory defaultFeeSchedule = nayms.getFeeSchedule(entityId, LC.FEE_TYPE_PREMIUM);
 
         bytes32[] memory customRecipient = b32Array1("recipient");
         uint16[] memory customFeeBP = u16Array1(42);
 
-        nayms.addFeeSchedule(entityId, LibConstants.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
+        nayms.addFeeSchedule(entityId, LC.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
 
-        FeeSchedule memory storedFeeSchedule = nayms.getFeeSchedule(entityId, LibConstants.FEE_TYPE_PREMIUM);
+        FeeSchedule memory storedFeeSchedule = nayms.getFeeSchedule(entityId, LC.FEE_TYPE_PREMIUM);
         assertEq(storedFeeSchedule.receiver[0], customRecipient[0], "fee receiver is not custom");
         assertEq(storedFeeSchedule.basisPoints[0], customFeeBP[0], "fee basis points not custom");
 
-        nayms.removeFeeSchedule(entityId, LibConstants.FEE_TYPE_PREMIUM);
-        storedFeeSchedule = nayms.getFeeSchedule(entityId, LibConstants.FEE_TYPE_PREMIUM);
+        nayms.removeFeeSchedule(entityId, LC.FEE_TYPE_PREMIUM);
+        storedFeeSchedule = nayms.getFeeSchedule(entityId, LC.FEE_TYPE_PREMIUM);
         assertEq(storedFeeSchedule.receiver[0], defaultFeeSchedule.receiver[0], "fee receiver is not custom");
         assertEq(storedFeeSchedule.basisPoints[0], defaultFeeSchedule.basisPoints[0], "fee basis points not custom");
     }
 
     function test_getPremiumCommissionSchedule_Default() public {
         bytes32 entityWithDefault = keccak256("entity with default fee schedule");
-        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(entityWithDefault, LibConstants.FEE_TYPE_PREMIUM);
+        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(entityWithDefault, LC.FEE_TYPE_PREMIUM);
         assertEq(feeSchedule, premiumFeeScheduleDefault);
     }
 
     function test_getPremiumCommissionSchedule_Custom() public {
         bytes32 entityWithCustom = keccak256("entity with CUSTOM fee schedule");
-        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(entityWithCustom, LibConstants.FEE_TYPE_PREMIUM);
+        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(entityWithCustom, LC.FEE_TYPE_PREMIUM);
 
         assertEq(feeSchedule, premiumFeeScheduleDefault);
 
         bytes32[] memory customRecipient = b32Array1(NAYMS_LTD_IDENTIFIER);
         uint16[] memory customFeeBP = u16Array1(301);
 
-        nayms.addFeeSchedule(entityWithCustom, LibConstants.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
+        nayms.addFeeSchedule(entityWithCustom, LC.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
 
         FeeSchedule memory customFeeSchedule = feeSched(customRecipient, customFeeBP);
-        FeeSchedule memory storedFeeSchedule = nayms.getFeeSchedule(entityWithCustom, LibConstants.FEE_TYPE_PREMIUM);
+        FeeSchedule memory storedFeeSchedule = nayms.getFeeSchedule(entityWithCustom, LC.FEE_TYPE_PREMIUM);
         assertEq(storedFeeSchedule, customFeeSchedule);
     }
 
     function test_getTradingCommissionSchedule_Default() public {
         bytes32 entityWithDefault = keccak256("entity with default");
-        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(entityWithDefault, LibConstants.FEE_TYPE_TRADING);
+        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(entityWithDefault, LC.FEE_TYPE_TRADING);
         assertEq(feeSchedule, tradingFeeScheduleDefault);
     }
 
     function test_getTradingCommissionSchedule_Custom() public {
         bytes32 entityWithCustom = keccak256("entity with CUSTOM");
-        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(entityWithCustom, LibConstants.FEE_TYPE_TRADING);
+        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(entityWithCustom, LC.FEE_TYPE_TRADING);
 
         assertEq(feeSchedule, tradingFeeScheduleDefault);
 
         bytes32[] memory customRecipient = b32Array1(NAYMS_LTD_IDENTIFIER);
         uint16[] memory customFeeBP = u16Array1(31);
 
-        nayms.addFeeSchedule(entityWithCustom, LibConstants.FEE_TYPE_TRADING, customRecipient, customFeeBP);
+        nayms.addFeeSchedule(entityWithCustom, LC.FEE_TYPE_TRADING, customRecipient, customFeeBP);
 
         FeeSchedule memory customFeeSchedule = feeSched(customRecipient, customFeeBP);
-        FeeSchedule memory storedFeeSchedule = nayms.getFeeSchedule(entityWithCustom, LibConstants.FEE_TYPE_TRADING);
+        FeeSchedule memory storedFeeSchedule = nayms.getFeeSchedule(entityWithCustom, LC.FEE_TYPE_TRADING);
 
         assertEq(storedFeeSchedule, customFeeSchedule);
     }
@@ -130,12 +130,12 @@ contract NewFeesTest is D03ProtocolDefaults {
         uint16[] memory customFeeBP = u16Array1(900);
         FeeSchedule memory customFeeSchedule = feeSched(customRecipient, customFeeBP);
 
-        nayms.addFeeSchedule(acc2.entityId, LibConstants.FEE_TYPE_INITIAL_SALE, customRecipient, customFeeBP);
+        nayms.addFeeSchedule(acc2.entityId, LC.FEE_TYPE_INITIAL_SALE, customRecipient, customFeeBP);
 
         uint256 _buyAmount = 10 ether;
         (uint256 totalFees_, uint256 totalBP_) = nayms.calculateTradingFees(acc2.entityId, wethId, acc1.entityId, _buyAmount);
 
-        uint256 expectedValue = (_buyAmount * customFeeSchedule.basisPoints[0]) / LibConstants.BP_FACTOR;
+        uint256 expectedValue = (_buyAmount * customFeeSchedule.basisPoints[0]) / LC.BP_FACTOR;
 
         assertEq(totalFees_, expectedValue, "total fees is incorrect");
         assertEq(totalBP_, customFeeSchedule.basisPoints[0], "total bp is incorrect");
@@ -145,8 +145,8 @@ contract NewFeesTest is D03ProtocolDefaults {
         uint256 _buyAmount = 10 ether;
         (uint256 totalFees_, uint256 totalBP_) = nayms.calculateTradingFees(acc2.entityId, acc1.entityId, wethId, _buyAmount);
 
-        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(acc2.entityId, LibConstants.FEE_TYPE_TRADING);
-        uint256 expectedValue = (_buyAmount * feeSchedule.basisPoints[0]) / LibConstants.BP_FACTOR;
+        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(acc2.entityId, LC.FEE_TYPE_TRADING);
+        uint256 expectedValue = (_buyAmount * feeSchedule.basisPoints[0]) / LC.BP_FACTOR;
 
         assertEq(totalFees_, expectedValue, "total fees is incorrect");
         assertEq(totalBP_, feeSchedule.basisPoints[0], "total bp is incorrect");
@@ -157,12 +157,12 @@ contract NewFeesTest is D03ProtocolDefaults {
         uint16[] memory customFeeBP = u16Array3(150, 75, 75);
         FeeSchedule memory customFeeSchedule = feeSched(customRecipient, customFeeBP);
 
-        nayms.addFeeSchedule(acc2.entityId, LibConstants.FEE_TYPE_INITIAL_SALE, customRecipient, customFeeBP);
+        nayms.addFeeSchedule(acc2.entityId, LC.FEE_TYPE_INITIAL_SALE, customRecipient, customFeeBP);
 
         uint256 _buyAmount = 1e18;
         (uint256 totalFees_, uint256 totalBP_) = nayms.calculateTradingFees(acc2.entityId, wethId, acc1.entityId, _buyAmount);
 
-        uint256 expectedValue = (_buyAmount * (customFeeSchedule.basisPoints[0] + customFeeSchedule.basisPoints[1] + customFeeSchedule.basisPoints[2])) / LibConstants.BP_FACTOR;
+        uint256 expectedValue = (_buyAmount * (customFeeSchedule.basisPoints[0] + customFeeSchedule.basisPoints[1] + customFeeSchedule.basisPoints[2])) / LC.BP_FACTOR;
 
         assertEq(totalFees_, expectedValue, "total fees is incorrect");
         assertEq(totalBP_, (customFeeSchedule.basisPoints[0] + customFeeSchedule.basisPoints[1] + customFeeSchedule.basisPoints[2]), "total bp is incorrect");
@@ -172,38 +172,38 @@ contract NewFeesTest is D03ProtocolDefaults {
         customFeeBP = u16Array1(300);
         customFeeSchedule = feeSched(customRecipient, customFeeBP);
 
-        nayms.addFeeSchedule(acc2.entityId, LibConstants.FEE_TYPE_INITIAL_SALE, customRecipient, customFeeBP);
+        nayms.addFeeSchedule(acc2.entityId, LC.FEE_TYPE_INITIAL_SALE, customRecipient, customFeeBP);
 
         (totalFees_, totalBP_) = nayms.calculateTradingFees(acc2.entityId, wethId, acc1.entityId, _buyAmount);
 
-        expectedValue = (_buyAmount * customFeeSchedule.basisPoints[0]) / LibConstants.BP_FACTOR;
+        expectedValue = (_buyAmount * customFeeSchedule.basisPoints[0]) / LC.BP_FACTOR;
 
         assertEq(totalFees_, expectedValue, "total fees is incorrect");
         assertEq(totalBP_, customFeeSchedule.basisPoints[0], "total bp is incorrect");
 
         // Clear out custom fee schedule
-        nayms.removeFeeSchedule(acc2.entityId, LibConstants.FEE_TYPE_INITIAL_SALE);
+        nayms.removeFeeSchedule(acc2.entityId, LC.FEE_TYPE_INITIAL_SALE);
 
         // Should be back to default market fee schedule
         (totalFees_, totalBP_) = nayms.calculateTradingFees(acc2.entityId, wethId, acc1.entityId, _buyAmount);
 
-        FeeSchedule memory storedFeeSchedule = nayms.getFeeSchedule(acc2.entityId, LibConstants.FEE_TYPE_INITIAL_SALE);
+        FeeSchedule memory storedFeeSchedule = nayms.getFeeSchedule(acc2.entityId, LC.FEE_TYPE_INITIAL_SALE);
         uint256 totalBP;
         for (uint256 i; i < storedFeeSchedule.receiver.length; ++i) {
             totalBP += storedFeeSchedule.basisPoints[i];
         }
 
-        expectedValue = (_buyAmount * totalBP) / LibConstants.BP_FACTOR;
+        expectedValue = (_buyAmount * totalBP) / LC.BP_FACTOR;
 
         assertEq(totalFees_, expectedValue, "total fees is incorrect");
         assertEq(totalBP_, totalBP, "total bp is incorrect");
     }
 
     function test_calculatePremiumFees_SingleReceiver(uint16 _fee) public {
-        vm.assume(0 <= _fee && _fee <= LibConstants.BP_FACTOR / 2);
+        vm.assume(0 <= _fee && _fee <= LC.BP_FACTOR / 2);
         bytes32[] memory customRecipient = b32Array1(NAYMS_LTD_IDENTIFIER);
         uint16[] memory customFeeBP = u16Array1(_fee);
-        nayms.addFeeSchedule(acc1.entityId, LibConstants.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
+        nayms.addFeeSchedule(acc1.entityId, LC.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
 
         fundEntityWeth(acc1, 1 ether);
 
@@ -215,7 +215,7 @@ contract NewFeesTest is D03ProtocolDefaults {
         CalculatedFees memory cf = nayms.calculatePremiumFees(policyId, premiumPaid);
 
         uint256 expectedTotalPremiumFeeBP = totalPremiumFeeBP(simplePolicy, customFeeBP);
-        uint256 expectedPremiumAmount = (premiumPaid * expectedTotalPremiumFeeBP) / LibConstants.BP_FACTOR;
+        uint256 expectedPremiumAmount = (premiumPaid * expectedTotalPremiumFeeBP) / LC.BP_FACTOR;
 
         assertEq(cf.totalFees, expectedPremiumAmount, "total fees is incorrect");
         assertEq(cf.totalBP, expectedTotalPremiumFeeBP, "total bp is incorrect");
@@ -227,13 +227,13 @@ contract NewFeesTest is D03ProtocolDefaults {
         uint16 _fee2,
         uint16 _fee3
     ) public {
-        vm.assume(0 <= _fee && _fee <= LibConstants.BP_FACTOR / 2);
-        vm.assume(_fee1 < LibConstants.BP_FACTOR / 2 && _fee2 < LibConstants.BP_FACTOR / 2 && _fee3 < LibConstants.BP_FACTOR / 2);
-        vm.assume(0 <= (_fee1 + _fee2 + _fee3) && (_fee1 + _fee2 + _fee3) <= LibConstants.BP_FACTOR / 2);
+        vm.assume(0 <= _fee && _fee <= LC.BP_FACTOR / 2);
+        vm.assume(_fee1 < LC.BP_FACTOR / 2 && _fee2 < LC.BP_FACTOR / 2 && _fee3 < LC.BP_FACTOR / 2);
+        vm.assume(0 <= (_fee1 + _fee2 + _fee3) && (_fee1 + _fee2 + _fee3) <= LC.BP_FACTOR / 2);
 
         bytes32[] memory customRecipient = b32Array3(NAYMS_LTD_IDENTIFIER, NDF_IDENTIFIER, STM_IDENTIFIER);
         uint16[] memory customFeeBP = u16Array3(_fee1, _fee2, _fee3);
-        nayms.addFeeSchedule(acc1.entityId, LibConstants.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
+        nayms.addFeeSchedule(acc1.entityId, LC.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
 
         fundEntityWeth(acc1, 1 ether);
 
@@ -245,7 +245,7 @@ contract NewFeesTest is D03ProtocolDefaults {
         CalculatedFees memory cf = nayms.calculatePremiumFees(policyId, _premiumPaid);
 
         uint256 expectedTotalPremiumFeeBP = totalPremiumFeeBP(simplePolicy, customFeeBP);
-        uint256 expectedValue = (_premiumPaid * expectedTotalPremiumFeeBP) / LibConstants.BP_FACTOR;
+        uint256 expectedValue = (_premiumPaid * expectedTotalPremiumFeeBP) / LC.BP_FACTOR;
 
         assertEq(cf.totalFees, expectedValue, "total fees is incorrect");
         assertEq(cf.totalBP, expectedTotalPremiumFeeBP, "total bp is incorrect");
@@ -253,19 +253,19 @@ contract NewFeesTest is D03ProtocolDefaults {
         // Update the same fee schedule: 3 receivers to 1 receiver
         customRecipient = b32Array1(NAYMS_LTD_IDENTIFIER);
         customFeeBP = u16Array1(_fee);
-        nayms.addFeeSchedule(acc1.entityId, LibConstants.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
+        nayms.addFeeSchedule(acc1.entityId, LC.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
 
         cf = nayms.calculatePremiumFees(policyId, _premiumPaid);
 
         expectedTotalPremiumFeeBP = totalPremiumFeeBP(simplePolicy, customFeeBP);
-        expectedValue = (_premiumPaid * expectedTotalPremiumFeeBP) / LibConstants.BP_FACTOR;
+        expectedValue = (_premiumPaid * expectedTotalPremiumFeeBP) / LC.BP_FACTOR;
 
         assertEq(cf.totalFees, expectedValue, "total fees is incorrect");
         assertEq(cf.totalBP, expectedTotalPremiumFeeBP, "total bp is incorrect");
     }
 
     function test_zeroPremiumFees() public {
-        nayms.addFeeSchedule(acc1.entityId, LibConstants.FEE_TYPE_PREMIUM, b32Array1(NAYMS_LTD_IDENTIFIER), u16Array1(0));
+        nayms.addFeeSchedule(acc1.entityId, LC.FEE_TYPE_PREMIUM, b32Array1(NAYMS_LTD_IDENTIFIER), u16Array1(0));
 
         fundEntityWeth(acc1, 1 ether);
 
@@ -277,11 +277,11 @@ contract NewFeesTest is D03ProtocolDefaults {
         CalculatedFees memory cf = nayms.calculatePremiumFees(policyId, premiumAmount);
 
         uint256 expectedTotalPremiumFeeBP = totalPremiumFeeBP(simplePolicy, u16Array1(0));
-        uint256 expectedValue = (premiumAmount * expectedTotalPremiumFeeBP) / LibConstants.BP_FACTOR;
+        uint256 expectedValue = (premiumAmount * expectedTotalPremiumFeeBP) / LC.BP_FACTOR;
 
         assertEq(cf.totalFees, expectedValue, "Invalid total fees!");
 
-        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(acc1.entityId, LibConstants.FEE_TYPE_PREMIUM);
+        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(acc1.entityId, LC.FEE_TYPE_PREMIUM);
         assertEq(feeSchedule.basisPoints.length, 1);
         assertEq(feeSchedule.basisPoints[0], 0);
     }
@@ -323,7 +323,7 @@ contract NewFeesTest is D03ProtocolDefaults {
 
         assertEq(defaultFeeScheduleTotalBP + makerBP, totalBP_, "total BP is incorrect");
 
-        assertEq(nayms.internalBalanceOf(acc1.entityId, wethId), buyAmount + ((buyAmount * makerBP) / LibConstants.BP_FACTOR), "makers's weth balance is incorrect");
+        assertEq(nayms.internalBalanceOf(acc1.entityId, wethId), buyAmount + ((buyAmount * makerBP) / LC.BP_FACTOR), "makers's weth balance is incorrect");
         assertEq(nayms.internalBalanceOf(acc2.entityId, wethId), (sellAmount - buyAmount - totalFees_), "taker's weth balance is incorrect");
     }
 
@@ -346,13 +346,13 @@ contract NewFeesTest is D03ProtocolDefaults {
 
         nayms.executeLimitOffer(wethId, buyAmount, acc1.entityId, buyAmount);
 
-        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(acc1.entityId, LibConstants.FEE_TYPE_INITIAL_SALE);
+        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(acc1.entityId, LC.FEE_TYPE_INITIAL_SALE);
 
         assertEq(nayms.internalBalanceOf(acc1.entityId, wethId), buyAmount, "maker's weth balance is incorrect");
         assertEq(nayms.internalBalanceOf(acc2.entityId, acc1.entityId), buyAmount, "taker's par token (acc1.entityId) balance is incorrect");
 
         // For FIRST_OFFER, the commission should be paid by the buyer of the par tokens
-        uint256 commission = (buyAmount * feeSchedule.basisPoints[0]) / LibConstants.BP_FACTOR;
+        uint256 commission = (buyAmount * feeSchedule.basisPoints[0]) / LC.BP_FACTOR;
         assertEq(nayms.internalBalanceOf(acc2.entityId, wethId), buyAmount - commission, "entity's weth balance is incorrect");
         assertEq(nayms.internalBalanceOf(NAYMS_LTD_IDENTIFIER, wethId), commission, "nayms ltd weth balance is incorrect");
     }
@@ -365,13 +365,13 @@ contract NewFeesTest is D03ProtocolDefaults {
         changePrank(systemAdmin);
         nayms.startTokenSale(acc1.entityId, 1 ether, 1 ether);
 
-        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(acc1.entityId, LibConstants.FEE_TYPE_INITIAL_SALE);
+        FeeSchedule memory feeSchedule = nayms.getFeeSchedule(acc1.entityId, LC.FEE_TYPE_INITIAL_SALE);
 
         assertEq(nayms.internalBalanceOf(acc1.entityId, wethId), 0.5 ether, "par token seller's weth balance is incorrect");
         assertEq(nayms.internalBalanceOf(acc2.entityId, acc1.entityId), 0.5 ether, "par token buyer's par token (acc1.entityId) balance is incorrect");
 
         // For FIRST_OFFER, the commission should be paid by the buyer of the par tokens
-        uint256 commission = (0.5 ether * feeSchedule.basisPoints[0]) / LibConstants.BP_FACTOR;
+        uint256 commission = (0.5 ether * feeSchedule.basisPoints[0]) / LC.BP_FACTOR;
         assertEq(nayms.internalBalanceOf(acc2.entityId, wethId), 0.5 ether - commission, "par token buyer's weth balance is incorrect");
         assertEq(nayms.internalBalanceOf(NAYMS_LTD_IDENTIFIER, wethId), commission, "nayms ltd weth balance is incorrect");
     }
@@ -382,7 +382,7 @@ contract NewFeesTest is D03ProtocolDefaults {
         uint256 singleSaleAmount = 1 ether;
 
         uint256 defaultTotalBP = 30;
-        fundEntityWeth(acc2, totalAmount + ((totalAmount * defaultTotalBP) / LibConstants.BP_FACTOR));
+        fundEntityWeth(acc2, totalAmount + ((totalAmount * defaultTotalBP) / LC.BP_FACTOR));
 
         changePrank(acc2.addr);
         nayms.executeLimitOffer(wethId, singleOrderAmount, acc1.entityId, singleOrderAmount);
@@ -394,7 +394,7 @@ contract NewFeesTest is D03ProtocolDefaults {
         nayms.executeLimitOffer(wethId, singleOrderAmount, acc1.entityId, singleOrderAmount);
 
         changePrank(systemAdmin);
-        nayms.assignRole(acc3.id, systemContext, LibConstants.ROLE_SYSTEM_MANAGER);
+        nayms.assignRole(acc3.id, systemContext, LC.ROLE_SYSTEM_MANAGER);
 
         // Switch up who starts the token sale
         changePrank(acc3.addr);
@@ -426,7 +426,7 @@ contract NewFeesTest is D03ProtocolDefaults {
         nayms.startTokenSale(acc1.entityId, saleAmount, saleAmount);
         assertEq(nayms.internalBalanceOf(acc1.entityId, acc1.entityId), saleAmount, "entity selling par balance is incorrect");
 
-        nayms.addFeeSchedule(acc2.entityId, LibConstants.FEE_TYPE_INITIAL_SALE, b32Array1(NAYMS_LTD_IDENTIFIER), u16Array1(0));
+        nayms.addFeeSchedule(acc2.entityId, LC.FEE_TYPE_INITIAL_SALE, b32Array1(NAYMS_LTD_IDENTIFIER), u16Array1(0));
 
         fundEntityWeth(acc2, saleAmount);
 

--- a/test/NewFees.t.sol
+++ b/test/NewFees.t.sol
@@ -34,7 +34,7 @@ contract NewFeesTest is D03ProtocolDefaults {
             simplePolicyEnabled: true 
         });
 
-        changePrank(systemAdmin);
+        changePrank(sm.addr);
 
         nayms.createEntity(acc1.entityId, acc1.id, entityInfo, testHash);
         nayms.createEntity(acc2.entityId, acc2.id, entityInfo, testHash);
@@ -43,6 +43,8 @@ contract NewFeesTest is D03ProtocolDefaults {
         nayms.enableEntityTokenization(acc1.entityId, "ESPT", "Entity Selling Par Tokens");
 
         (stakeholders, simplePolicy) = initPolicy(testHash);
+
+        changePrank(sa.addr);
     }
 
     function fundEntityWeth(NaymsAccount memory acc, uint256 amount) private {
@@ -207,7 +209,7 @@ contract NewFeesTest is D03ProtocolDefaults {
 
         fundEntityWeth(acc1, 1 ether);
 
-        changePrank(systemAdmin);
+        changePrank(su.addr);
         bytes32 policyId = "policy1";
         nayms.createSimplePolicy(policyId, acc1.entityId, stakeholders, simplePolicy, testHash);
 
@@ -237,7 +239,7 @@ contract NewFeesTest is D03ProtocolDefaults {
 
         fundEntityWeth(acc1, 1 ether);
 
-        changePrank(systemAdmin);
+        changePrank(su.addr);
         bytes32 policyId = "policy1";
         nayms.createSimplePolicy(policyId, acc1.entityId, stakeholders, simplePolicy, testHash);
 
@@ -249,6 +251,8 @@ contract NewFeesTest is D03ProtocolDefaults {
 
         assertEq(cf.totalFees, expectedValue, "total fees is incorrect");
         assertEq(cf.totalBP, expectedTotalPremiumFeeBP, "total bp is incorrect");
+
+        changePrank(systemAdmin);
 
         // Update the same fee schedule: 3 receivers to 1 receiver
         customRecipient = b32Array1(NAYMS_LTD_IDENTIFIER);
@@ -269,7 +273,7 @@ contract NewFeesTest is D03ProtocolDefaults {
 
         fundEntityWeth(acc1, 1 ether);
 
-        changePrank(systemAdmin);
+        changePrank(su.addr);
         bytes32 policyId = "policy1";
         nayms.createSimplePolicy(policyId, acc1.entityId, stakeholders, simplePolicy, testHash);
 
@@ -313,6 +317,8 @@ contract NewFeesTest is D03ProtocolDefaults {
         uint256 sellAmount = 1 ether;
         uint256 buyAmount = 0.5 ether;
 
+        changePrank(sm.addr);
+        nayms.assignRole(acc2.id, systemContext, LC.ROLE_ENTITY_CP);
         nayms.startTokenSale(acc1.entityId, sellAmount, sellAmount);
 
         fundEntityWeth(acc2, sellAmount);
@@ -334,6 +340,8 @@ contract NewFeesTest is D03ProtocolDefaults {
         uint256 saleAmount = 1 ether;
         uint256 buyAmount = 0.5 ether;
 
+        changePrank(sm.addr);
+        nayms.assignRole(acc2.id, systemContext, LC.ROLE_ENTITY_CP);
         nayms.startTokenSale(acc1.entityId, saleAmount, saleAmount);
 
         assertEq(nayms.internalBalanceOf(acc1.entityId, acc1.entityId), saleAmount, "maker balance is incorrect");
@@ -358,11 +366,14 @@ contract NewFeesTest is D03ProtocolDefaults {
     }
 
     function test_startTokenSale_PlaceOrderBeforeStartTokenSale() public {
+        changePrank(sm.addr);
+        nayms.assignRole(acc2.id, systemContext, LC.ROLE_ENTITY_CP);
+
         fundEntityWeth(acc2, 1 ether);
 
         nayms.executeLimitOffer(wethId, 0.5 ether, acc1.entityId, 0.5 ether);
 
-        changePrank(systemAdmin);
+        changePrank(sm.addr);
         nayms.startTokenSale(acc1.entityId, 1 ether, 1 ether);
 
         FeeSchedule memory feeSchedule = nayms.getFeeSchedule(acc1.entityId, LC.FEE_TYPE_INITIAL_SALE);
@@ -382,13 +393,16 @@ contract NewFeesTest is D03ProtocolDefaults {
         uint256 singleSaleAmount = 1 ether;
 
         uint256 defaultTotalBP = 30;
+        changePrank(sm.addr);
+        nayms.assignRole(acc2.id, systemContext, LC.ROLE_ENTITY_CP);
+
         fundEntityWeth(acc2, totalAmount + ((totalAmount * defaultTotalBP) / LC.BP_FACTOR));
 
         changePrank(acc2.addr);
         nayms.executeLimitOffer(wethId, singleOrderAmount, acc1.entityId, singleOrderAmount);
         nayms.executeLimitOffer(wethId, singleOrderAmount, acc1.entityId, singleOrderAmount);
 
-        changePrank(systemAdmin);
+        changePrank(sm.addr);
         nayms.startTokenSale(acc1.entityId, singleSaleAmount, singleSaleAmount);
         changePrank(acc2.addr);
         nayms.executeLimitOffer(wethId, singleOrderAmount, acc1.entityId, singleOrderAmount);
@@ -422,10 +436,14 @@ contract NewFeesTest is D03ProtocolDefaults {
         // acc1 is the par token seller
         // acc2 is the par token buyer
 
+        changePrank(sm.addr);
+        nayms.assignRole(acc2.id, systemContext, LC.ROLE_ENTITY_CP);
+
         uint256 saleAmount = 1 ether;
         nayms.startTokenSale(acc1.entityId, saleAmount, saleAmount);
         assertEq(nayms.internalBalanceOf(acc1.entityId, acc1.entityId), saleAmount, "entity selling par balance is incorrect");
 
+        changePrank(sa.addr);
         nayms.addFeeSchedule(acc2.entityId, LC.FEE_TYPE_INITIAL_SALE, b32Array1(NAYMS_LTD_IDENTIFIER), u16Array1(0));
 
         fundEntityWeth(acc2, saleAmount);

--- a/test/T02ACL.t.sol
+++ b/test/T02ACL.t.sol
@@ -65,7 +65,7 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
         bytes32 context = LibHelpers._stringToBytes32("test");
 
         // assign the role signer1
-        assertTrue(nayms.canAssignRole(systemAdminId, signer1Id, context, role));
+        assertTrue(nayms.canAssign(systemAdminId, signer1Id, context, role));
         nayms.assignRole(signer1Id, context, role);
 
         // the group that the signer1 is in is now the approved users group

--- a/test/T02ACL.t.sol
+++ b/test/T02ACL.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 import { console2 } from "forge-std/console2.sol";
-import { D03ProtocolDefaults, LibHelpers, LibConstants } from "./defaults/D03ProtocolDefaults.sol";
+import { D03ProtocolDefaults, LibHelpers, LC } from "./defaults/D03ProtocolDefaults.sol";
 import { MockAccounts } from "test/utils/users/MockAccounts.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { Entity } from "../src/diamonds/nayms/AppStorage.sol";
@@ -21,7 +21,7 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
 
     // the deployer should NOT be a system admin
     function testDeployerIsNotASystemAdmin() public {
-        assertFalse(nayms.isInGroup(account0Id, systemContext, LibConstants.GROUP_SYSTEM_ADMINS));
+        assertFalse(nayms.isInGroup(account0Id, systemContext, LC.GROUP_SYSTEM_ADMINS));
     }
 
     function testUnassignLastSystemAdminFails() public {
@@ -37,11 +37,11 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
         naymsAddress.write_sysAdmins(1);
 
         vm.expectRevert("must have at least one system admin");
-        nayms.assignRole(systemAdminId, systemContext, LibConstants.ROLE_BROKER);
+        nayms.assignRole(systemAdminId, systemContext, LC.ROLE_SYSTEM_MANAGER);
     }
 
     function testUnassignSystemAdmin() public {
-        nayms.assignRole(signer1Id, systemContext, LibConstants.ROLE_SYSTEM_ADMIN);
+        nayms.assignRole(signer1Id, systemContext, LC.ROLE_SYSTEM_ADMIN);
 
         changePrank(signer1);
         nayms.unassignRole(systemAdminId, systemContext);
@@ -49,28 +49,28 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
 
     /// test_canAssign_SystemAdminCanAssignAnyRoleToAnotherObjectInSystemContext
     function testDeployerAssignRoleToAnotherObject() public {
-        string memory role = LibConstants.ROLE_ENTITY_ADMIN;
+        string memory role = LC.ROLE_ENTITY_ADMIN;
 
         // assign the role entity admin to deployer / account0
         assertTrue(nayms.canAssign(systemAdminId, signer1Id, systemContext, role));
         nayms.assignRole(signer1Id, systemContext, role);
 
         // the group that the deployer / account0 is in is now the entity admins group
-        assertTrue(nayms.isInGroup(signer1Id, systemContext, LibConstants.GROUP_ENTITY_ADMINS));
+        assertTrue(nayms.isInGroup(signer1Id, systemContext, LC.GROUP_ENTITY_ADMINS));
     }
 
     /// test_canAssign_SystemAdminCanAssignAnyRoleToAnotherObjectInAnyContext
     function testSystemAdminAssignAnyRoleToAnotherObjectInNewContext() public {
-        string memory role = LibConstants.ROLE_SYSTEM_MANAGER;
+        string memory role = LC.ROLE_SYSTEM_MANAGER;
         bytes32 context = LibHelpers._stringToBytes32("test");
 
         // assign the role signer1
         // changePrank(systemAdmin);
-        assertTrue(nayms.canAssign(systemAdminId, signer1Id, context, role));
+        assertTrue(nayms.canAssignRole(systemAdminId, signer1Id, context, role));
         nayms.assignRole(signer1Id, context, role);
 
         // the group that the signer1 is in is now the approved users group
-        assertTrue(nayms.isInGroup(signer1Id, context, LibConstants.GROUP_SYSTEM_MANAGERS));
+        assertTrue(nayms.isInGroup(signer1Id, context, LC.GROUP_SYSTEM_MANAGERS));
     }
 
     function testDeployerUnassignRoleOnAnotherObject() public {
@@ -80,12 +80,12 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
         // 2. unassign role
         nayms.unassignRole(signer1Id, systemContext);
 
-        assertFalse(nayms.isInGroup(signer1Id, systemContext, LibConstants.GROUP_ENTITY_ADMINS));
+        assertFalse(nayms.isInGroup(signer1Id, systemContext, LC.GROUP_ENTITY_ADMINS));
     }
 
     function testRoleAssignmentEmitsAnEvent() public {
         bytes32 context = LibHelpers._stringToBytes32("test");
-        string memory role = LibConstants.ROLE_ENTITY_ADMIN;
+        string memory role = LC.ROLE_ENTITY_ADMIN;
 
         vm.recordLogs();
 
@@ -104,19 +104,19 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
 
     function testInvalidObjectIdWhenAssignRole() public {
         bytes32 invalidObjectId = bytes32(0);
-        string memory role = LibConstants.ROLE_ENTITY_ADMIN;
+        string memory role = LC.ROLE_ENTITY_ADMIN;
         vm.expectRevert("invalid object ID");
         nayms.assignRole(invalidObjectId, systemContext, role);
     }
 
-    function testAssignInvalidRole() public {
+    function testAssignInvalidGroupPrivilege() public {
         // assign a role to signer1
         vm.expectRevert("not in assigners group");
         nayms.assignRole(signer1Id, systemContext, "random role");
     }
 
     function testNonAssignersCannotAssignRole() public {
-        string memory role = LibConstants.ROLE_ENTITY_ADMIN;
+        string memory role = LC.ROLE_ENTITY_ADMIN;
         bytes32 context = LibHelpers._stringToBytes32("test");
 
         // assign a role to signer1
@@ -130,13 +130,13 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
     }
 
     function testNonAssignersCanAssignRoleIfTheirParentHasAssignerRoleInSystemContext() public {
-        string memory role = LibConstants.ROLE_ENTITY_ADMIN;
+        string memory role = LC.ROLE_ENTITY_ADMIN;
         bytes32 context = LibHelpers._stringToBytes32("test");
 
         // create entity with signer2 as child
         bytes32 entityId1 = createTestEntity(signer2Id);
         // assign entity as system manager
-        nayms.assignRole(entityId1, systemContext, LibConstants.ROLE_SYSTEM_MANAGER);
+        nayms.assignRole(entityId1, systemContext, LC.ROLE_SYSTEM_MANAGER);
 
         // signer2 tries to assign to signer3
         assertTrue(nayms.canAssign(signer2Id, signer3Id, context, role));
@@ -145,25 +145,28 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
     }
 
     function testAssignersCanAssignRole() public {
-        string memory role = LibConstants.ROLE_SYSTEM_MANAGER;
+        string memory role = LC.ROLE_SYSTEM_MANAGER;
         bytes32 context = LibHelpers._stringToBytes32("test");
 
         // give signer3 assigner powers
-        nayms.assignRole(signer3Id, context, LibConstants.ROLE_SYSTEM_MANAGER);
+        nayms.assignRole(signer3Id, context, LC.ROLE_SYSTEM_MANAGER);
 
         // signer3 makes signer2 an approved user
-        assertTrue(nayms.canAssign(signer3Id, signer2Id, context, role));
+        assertFalse(nayms.canAssign(signer3Id, signer2Id, context, role));
+        assertTrue(nayms.canAssign(signer3Id, signer2Id, context, LC.ROLE_ENTITY_BROKER));
         changePrank(signer3);
-        nayms.assignRole(signer2Id, context, role);
+        // nayms.assignRole(signer2Id, context, role);
+        nayms.assignRole(signer2Id, context, LC.ROLE_ENTITY_BROKER);
 
         changePrank(systemAdmin);
-        assertTrue(nayms.isInGroup(signer2Id, context, LibConstants.GROUP_SYSTEM_MANAGERS));
+        assertFalse(nayms.isInGroup(signer2Id, context, LC.GROUP_SYSTEM_MANAGERS));
+        assertTrue(nayms.isInGroup(signer2Id, context, LC.GROUP_PAY_SIMPLE_PREMIUM));
     }
 
     function testNonAssignersCannotUnassignRole() public {
         testAssignersCanAssignRole();
 
-        string memory role = LibConstants.ROLE_ENTITY_ADMIN;
+        string memory role = LC.ROLE_ENTITY_ADMIN;
         bytes32 context = LibHelpers._stringToBytes32("test");
 
         // assign a role to signer1
@@ -184,7 +187,7 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
         // create entity with signer1 as child
         bytes32 entityId1 = createTestEntity(signer1Id);
         // assign entity as system manager
-        nayms.assignRole(entityId1, systemContext, LibConstants.ROLE_SYSTEM_MANAGER);
+        nayms.assignRole(entityId1, systemContext, LC.ROLE_SYSTEM_MANAGER);
 
         // signer1 tries to unassign to signer2
         changePrank(signer1);
@@ -205,11 +208,11 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
         // signer3 can unassign signer2 as approved user
         changePrank(signer3);
         nayms.unassignRole(signer2Id, context);
-        assertFalse(nayms.isInGroup(signer2Id, context, LibConstants.GROUP_SYSTEM_MANAGERS));
+        assertFalse(nayms.isInGroup(signer2Id, context, LC.GROUP_SYSTEM_MANAGERS));
     }
 
     function testRoleUnassignmentEmitsAnEvent() public {
-        string memory role = LibConstants.ROLE_SYSTEM_MANAGER;
+        string memory role = LC.ROLE_SYSTEM_MANAGER;
         bytes32 context = LibHelpers._stringToBytes32("test");
 
         // signer3 makes signer2 an approved user
@@ -232,7 +235,7 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
     }
 
     function testGetRoleInContext() public {
-        string memory role = LibConstants.ROLE_SYSTEM_MANAGER;
+        string memory role = LC.ROLE_SYSTEM_MANAGER;
         bytes32 context = LibHelpers._stringToBytes32("test");
 
         // signer3 assigns signer2 as approved user
@@ -249,8 +252,8 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
     }
 
     function testHavingRoleInSystemContextConfersRoleInAllContexts() public {
-        string memory role = LibConstants.ROLE_SYSTEM_MANAGER;
-        string memory group = LibConstants.GROUP_SYSTEM_MANAGERS;
+        string memory role = LC.ROLE_SYSTEM_MANAGER;
+        string memory group = LC.GROUP_SYSTEM_MANAGERS;
         bytes32 context = LibHelpers._stringToBytes32("test");
 
         // assign role in system context
@@ -267,8 +270,8 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
     }
 
     function testIsParentInGroup() public {
-        string memory role = LibConstants.ROLE_ENTITY_ADMIN;
-        string memory group = LibConstants.GROUP_ENTITY_ADMINS;
+        string memory role = LC.ROLE_ENTITY_ADMIN;
+        string memory group = LC.GROUP_ENTITY_ADMINS;
 
         // create entity with signer2 as child
         bytes32 entityId1 = createTestEntity(signer2Id);
@@ -289,24 +292,24 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
 
     function testUpdateRoleAssigner() public {
         // setup signer1 as broker
-        nayms.assignRole(signer1Id, systemContext, LibConstants.ROLE_BROKER);
+        nayms.assignRole(signer1Id, systemContext, LC.ROLE_BROKER);
         // brokers can't usually assign approved users
-        assertFalse(nayms.canAssign(signer1Id, signer2Id, systemContext, LibConstants.ROLE_ENTITY_ADMIN));
-        assertFalse(nayms.canGroupAssignRole(LibConstants.ROLE_ENTITY_ADMIN, LibConstants.GROUP_BROKERS));
+        assertFalse(nayms.canAssign(signer1Id, signer2Id, systemContext, LC.ROLE_ENTITY_ADMIN));
+        assertFalse(nayms.canGroupAssignRole(LC.ROLE_ENTITY_ADMIN, LC.GROUP_BROKERS));
 
         // now change this
         vm.recordLogs();
 
-        nayms.updateRoleAssigner(LibConstants.ROLE_ENTITY_ADMIN, LibConstants.GROUP_BROKERS);
-        assertTrue(nayms.canAssign(signer1Id, signer2Id, systemContext, LibConstants.ROLE_ENTITY_ADMIN));
-        assertTrue(nayms.canGroupAssignRole(LibConstants.ROLE_ENTITY_ADMIN, LibConstants.GROUP_BROKERS));
+        nayms.updateRoleAssigner(LC.ROLE_ENTITY_ADMIN, LC.GROUP_BROKERS);
+        assertTrue(nayms.canAssign(signer1Id, signer2Id, systemContext, LC.ROLE_ENTITY_ADMIN));
+        assertTrue(nayms.canGroupAssignRole(LC.ROLE_ENTITY_ADMIN, LC.GROUP_BROKERS));
 
         Vm.Log[] memory entries = vm.getRecordedLogs();
         assertEq(entries[0].topics.length, 1);
         assertEq(entries[0].topics[0], keccak256("RoleCanAssignUpdated(string,string)"));
         (string memory r, string memory g) = abi.decode(entries[0].data, (string, string));
-        assertEq(r, LibConstants.ROLE_ENTITY_ADMIN);
-        assertEq(g, LibConstants.GROUP_BROKERS);
+        assertEq(r, LC.ROLE_ENTITY_ADMIN);
+        assertEq(g, LC.GROUP_BROKERS);
     }
 
     function testUpdateRoleGroupFailIfNotAdmin() public {
@@ -318,44 +321,44 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
 
     function testUpdateRoleGroup() public {
         // setup signer1 as broker
-        nayms.assignRole(signer1Id, systemContext, LibConstants.ROLE_BROKER);
+        nayms.assignRole(signer1Id, systemContext, LC.ROLE_BROKER);
         // brokers can't usually assign approved users
-        assertFalse(nayms.canAssign(signer1Id, signer2Id, systemContext, LibConstants.ROLE_ENTITY_ADMIN));
-        assertFalse(nayms.isRoleInGroup(LibConstants.ROLE_BROKER, LibConstants.GROUP_SYSTEM_MANAGERS));
+        assertFalse(nayms.canAssign(signer1Id, signer2Id, systemContext, LC.ROLE_ENTITY_ADMIN));
+        assertFalse(nayms.isRoleInGroup(LC.ROLE_BROKER, LC.GROUP_SYSTEM_MANAGERS));
 
         vm.expectRevert(abi.encodePacked(RoleIsMissing.selector));
-        nayms.updateRoleGroup("", LibConstants.GROUP_SYSTEM_MANAGERS, false);
+        nayms.updateRoleGroup("", LC.GROUP_SYSTEM_MANAGERS, false);
 
         vm.expectRevert(abi.encodePacked(AssignerGroupIsMissing.selector));
-        nayms.updateRoleGroup(LibConstants.ROLE_BROKER, "", false);
+        nayms.updateRoleGroup(LC.ROLE_BROKER, "", false);
 
         // now change this
         vm.recordLogs();
 
-        nayms.updateRoleGroup(LibConstants.ROLE_BROKER, LibConstants.GROUP_SYSTEM_MANAGERS, true);
-        assertTrue(nayms.canAssign(signer1Id, signer2Id, systemContext, LibConstants.ROLE_ENTITY_ADMIN));
-        assertTrue(nayms.isRoleInGroup(LibConstants.ROLE_BROKER, LibConstants.GROUP_SYSTEM_MANAGERS));
+        nayms.updateRoleGroup(LC.ROLE_BROKER, LC.GROUP_SYSTEM_MANAGERS, true);
+        assertTrue(nayms.canAssign(signer1Id, signer2Id, systemContext, LC.ROLE_ENTITY_ADMIN));
+        assertTrue(nayms.isRoleInGroup(LC.ROLE_BROKER, LC.GROUP_SYSTEM_MANAGERS));
 
         Vm.Log[] memory entries = vm.getRecordedLogs();
         assertEq(entries[0].topics.length, 1);
         assertEq(entries[0].topics[0], keccak256("RoleGroupUpdated(string,string,bool)"));
         (string memory r, string memory g, bool v) = abi.decode(entries[0].data, (string, string, bool));
-        assertEq(r, LibConstants.ROLE_BROKER);
-        assertEq(g, LibConstants.GROUP_SYSTEM_MANAGERS);
+        assertEq(r, LC.ROLE_BROKER);
+        assertEq(g, LC.GROUP_SYSTEM_MANAGERS);
         assertTrue(v);
 
         // now change it back
         vm.recordLogs();
 
-        nayms.updateRoleGroup(LibConstants.ROLE_BROKER, LibConstants.GROUP_SYSTEM_MANAGERS, false);
-        assertFalse(nayms.canAssign(signer1Id, signer2Id, systemContext, LibConstants.ROLE_ENTITY_ADMIN));
+        nayms.updateRoleGroup(LC.ROLE_BROKER, LC.GROUP_SYSTEM_MANAGERS, false);
+        assertFalse(nayms.canAssign(signer1Id, signer2Id, systemContext, LC.ROLE_ENTITY_ADMIN));
 
         entries = vm.getRecordedLogs();
         assertEq(entries[0].topics.length, 1);
         assertEq(entries[0].topics[0], keccak256("RoleGroupUpdated(string,string,bool)"));
         (r, g, v) = abi.decode(entries[0].data, (string, string, bool));
-        assertEq(r, LibConstants.ROLE_BROKER);
-        assertEq(g, LibConstants.GROUP_SYSTEM_MANAGERS);
+        assertEq(r, LC.ROLE_BROKER);
+        assertEq(g, LC.GROUP_SYSTEM_MANAGERS);
         assertFalse(v);
     }
 }

--- a/test/T02Access.t.sol
+++ b/test/T02Access.t.sol
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+import { console2 } from "forge-std/console2.sol";
+import { D03ProtocolDefaults, LibHelpers, LibConstants as LC } from "./defaults/D03ProtocolDefaults.sol";
+import { Entity, MarketInfo, SimplePolicy, SimplePolicyInfo, Stakeholders } from "src/diamonds/nayms/interfaces/FreeStructs.sol";
+import { Modifiers } from "src/diamonds/nayms/Modifiers.sol";
+import { IDiamondCut } from "src/diamonds/shared/interfaces/IDiamondCut.sol";
+
+// updateRoleGroup | isRoleInGroup | groups [role][group] = bool
+// updateRoleAssigner | canGroupAssignRole | canAssign [role] = group
+// getRoleInContext | roles[objectId][contextId] = role
+
+contract PermissionsFixture is Modifiers {
+    function assertPermissionsT(string memory _group, bytes32 _context) public view assertPermissions(_group, _context) {}
+}
+
+abstract contract T02AccessHelpers is D03ProtocolDefaults {
+    string[3] internal rolesThatCanAssignRoles = [LC.ROLE_SYSTEM_ADMIN, LC.ROLE_SYSTEM_MANAGER, LC.ROLE_ENTITY_MANAGER];
+    mapping(string => string[]) internal roleCanAssignRoles;
+    mapping(string => bytes32[]) internal roleToUsers;
+    mapping(bytes32 => bytes32) internal objectToContext;
+
+    mapping(string => string[]) internal functionToRoles;
+    string[] internal functionsUsingAssertP = [
+        LC.GROUP_START_TOKEN_SALE,
+        LC.GROUP_EXECUTE_LIMIT_OFFER,
+        LC.GROUP_CANCEL_OFFER,
+        LC.GROUP_PAY_SIMPLE_PREMIUM,
+        LC.GROUP_PAY_SIMPLE_CLAIM,
+        LC.GROUP_PAY_DIVIDEND_FROM_ENTITY,
+        LC.GROUP_EXTERNAL_DEPOSIT,
+        LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY
+    ];
+
+    function hAssignRole(
+        bytes32 _objectId,
+        bytes32 _contextId,
+        string memory _role
+    ) internal {
+        nayms.assignRole(_objectId, _contextId, _role);
+        roleToUsers[_role].push(_objectId);
+
+        if (objectToContext[_objectId] == systemContext) {
+            console2.log("warning: object's context is currently systemContext");
+        } else {
+            objectToContext[_objectId] = _contextId;
+        }
+    }
+
+    function hCreateEntity(
+        bytes32 _entityId,
+        bytes32 _entityAdmin,
+        Entity memory _entityData,
+        bytes32 _dataHash
+    ) internal {
+        nayms.createEntity(_entityId, _entityAdmin, _entityData, _dataHash);
+        roleToUsers[LC.ROLE_ENTITY_ADMIN].push(_entityAdmin);
+
+        if (objectToContext[_entityAdmin] == systemContext) {
+            console2.log("warning: object's context is currently systemContext");
+        } else {
+            objectToContext[_entityAdmin] = _entityId;
+        }
+    }
+}
+
+contract T02Access is T02AccessHelpers {
+    using LibHelpers for *;
+
+    NaymsAccount sa = makeNaymsAcc("System Admin");
+    NaymsAccount sm = makeNaymsAcc("System Manager");
+    NaymsAccount su = makeNaymsAcc("System Underwriter");
+
+    NaymsAccount ea = makeNaymsAcc("Entity Admin");
+    NaymsAccount em = makeNaymsAcc("Entity Manager");
+
+    NaymsAccount ts = makeNaymsAcc("Tenant Sponsor");
+    NaymsAccount tcp = makeNaymsAcc("Tenant CP");
+    NaymsAccount ti = makeNaymsAcc("Tenant Insured");
+    NaymsAccount tb = makeNaymsAcc("Tenant Broker");
+    NaymsAccount tc = makeNaymsAcc("Tenant Consultant");
+
+    NaymsAccount cc = makeNaymsAcc("Comptroller Combined");
+    NaymsAccount cw = makeNaymsAcc("Comptroller Withdraw");
+    NaymsAccount cClaim = makeNaymsAcc("Comptroller Claim");
+    NaymsAccount cd = makeNaymsAcc("Comptroller Dividend");
+
+    bytes32 internal testPolicyDataHash = 0x00a420601de63bf726c0be38414e9255d301d74ad0d820d633f3ab75effd6f5b;
+    Stakeholders internal stakeholders;
+    SimplePolicy internal simplePolicy;
+
+    string constant GROUP_ADMINS = "new admin group";
+
+    function setUp() public {
+        bytes4[] memory fs = new bytes4[](1);
+        fs[0] = PermissionsFixture.assertPermissionsT.selector;
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({ facetAddress: address(new PermissionsFixture()), action: IDiamondCut.FacetCutAction.Add, functionSelectors: fs });
+
+        scheduleAndUpgradeDiamond(cut, address(0), "");
+
+        // Remove system admin from system managers group
+        nayms.updateRoleGroup(LC.ROLE_SYSTEM_ADMIN, LC.GROUP_SYSTEM_MANAGERS, false);
+
+        nayms.updateRoleGroup(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_SYSTEM_MANAGERS, true);
+        nayms.updateRoleAssigner(LC.ROLE_ENTITY_CP, LC.GROUP_SYSTEM_MANAGERS);
+
+        nayms.updateRoleGroup(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_MANAGERS, true);
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_MANAGER, LC.GROUP_MANAGERS, true);
+        nayms.updateRoleAssigner(LC.ROLE_ENTITY_BROKER, LC.GROUP_MANAGERS);
+        nayms.updateRoleAssigner(LC.ROLE_ENTITY_INSURED, LC.GROUP_MANAGERS);
+
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_MANAGER, LC.GROUP_ENTITY_MANAGERS, true);
+        nayms.updateRoleAssigner(LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.GROUP_ENTITY_MANAGERS);
+        nayms.updateRoleAssigner(LC.ROLE_ENTITY_COMPTROLLER_WITHDRAW, LC.GROUP_ENTITY_MANAGERS);
+        nayms.updateRoleAssigner(LC.ROLE_ENTITY_COMPTROLLER_CLAIM, LC.GROUP_ENTITY_MANAGERS);
+        nayms.updateRoleAssigner(LC.ROLE_ENTITY_COMPTROLLER_DIVIDEND, LC.GROUP_ENTITY_MANAGERS);
+
+        nayms.updateRoleGroup(LC.ROLE_SYSTEM_ADMIN, GROUP_ADMINS, true);
+        nayms.updateRoleAssigner(LC.ROLE_SYSTEM_ADMIN, GROUP_ADMINS);
+        nayms.updateRoleAssigner(LC.ROLE_SYSTEM_MANAGER, GROUP_ADMINS);
+        nayms.updateRoleAssigner(LC.ROLE_SYSTEM_UNDERWRITER, GROUP_ADMINS);
+        nayms.updateRoleAssigner(LC.ROLE_ENTITY_ADMIN, GROUP_ADMINS);
+        nayms.updateRoleAssigner(LC.ROLE_ENTITY_MANAGER, GROUP_ADMINS);
+
+        // Setup roles which can call functions
+        nayms.updateRoleGroup(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_START_TOKEN_SALE, true);
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_MANAGER, LC.GROUP_START_TOKEN_SALE, true);
+
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_MANAGER, LC.GROUP_CANCEL_OFFER, true);
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_CP, LC.GROUP_CANCEL_OFFER, true);
+
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_CP, LC.GROUP_EXECUTE_LIMIT_OFFER, true);
+
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_BROKER, LC.GROUP_PAY_SIMPLE_PREMIUM, true);
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_INSURED, LC.GROUP_PAY_SIMPLE_PREMIUM, true);
+
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.GROUP_PAY_SIMPLE_CLAIM, true);
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_CLAIM, LC.GROUP_PAY_SIMPLE_CLAIM, true);
+
+        // todo currently have a check on internalTransferFromEntity, is this needed?
+
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.GROUP_PAY_DIVIDEND_FROM_ENTITY, true);
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_DIVIDEND, LC.GROUP_PAY_DIVIDEND_FROM_ENTITY, true);
+
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_ADMIN, LC.GROUP_EXTERNAL_DEPOSIT, true);
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.GROUP_EXTERNAL_DEPOSIT, true);
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_WITHDRAW, LC.GROUP_EXTERNAL_DEPOSIT, true);
+
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_ADMIN, LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY, true);
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY, true);
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_WITHDRAW, LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY, true);
+
+        // Assign roles to users
+        hAssignRole(sa.id, systemContext, LC.ROLE_SYSTEM_ADMIN);
+        hAssignRole(sm.id, systemContext, LC.ROLE_SYSTEM_MANAGER);
+        hAssignRole(su.id, systemContext, LC.ROLE_SYSTEM_UNDERWRITER);
+    }
+
+    function test_canAssign_comprehensive() public {
+        roleCanAssignRoles[LC.ROLE_SYSTEM_ADMIN] = [LC.ROLE_SYSTEM_ADMIN, LC.ROLE_SYSTEM_MANAGER, LC.ROLE_SYSTEM_UNDERWRITER, LC.ROLE_ENTITY_ADMIN, LC.ROLE_ENTITY_MANAGER];
+
+        roleCanAssignRoles[LC.ROLE_SYSTEM_MANAGER] = [LC.ROLE_ENTITY_BROKER, LC.ROLE_ENTITY_INSURED, LC.ROLE_ENTITY_CP];
+
+        roleCanAssignRoles[LC.ROLE_ENTITY_MANAGER] = [
+            LC.ROLE_ENTITY_BROKER,
+            LC.ROLE_ENTITY_INSURED,
+            LC.ROLE_ENTITY_COMPTROLLER_COMBINED,
+            LC.ROLE_ENTITY_COMPTROLLER_WITHDRAW,
+            LC.ROLE_ENTITY_COMPTROLLER_CLAIM,
+            LC.ROLE_ENTITY_COMPTROLLER_DIVIDEND
+        ];
+
+        hAssignRole(em.id, tb.entityId, LC.ROLE_ENTITY_MANAGER);
+
+        for (uint256 j; j < rolesThatCanAssignRoles.length; ++j) {
+            string memory role = rolesThatCanAssignRoles[j];
+
+            for (uint256 i; i < roleCanAssignRoles[role].length; ++i) {
+                bytes32 context = objectToContext[roleToUsers[role][0]];
+                assertTrue(nayms.canAssign(roleToUsers[role][0], tb.id, context, roleCanAssignRoles[role][i]), string.concat(role, " can assign ", roleCanAssignRoles[role][i]));
+
+                if (context != systemContext) {
+                    assertFalse(nayms.canAssign(roleToUsers[role][0], tb.id, systemContext, roleCanAssignRoles[role][i]));
+                }
+            }
+        }
+
+        assertTrue(nayms.canAssign(systemAdminId, sa.id, systemContext, LC.ROLE_SYSTEM_ADMIN));
+        assertTrue(nayms.canAssign(systemAdminId, sa.id, systemContext, LC.ROLE_SYSTEM_MANAGER));
+        assertTrue(nayms.canAssign(systemAdminId, sa.id, systemContext, LC.ROLE_SYSTEM_UNDERWRITER));
+
+        assertFalse(nayms.canAssign(sm.id, sa.id, systemContext, LC.ROLE_SYSTEM_ADMIN));
+        assertFalse(nayms.canAssign(sm.id, sa.id, systemContext, LC.ROLE_SYSTEM_MANAGER));
+        assertFalse(nayms.canAssign(sm.id, sa.id, systemContext, LC.ROLE_SYSTEM_UNDERWRITER));
+        assertFalse(nayms.canAssign(su.id, sa.id, systemContext, LC.ROLE_SYSTEM_ADMIN));
+        assertFalse(nayms.canAssign(su.id, sa.id, systemContext, LC.ROLE_SYSTEM_MANAGER));
+        assertFalse(nayms.canAssign(su.id, sa.id, systemContext, LC.ROLE_SYSTEM_UNDERWRITER));
+
+        assertTrue(nayms.isRoleInGroup(LC.ROLE_SYSTEM_ADMIN, LC.GROUP_SYSTEM_ADMINS));
+        assertFalse(nayms.isRoleInGroup(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_SYSTEM_ADMINS));
+        assertFalse(nayms.isRoleInGroup(LC.ROLE_SYSTEM_UNDERWRITER, LC.GROUP_SYSTEM_ADMINS));
+
+        // new group admins
+        assertTrue(nayms.isRoleInGroup(LC.ROLE_SYSTEM_ADMIN, GROUP_ADMINS));
+
+        assertFalse(nayms.isRoleInGroup(LC.ROLE_SYSTEM_MANAGER, GROUP_ADMINS));
+        assertFalse(nayms.isRoleInGroup(LC.ROLE_SYSTEM_UNDERWRITER, GROUP_ADMINS));
+
+        assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_ADMIN, GROUP_ADMINS));
+        assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_MANAGER, GROUP_ADMINS));
+        assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_UNDERWRITER, GROUP_ADMINS));
+
+        // assertTrue(nayms.canAssign(systemAdminId, sa.id, systemContext, LC.ROLE_SYSTEM_ADMIN));
+        // assertTrue(nayms.canAssign(systemAdminId, sa.id, systemContext, LC.ROLE_SYSTEM_MANAGER));
+        // assertTrue(nayms.canAssign(systemAdminId, sa.id, systemContext, LC.ROLE_SYSTEM_UNDERWRITER));
+
+        assertFalse(nayms.isRoleInGroup(LC.ROLE_ENTITY_BROKER, LC.GROUP_SYSTEM_MANAGERS));
+        assertFalse(nayms.isRoleInGroup(LC.ROLE_ENTITY_BROKER, LC.GROUP_ENTITY_MANAGERS));
+
+        hAssignRole(em.id, tb.entityId, LC.ROLE_ENTITY_MANAGER);
+
+        changePrank(sm.addr);
+        hAssignRole(tb.id, tb.entityId, LC.ROLE_ENTITY_BROKER);
+        hAssignRole(tb.id, systemContext, LC.ROLE_ENTITY_BROKER);
+        assertTrue(nayms.canAssign(sm.id, tb.id, systemContext, LC.ROLE_ENTITY_BROKER));
+        assertFalse(nayms.canAssign(em.id, tb.id, systemContext, LC.ROLE_ENTITY_BROKER)); // can only assign in entity context
+        assertTrue(nayms.canAssign(sm.id, tb.id, tb.entityId, LC.ROLE_ENTITY_BROKER));
+        assertTrue(nayms.canAssign(em.id, tb.id, tb.entityId, LC.ROLE_ENTITY_BROKER));
+
+        changePrank(sa.addr);
+        hAssignRole(em.id, systemContext, LC.ROLE_ENTITY_MANAGER);
+        assertTrue(nayms.canAssign(em.id, tb.id, systemContext, LC.ROLE_ENTITY_BROKER)); // can assign in system context
+
+        // assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_ADMIN, LC.GROUP_SYSTEM_ADMINS));
+        // assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_SYSTEM_ADMINS));
+        // assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_UNDERWRITER, LC.GROUP_SYSTEM_ADMINS));
+        // assertTrue(nayms.canGroupAssignRole(LC.ROLE_CAPITAL_PROVIDER, LC.GROUP_SYSTEM_MANAGERS));
+
+        // assertFalse(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_ADMIN, LC.GROUP_SYSTEM_MANAGERS));
+    }
+
+    function test_roles_assertPermissions() public {
+        hAssignRole(em.id, sm.entityId, LC.ROLE_ENTITY_MANAGER);
+
+        changePrank(sm.addr);
+        hCreateEntity(sm.entityId, ea.id, entity, "entity test hash");
+        hAssignRole(tcp.id, sm.entityId, LC.ROLE_ENTITY_CP);
+        hAssignRole(tb.id, sm.entityId, LC.ROLE_ENTITY_BROKER);
+        hAssignRole(ti.id, sm.entityId, LC.ROLE_ENTITY_INSURED);
+
+        changePrank(em.addr);
+        hAssignRole(cc.id, sm.entityId, LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
+        hAssignRole(cw.id, sm.entityId, LC.ROLE_ENTITY_COMPTROLLER_WITHDRAW);
+        hAssignRole(cClaim.id, sm.entityId, LC.ROLE_ENTITY_COMPTROLLER_CLAIM);
+        hAssignRole(cd.id, sm.entityId, LC.ROLE_ENTITY_COMPTROLLER_DIVIDEND);
+
+        functionToRoles[LC.GROUP_START_TOKEN_SALE] = [LC.ROLE_SYSTEM_MANAGER, LC.ROLE_ENTITY_MANAGER];
+        functionToRoles[LC.GROUP_EXECUTE_LIMIT_OFFER] = [LC.ROLE_ENTITY_CP];
+        functionToRoles[LC.GROUP_CANCEL_OFFER] = [LC.ROLE_ENTITY_MANAGER, LC.ROLE_ENTITY_CP];
+        functionToRoles[LC.GROUP_PAY_SIMPLE_PREMIUM] = [LC.ROLE_ENTITY_BROKER, LC.ROLE_ENTITY_INSURED];
+        functionToRoles[LC.GROUP_PAY_SIMPLE_CLAIM] = [LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.ROLE_ENTITY_COMPTROLLER_CLAIM];
+        functionToRoles[LC.GROUP_PAY_DIVIDEND_FROM_ENTITY] = [LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.ROLE_ENTITY_COMPTROLLER_DIVIDEND];
+        functionToRoles[LC.GROUP_EXTERNAL_DEPOSIT] = [LC.ROLE_ENTITY_ADMIN, LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.ROLE_ENTITY_COMPTROLLER_WITHDRAW];
+        functionToRoles[LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY] = [LC.ROLE_ENTITY_ADMIN, LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.ROLE_ENTITY_COMPTROLLER_WITHDRAW];
+
+        for (uint256 i; i < functionsUsingAssertP.length; ++i) {
+            string memory functionGroup = functionsUsingAssertP[i];
+            for (uint256 j; j < functionToRoles[functionGroup].length; ++j) {
+                string memory role = functionToRoles[functionGroup][j];
+                bytes32 user = roleToUsers[role][0];
+                bytes32 context = objectToContext[user];
+
+                changePrank(user._getAddressFromId());
+                PermissionsFixture(naymsAddress).assertPermissionsT(functionGroup, context);
+            }
+        }
+    }
+}

--- a/test/T02Access.t.sol
+++ b/test/T02Access.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
-import { console2 } from "forge-std/console2.sol";
+import { console2 as c } from "forge-std/console2.sol";
 import { D03ProtocolDefaults, LibHelpers, LC } from "./defaults/D03ProtocolDefaults.sol";
 import { Entity, MarketInfo, SimplePolicy, SimplePolicyInfo, Stakeholders } from "src/diamonds/nayms/interfaces/FreeStructs.sol";
 import { Modifiers } from "src/diamonds/nayms/Modifiers.sol";
@@ -41,7 +41,7 @@ abstract contract T02AccessHelpers is D03ProtocolDefaults {
         roleToUsers[_role].push(_objectId);
 
         if (objectToContext[_objectId] == systemContext) {
-            console2.log("warning: object's context is currently systemContext");
+            c.log("warning: object's context is currently systemContext");
         } else {
             objectToContext[_objectId] = _contextId;
         }
@@ -57,7 +57,7 @@ abstract contract T02AccessHelpers is D03ProtocolDefaults {
         roleToUsers[LC.ROLE_ENTITY_ADMIN].push(_entityAdmin);
 
         if (objectToContext[_entityAdmin] == systemContext) {
-            console2.log("warning: object's context is currently systemContext");
+            c.log("warning: object's context is currently systemContext");
         } else {
             objectToContext[_entityAdmin] = _entityId;
         }
@@ -79,56 +79,6 @@ contract T02Access is T02AccessHelpers {
         // cut[0] = IDiamondCut.FacetCut({ facetAddress: address(new PermissionsFixture()), action: IDiamondCut.FacetCutAction.Add, functionSelectors: fs });
 
         // scheduleAndUpgradeDiamond(cut, address(0), "");
-
-        // Remove system admin from system managers group
-        nayms.updateRoleGroup(LC.ROLE_SYSTEM_ADMIN, LC.GROUP_SYSTEM_MANAGERS, false);
-
-        nayms.updateRoleGroup(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_SYSTEM_MANAGERS, true);
-        nayms.updateRoleAssigner(LC.ROLE_ENTITY_CP, LC.GROUP_SYSTEM_MANAGERS);
-
-        nayms.updateRoleGroup(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_MANAGERS, true);
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_MANAGER, LC.GROUP_MANAGERS, true);
-        nayms.updateRoleAssigner(LC.ROLE_ENTITY_BROKER, LC.GROUP_MANAGERS);
-        nayms.updateRoleAssigner(LC.ROLE_ENTITY_INSURED, LC.GROUP_MANAGERS);
-
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_MANAGER, LC.GROUP_ENTITY_MANAGERS, true);
-        nayms.updateRoleAssigner(LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.GROUP_ENTITY_MANAGERS);
-        nayms.updateRoleAssigner(LC.ROLE_ENTITY_COMPTROLLER_WITHDRAW, LC.GROUP_ENTITY_MANAGERS);
-        nayms.updateRoleAssigner(LC.ROLE_ENTITY_COMPTROLLER_CLAIM, LC.GROUP_ENTITY_MANAGERS);
-        nayms.updateRoleAssigner(LC.ROLE_ENTITY_COMPTROLLER_DIVIDEND, LC.GROUP_ENTITY_MANAGERS);
-
-        nayms.updateRoleGroup(LC.ROLE_SYSTEM_ADMIN, GROUP_ADMINS, true);
-        nayms.updateRoleAssigner(LC.ROLE_SYSTEM_ADMIN, GROUP_ADMINS);
-        nayms.updateRoleAssigner(LC.ROLE_SYSTEM_MANAGER, GROUP_ADMINS);
-        nayms.updateRoleAssigner(LC.ROLE_SYSTEM_UNDERWRITER, GROUP_ADMINS);
-        nayms.updateRoleAssigner(LC.ROLE_ENTITY_ADMIN, GROUP_ADMINS);
-        nayms.updateRoleAssigner(LC.ROLE_ENTITY_MANAGER, GROUP_ADMINS);
-
-        // Setup roles which can call functions
-        nayms.updateRoleGroup(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_START_TOKEN_SALE, true);
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_MANAGER, LC.GROUP_START_TOKEN_SALE, true);
-
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_MANAGER, LC.GROUP_CANCEL_OFFER, true);
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_CP, LC.GROUP_CANCEL_OFFER, true);
-
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_CP, LC.GROUP_EXECUTE_LIMIT_OFFER, true);
-
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_BROKER, LC.GROUP_PAY_SIMPLE_PREMIUM, true);
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_INSURED, LC.GROUP_PAY_SIMPLE_PREMIUM, true);
-
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.GROUP_PAY_SIMPLE_CLAIM, true);
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_CLAIM, LC.GROUP_PAY_SIMPLE_CLAIM, true);
-
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.GROUP_PAY_DIVIDEND_FROM_ENTITY, true);
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_DIVIDEND, LC.GROUP_PAY_DIVIDEND_FROM_ENTITY, true);
-
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_ADMIN, LC.GROUP_EXTERNAL_DEPOSIT, true);
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.GROUP_EXTERNAL_DEPOSIT, true);
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_WITHDRAW, LC.GROUP_EXTERNAL_DEPOSIT, true);
-
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_ADMIN, LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY, true);
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY, true);
-        nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_WITHDRAW, LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY, true);
 
         // Assign roles to users
         hAssignRole(sa.id, systemContext, LC.ROLE_SYSTEM_ADMIN);
@@ -181,18 +131,18 @@ contract T02Access is T02AccessHelpers {
         assertFalse(nayms.isRoleInGroup(LC.ROLE_SYSTEM_UNDERWRITER, LC.GROUP_SYSTEM_ADMINS));
 
         // new group admins
-        assertTrue(nayms.isRoleInGroup(LC.ROLE_SYSTEM_ADMIN, GROUP_ADMINS));
+        assertTrue(nayms.isRoleInGroup(LC.ROLE_SYSTEM_ADMIN, LC.GROUP_SYSTEM_ADMINS));
 
-        assertFalse(nayms.isRoleInGroup(LC.ROLE_SYSTEM_MANAGER, GROUP_ADMINS));
-        assertFalse(nayms.isRoleInGroup(LC.ROLE_SYSTEM_UNDERWRITER, GROUP_ADMINS));
+        assertFalse(nayms.isRoleInGroup(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_SYSTEM_ADMINS));
+        assertFalse(nayms.isRoleInGroup(LC.ROLE_SYSTEM_UNDERWRITER, LC.GROUP_SYSTEM_ADMINS));
 
-        assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_ADMIN, GROUP_ADMINS));
-        assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_MANAGER, GROUP_ADMINS));
-        assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_UNDERWRITER, GROUP_ADMINS));
+        assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_ADMIN, LC.GROUP_SYSTEM_ADMINS));
+        assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_SYSTEM_ADMINS));
+        assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_UNDERWRITER, LC.GROUP_SYSTEM_ADMINS));
 
-        // assertTrue(nayms.canAssign(systemAdminId, sa.id, systemContext, LC.ROLE_SYSTEM_ADMIN));
-        // assertTrue(nayms.canAssign(systemAdminId, sa.id, systemContext, LC.ROLE_SYSTEM_MANAGER));
-        // assertTrue(nayms.canAssign(systemAdminId, sa.id, systemContext, LC.ROLE_SYSTEM_UNDERWRITER));
+        assertTrue(nayms.canAssign(systemAdminId, sa.id, systemContext, LC.ROLE_SYSTEM_ADMIN));
+        assertTrue(nayms.canAssign(systemAdminId, sa.id, systemContext, LC.ROLE_SYSTEM_MANAGER));
+        assertTrue(nayms.canAssign(systemAdminId, sa.id, systemContext, LC.ROLE_SYSTEM_UNDERWRITER));
 
         assertFalse(nayms.isRoleInGroup(LC.ROLE_ENTITY_BROKER, LC.GROUP_SYSTEM_MANAGERS));
         assertFalse(nayms.isRoleInGroup(LC.ROLE_ENTITY_BROKER, LC.GROUP_ENTITY_MANAGERS));
@@ -211,12 +161,12 @@ contract T02Access is T02AccessHelpers {
         hAssignRole(em.id, systemContext, LC.ROLE_ENTITY_MANAGER);
         assertTrue(nayms.canAssign(em.id, tb.id, systemContext, LC.ROLE_ENTITY_BROKER)); // can assign in system context
 
-        // assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_ADMIN, LC.GROUP_SYSTEM_ADMINS));
-        // assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_SYSTEM_ADMINS));
-        // assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_UNDERWRITER, LC.GROUP_SYSTEM_ADMINS));
-        // assertTrue(nayms.canGroupAssignRole(LC.ROLE_CAPITAL_PROVIDER, LC.GROUP_SYSTEM_MANAGERS));
+        assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_ADMIN, LC.GROUP_SYSTEM_ADMINS));
+        assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_SYSTEM_ADMINS));
+        assertTrue(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_UNDERWRITER, LC.GROUP_SYSTEM_ADMINS));
+        assertTrue(nayms.canGroupAssignRole(LC.ROLE_CAPITAL_PROVIDER, LC.GROUP_SYSTEM_MANAGERS));
 
-        // assertFalse(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_ADMIN, LC.GROUP_SYSTEM_MANAGERS));
+        assertFalse(nayms.canGroupAssignRole(LC.ROLE_SYSTEM_ADMIN, LC.GROUP_SYSTEM_MANAGERS));
     }
 
     function test_roles_hasGroupPrivilege() public {
@@ -254,4 +204,65 @@ contract T02Access is T02AccessHelpers {
             }
         }
     }
+
+    function test_sysAdmin_canAssign_sysUW() public {
+        changePrank(sa.addr);
+        hAssignRole(address(888)._getIdForAddress(), systemContext, LC.ROLE_SYSTEM_UNDERWRITER);
+
+        nayms.updateRoleAssigner(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_SYSTEM_ADMINS);
+    }
+    // function testR2() public {
+    //     changePrank(sm.addr);
+    //     nayms.createEntity(ea.id, ea.id, entity, "entity test hash");
+    //     uint256 sellAmount = 1 ether;
+    //     uint256 buyAmount = 0.5 ether;
+
+    //     nayms.enableEntityTokenization(ea.id, "ESPT", "Entity Selling Par Tokens");
+
+    //     // changePrank(sa.addr);
+    //     bytes32 id = address(9999)._getIdForAddress();
+    //     nayms.setEntity(id, ea.id);
+
+    //     changePrank(sa.addr);
+    //     // nayms.assignRole(id, ea.id, LC.ROLE_SYSTEM_MANAGER);
+    //     nayms.assignRole(id, ea.id, LC.ROLE_ENTITY_ADMIN);
+    //     changePrank(sm.addr);
+    //     // changePrank(address(9999));
+    //     nayms.startTokenSale(ea.id, sellAmount, sellAmount);
+
+    //     // fundEntityWeth(acc2, sellAmount);
+
+    //     // the context is the parent of the caller
+    //     bytes32 context = nayms.getEntity(msg.sender._getIdForAddress());
+    //     c.logBytes32(context);
+    //     bytes32 roleInContextBytes32 = nayms.getRoleInContext(msg.sender._getIdForAddress(), context);
+    //     string memory roleInContext;
+    //     if (roleInContextBytes32 != bytes32(0)) {
+    //         roleInContext = abi.decode(roleInContextBytes32._bytes32ToBytes(), (string));
+    //     } else {
+    //         roleInContext = "hi";
+    //     }
+
+    //     c.log(roleInContext);
+    //     changePrank(address(9999));
+    //     roleInContextBytes32 = nayms.getRoleInContext(msg.sender._getIdForAddress(), context);
+    //     c.logBytes32(roleInContextBytes32);
+    //     if (roleInContextBytes32 != bytes32(0)) {
+    //         c.log("DECODING");
+    //         roleInContext = abi.decode(roleInContextBytes32._bytes32ToBytes(), (string));
+    //     }
+    //     c.log(roleInContext);
+    //     nayms.executeLimitOffer(wethId, buyAmount, ea.id, buyAmount);
+    //     // if (!msg.sender._getIdForAddress()._hasGroupPrivilege(_context, _group._stringToBytes32())) {
+    //     //     bytes32 roleInContextBytes32 = msg.sender._getIdForAddress()._getRoleInContext(_context);
+    //     //     string memory roleInContext;
+    //     //     if (roleInContextBytes32 != bytes32(0)) {
+    //     //         roleInContext = abi.decode(roleInContextBytes32._bytes32ToBytes(), (string));
+    //     //     }
+    //     //     revert InvalidGroupPrivilege(msg.sender._getIdForAddress(), _context, roleInContext, _group);
+    //     // }
+    //     // nayms.executeLimitOffer();
+    // }
 }
+// 0xd2d53960000000000000000000000000000000000000acc90000000000000000000000006530000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000018506179204469766964656e642046726f6d20456e746974790000000000000000
+// 0xd2d53960000000000000000000000000000000000000acc90000000000000000000000006530000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000018506179204469766964656e642046726f6d20456e746974790000000000000000

--- a/test/T02User.t.sol
+++ b/test/T02User.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import { D03ProtocolDefaults, LibHelpers, LibConstants } from "./defaults/D03ProtocolDefaults.sol";
+import { D03ProtocolDefaults, LibHelpers, LC } from "./defaults/D03ProtocolDefaults.sol";
 import { MockAccounts } from "test/utils/users/MockAccounts.sol";
 import { Vm } from "forge-std/Vm.sol";
 import "src/diamonds/nayms/interfaces/CustomErrors.sol";
@@ -14,23 +14,25 @@ contract T02UserTest is D03ProtocolDefaults, MockAccounts {
     }
 
     function testGetAddressFromExternalTokenId() public {
-        bytes32 id = LibHelpers._getIdForAddress(LibConstants.DAI_CONSTANT);
-        assertEq(nayms.getAddressFromExternalTokenId(id), LibConstants.DAI_CONSTANT);
+        bytes32 id = LibHelpers._getIdForAddress(LC.DAI_CONSTANT);
+        assertEq(nayms.getAddressFromExternalTokenId(id), LC.DAI_CONSTANT);
     }
 
-    function testSetEntityFailsIfNotSysAdmin() public {
+    function testSetEntityFailsIfNotSysManager() public {
         changePrank(signer2);
-        vm.expectRevert("not a system admin");
+        vm.expectRevert("not a system manager");
         nayms.setEntity(account0Id, bytes32(0));
     }
 
     function testGetSetEntity() public {
+        changePrank(sm.addr);
         bytes32 entityId = createTestEntity(account0Id);
         nayms.setEntity(signer1Id, entityId);
         assertEq(nayms.getEntity(signer1Id), entityId);
     }
 
     function testSetNonExistingEntity() public {
+        changePrank(sm.addr);
         bytes32 entityId;
         vm.expectRevert(abi.encodePacked(EntityDoesNotExist.selector, (entityId)));
         nayms.setEntity(signer1Id, entityId);

--- a/test/T03NaymsOwnership.t.sol
+++ b/test/T03NaymsOwnership.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import { D03ProtocolDefaults, LibHelpers, LibConstants } from "./defaults/D03ProtocolDefaults.sol";
+import { D03ProtocolDefaults, LibHelpers, LC } from "./defaults/D03ProtocolDefaults.sol";
 
 import { MockAccounts } from "./utils/users/MockAccounts.sol";
 
@@ -15,7 +15,7 @@ contract T03NaymsOwnershipTest is D03ProtocolDefaults, MockAccounts {
     }
 
     function testTransferOwernshipFailsIfNewOwnerIsSysAdmin() public {
-        nayms.assignRole(signer1Id, systemContext, LibConstants.ROLE_SYSTEM_ADMIN);
+        nayms.assignRole(signer1Id, systemContext, LC.ROLE_SYSTEM_ADMIN);
 
         changePrank(signer1);
         vm.expectRevert("NEW owner MUST NOT be sys admin");
@@ -23,8 +23,8 @@ contract T03NaymsOwnershipTest is D03ProtocolDefaults, MockAccounts {
     }
 
     function testTransferOwernshipFailsIfNewOwnerIsSysManager() public {
-        nayms.assignRole(signer1Id, systemContext, LibConstants.ROLE_SYSTEM_ADMIN);
-        nayms.assignRole(signer2Id, systemContext, LibConstants.ROLE_SYSTEM_MANAGER);
+        nayms.assignRole(signer1Id, systemContext, LC.ROLE_SYSTEM_ADMIN);
+        nayms.assignRole(signer2Id, systemContext, LC.ROLE_SYSTEM_MANAGER);
 
         changePrank(signer1);
         vm.expectRevert("NEW owner MUST NOT be sys manager");
@@ -32,14 +32,14 @@ contract T03NaymsOwnershipTest is D03ProtocolDefaults, MockAccounts {
     }
 
     function testTransferOwernship() public {
-        nayms.assignRole(signer1Id, systemContext, LibConstants.ROLE_SYSTEM_ADMIN);
+        nayms.assignRole(signer1Id, systemContext, LC.ROLE_SYSTEM_ADMIN);
 
         changePrank(signer1);
         nayms.transferOwnership(signer2);
         vm.stopPrank();
 
         assertTrue(nayms.owner() == signer2);
-        assertFalse(nayms.isInGroup(signer2Id, systemContext, LibConstants.GROUP_SYSTEM_ADMINS));
+        assertFalse(nayms.isInGroup(signer2Id, systemContext, LC.GROUP_SYSTEM_ADMINS));
     }
 
     function testFuzz_TransferOwnership(
@@ -52,7 +52,7 @@ contract T03NaymsOwnershipTest is D03ProtocolDefaults, MockAccounts {
 
         bytes32 notSysAdminId = LibHelpers._getIdForAddress(address(notSysAdmin));
         // note: for this test, assume that the notSysAdmin address is not a system admin
-        vm.assume(!nayms.isInGroup(notSysAdminId, systemContext, LibConstants.GROUP_SYSTEM_ADMINS));
+        vm.assume(!nayms.isInGroup(notSysAdminId, systemContext, LC.GROUP_SYSTEM_ADMINS));
 
         vm.label(newOwner, "newOwner");
         vm.label(notSysAdmin, "notSysAdmin");
@@ -77,7 +77,7 @@ contract T03NaymsOwnershipTest is D03ProtocolDefaults, MockAccounts {
         assertTrue(nayms.owner() == newOwner);
 
         bytes32 anotherSysAdminId = LibHelpers._getIdForAddress(address(anotherSysAdmin));
-        nayms.assignRole(anotherSysAdminId, systemContext, LibConstants.ROLE_SYSTEM_ADMIN);
+        nayms.assignRole(anotherSysAdminId, systemContext, LC.ROLE_SYSTEM_ADMIN);
 
         changePrank(anotherSysAdmin);
         nayms.transferOwnership(nayms.owner());

--- a/test/T03SystemFacet.t.sol
+++ b/test/T03SystemFacet.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import { D03ProtocolDefaults, LibConstants } from "./defaults/D03ProtocolDefaults.sol";
+import { D03ProtocolDefaults, LC } from "./defaults/D03ProtocolDefaults.sol";
 
 import { MockAccounts } from "./utils/users/MockAccounts.sol";
 
@@ -11,7 +11,10 @@ import "src/diamonds/nayms/interfaces/CustomErrors.sol";
 contract T03SystemFacetTest is D03ProtocolDefaults, MockAccounts {
     bytes32 internal immutable objectContext1 = "0x1";
 
-    function setUp() public {}
+    function setUp() public {
+        // Start with system manager privileges for all tests
+        changePrank(sm.addr);
+    }
 
     function testD03CreateEntity() public {
         // Test entity created in D03ProtocolDefaults
@@ -23,7 +26,7 @@ contract T03SystemFacetTest is D03ProtocolDefaults, MockAccounts {
     function testUnsupportedExternalTokenWhenCreatingEntity() public {
         bytes32 objectId1 = "0x1";
         vm.expectRevert("external token is not supported");
-        nayms.createEntity(objectId1, objectContext1, initEntity(wbtcId, LibConstants.BP_FACTOR, LibConstants.BP_FACTOR, false), "entity test hash");
+        nayms.createEntity(objectId1, objectContext1, initEntity(wbtcId, LC.BP_FACTOR, LC.BP_FACTOR, false), "entity test hash");
     }
 
     function testZeroCollateralRatioWhenCreatingEntity() public {
@@ -37,28 +40,28 @@ contract T03SystemFacetTest is D03ProtocolDefaults, MockAccounts {
 
         vm.expectRevert("not a system manager");
         changePrank(account1);
-        nayms.createEntity(objectId1, objectContext1, initEntity(wethId, 5000, LibConstants.BP_FACTOR, true), "entity test hash");
+        nayms.createEntity(objectId1, objectContext1, initEntity(wethId, 5000, LC.BP_FACTOR, true), "entity test hash");
     }
 
     function testSingleCreateEntity() public {
         bytes32 objectId1 = "0x1";
-        nayms.createEntity(objectId1, objectContext1, initEntity(wethId, 5000, LibConstants.BP_FACTOR, true), "entity test hash");
+        nayms.createEntity(objectId1, objectContext1, initEntity(wethId, 5000, LC.BP_FACTOR, true), "entity test hash");
     }
 
     function testMultipleCreateEntity() public {
         bytes32 objectId1 = "0x1";
-        nayms.createEntity(objectId1, objectContext1, initEntity(wethId, 5000, LibConstants.BP_FACTOR, true), "entity test hash");
+        nayms.createEntity(objectId1, objectContext1, initEntity(wethId, 5000, LC.BP_FACTOR, true), "entity test hash");
 
         // cannot create an object that already exists in a given context
         vm.expectRevert(abi.encodePacked(CreatingEntityThatAlreadyExists.selector, (objectId1)));
-        nayms.createEntity(objectId1, objectContext1, initEntity(wethId, 5000, LibConstants.BP_FACTOR, true), "entity test hash");
+        nayms.createEntity(objectId1, objectContext1, initEntity(wethId, 5000, LC.BP_FACTOR, true), "entity test hash");
 
         // still reverts regardless of role being assigned
         vm.expectRevert(abi.encodePacked(CreatingEntityThatAlreadyExists.selector, (objectId1)));
-        nayms.createEntity(objectId1, objectContext1, initEntity(wethId, 5000, LibConstants.BP_FACTOR, true), "entity test hash");
+        nayms.createEntity(objectId1, objectContext1, initEntity(wethId, 5000, LC.BP_FACTOR, true), "entity test hash");
 
         bytes32 objectId2 = "0x2";
-        nayms.createEntity(objectId2, objectContext1, initEntity(wethId, 5000, LibConstants.BP_FACTOR, true), "entity test hash");
+        nayms.createEntity(objectId2, objectContext1, initEntity(wethId, 5000, LC.BP_FACTOR, true), "entity test hash");
     }
 
     function testStringToBytes32() public {
@@ -69,14 +72,14 @@ contract T03SystemFacetTest is D03ProtocolDefaults, MockAccounts {
     function testIsObject() public {
         bytes32 objectId2 = "0x2";
         assertFalse(nayms.isObject(objectId2));
-        nayms.createEntity(objectId2, objectContext1, initEntity(wethId, 5000, LibConstants.BP_FACTOR, true), "entity test hash");
+        nayms.createEntity(objectId2, objectContext1, initEntity(wethId, 5000, LC.BP_FACTOR, true), "entity test hash");
         assertTrue(nayms.isObject(objectId2));
     }
 
     function testGetObjectMeta() public {
         bytes32 objectId2 = "0x2";
 
-        nayms.createEntity(objectId2, objectContext1, initEntity(wethId, 5000, LibConstants.BP_FACTOR, true), "entity test hash");
+        nayms.createEntity(objectId2, objectContext1, initEntity(wethId, 5000, LC.BP_FACTOR, true), "entity test hash");
         (bytes32 parent, bytes32 dataHash, string memory tokenSymbol, string memory tokenName, address wrapperAddress) = nayms.getObjectMeta(objectId2);
 
         assertEq(dataHash, "entity test hash");

--- a/test/T03TokenizedVault.t.sol
+++ b/test/T03TokenizedVault.t.sol
@@ -466,11 +466,9 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         assertEq(nayms.internalBalanceOf(eBob, nWETH), 1 ether + totalFees_, "eBob's nWETH balance should INCREASE");
 
         changePrank(sm.addr);
-        // nayms.assignRole(bobId, eAlice, LC.ROLE_ENTITY_CP);
         nayms.assignRole(eBob, eBob, LC.ROLE_ENTITY_CP);
         changePrank(bob);
         nayms.executeLimitOffer(nWETH, 1 ether, eAlice, 1e18);
-        // nayms.executeLimitOffer(nWETH, 1 ether, eBob, 1e18);
         vm.stopPrank();
 
         assertEq(nayms.internalBalanceOf(eBob, nWETH), 0, "eBob's nWETH balance should DECREASE");

--- a/test/T03TokenizedVault.t.sol
+++ b/test/T03TokenizedVault.t.sol
@@ -275,9 +275,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         nayms.externalDeposit(wethAddress, 1 ether);
         changePrank(account9);
 
-        bytes32 role = nayms.getRoleInContext(account9._getIdForAddress(), nayms.getEntity(account9._getIdForAddress()));
-        string memory roleString = string(role._bytes32ToBytes());
-        vm.expectRevert(abi.encodeWithSelector(InvalidGroupPrivilege.selector, acc9Id, acc0EntityId, roleString, LC.GROUP_PAY_DIVIDEND_FROM_ENTITY));
+        vm.expectRevert(abi.encodeWithSelector(InvalidGroupPrivilege.selector, acc9Id, acc0EntityId, "", LC.GROUP_PAY_DIVIDEND_FROM_ENTITY));
         nayms.payDividendFromEntity(bytes32("0x1"), 1 ether);
     }
 
@@ -307,11 +305,8 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         changePrank(sm.addr);
         nayms.setEntity(nonAdminId, acc0EntityId);
 
-        bytes32 role = nayms.getRoleInContext(account9._getIdForAddress(), nayms.getEntity(account9._getIdForAddress()));
-        string memory roleString = string(role._bytes32ToBytes());
-
         changePrank(nonAdminAddress);
-        vm.expectRevert(abi.encodeWithSelector(InvalidGroupPrivilege.selector, nonAdminId, acc0EntityId, roleString, LC.GROUP_PAY_DIVIDEND_FROM_ENTITY));
+        vm.expectRevert(abi.encodeWithSelector(InvalidGroupPrivilege.selector, nonAdminId, acc0EntityId, "", LC.GROUP_PAY_DIVIDEND_FROM_ENTITY));
         nayms.payDividendFromEntity(randomGuid, 10 ether);
 
         changePrank(em.addr);

--- a/test/T03TokenizedVault.t.sol
+++ b/test/T03TokenizedVault.t.sol
@@ -274,7 +274,10 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         writeTokenBalance(account0, naymsAddress, wethAddress, depositAmount);
         nayms.externalDeposit(wethAddress, 1 ether);
         changePrank(account9);
-        vm.expectRevert(abi.encodeWithSelector(InvalidGroupPrivilege.selector, acc9Id, acc0EntityId, "", LC.GROUP_PAY_DIVIDEND_FROM_ENTITY));
+
+        bytes32 role = nayms.getRoleInContext(account9._getIdForAddress(), nayms.getEntity(account9._getIdForAddress()));
+        string memory roleString = string(role._bytes32ToBytes());
+        vm.expectRevert(abi.encodeWithSelector(InvalidGroupPrivilege.selector, acc9Id, acc0EntityId, roleString, LC.GROUP_PAY_DIVIDEND_FROM_ENTITY));
         nayms.payDividendFromEntity(bytes32("0x1"), 1 ether);
     }
 
@@ -304,8 +307,11 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         changePrank(sm.addr);
         nayms.setEntity(nonAdminId, acc0EntityId);
 
+        bytes32 role = nayms.getRoleInContext(account9._getIdForAddress(), nayms.getEntity(account9._getIdForAddress()));
+        string memory roleString = string(role._bytes32ToBytes());
+
         changePrank(nonAdminAddress);
-        vm.expectRevert(abi.encodeWithSelector(InvalidGroupPrivilege.selector, nonAdminId, acc0EntityId, "", LC.GROUP_PAY_DIVIDEND_FROM_ENTITY));
+        vm.expectRevert(abi.encodeWithSelector(InvalidGroupPrivilege.selector, nonAdminId, acc0EntityId, roleString, LC.GROUP_PAY_DIVIDEND_FROM_ENTITY));
         nayms.payDividendFromEntity(randomGuid, 10 ether);
 
         changePrank(em.addr);

--- a/test/T03TokenizedVault.t.sol
+++ b/test/T03TokenizedVault.t.sol
@@ -408,7 +408,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         assertEq(nayms.internalBalanceOf(signer1EntityId, nWETH), calculatedTakerAmount, "balance of signer1's entity should be the their buy amount minus the commission fees"); // order filled minus trading commissions)
     }
 
-    function testMultipleDepositDividendss() public {
+    function testMultipleDepositDividends() public {
         // naming conventions for this test:
         // alice == account0
         // aliceId == account0Id

--- a/test/T03TokenizedVault.t.sol
+++ b/test/T03TokenizedVault.t.sol
@@ -2,15 +2,17 @@
 pragma solidity 0.8.17;
 
 import { MockAccounts } from "./utils/users/MockAccounts.sol";
-import { console2, D03ProtocolDefaults, LibHelpers, LibConstants } from "./defaults/D03ProtocolDefaults.sol";
+import { console2, D03ProtocolDefaults, LibHelpers, LC } from "./defaults/D03ProtocolDefaults.sol";
 import { Entity, CalculatedFees } from "src/diamonds/nayms/AppStorage.sol";
 import { IDiamondCut } from "src/diamonds/nayms/INayms.sol";
 import { TokenizedVaultFixture } from "test/fixtures/TokenizedVaultFixture.sol";
+import "src/diamonds/nayms/interfaces/CustomErrors.sol";
 
 // solhint-disable max-states-count
 // solhint-disable no-console
 
 contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
+    using LibHelpers for *;
     bytes32 internal nWETH;
     bytes32 internal nWBTC;
     bytes32 internal dividendBankId;
@@ -50,16 +52,17 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
     function setUp() public {
         nWETH = LibHelpers._getIdForAddress(wethAddress);
         nWBTC = LibHelpers._getIdForAddress(wbtcAddress);
-        dividendBankId = LibHelpers._stringToBytes32(LibConstants.DIVIDEND_BANK_IDENTIFIER);
+        dividendBankId = LibHelpers._stringToBytes32(LC.DIVIDEND_BANK_IDENTIFIER);
 
         nayms.addSupportedExternalToken(wbtcAddress);
         entityWbtc = Entity({
             assetId: LibHelpers._getIdForAddress(wbtcAddress),
-            collateralRatio: LibConstants.BP_FACTOR,
+            collateralRatio: LC.BP_FACTOR,
             maxCapacity: 100 ether,
             utilizedCapacity: 0,
             simplePolicyEnabled: true
         });
+        changePrank(sm.addr);
         nayms.createEntity(bytes32("0x11111"), davidId, entityWbtc, "entity wbtc test hash");
         nayms.createEntity(bytes32("0x22222"), emilyId, entityWbtc, "entity wbtc test hash");
         nayms.createEntity(bytes32("0x33333"), faithId, entityWbtc, "entity wbtc test hash");
@@ -94,6 +97,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
     }
 
     function testEntityTokenSymbolUniqueness() public {
+        changePrank(sm.addr);
         bytes32 entityId = createTestEntity(account0Id);
         bytes32 entityId2 = createTestEntityWithId(account0Id, "0xe2");
         bytes32 entityId3 = createTestEntityWithId(account0Id, "0xe3");
@@ -108,6 +112,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
     }
 
     function testGetLockedBalance() public {
+        changePrank(sm.addr);
         bytes32 entityId = createTestEntity(account0Id);
 
         // nothing at first
@@ -121,10 +126,17 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
     }
 
     function testSingleExternalDeposit() public {
+        changePrank(sm.addr);
         nayms.createEntity(entity1, signer1Id, initEntity(wethId, collateralRatio_500, maxCapital_3000eth, true), "entity test hash");
         nayms.createEntity(entity2, signer2Id, initEntity(wethId, collateralRatio_500, maxCapital_3000eth, true), "entity test hash");
 
         uint256 externalDepositAmount = depositAmount / 5;
+
+        // note The following test shows that it's currently possible for a system admin to assign a
+        // ROLE_ENTITY_ADMIN in the systemContext, which will pass the permissions check, but externalDeposit()
+        // will revert if the user does not have an assigned valid parent entity.
+        changePrank(systemAdmin);
+        nayms.assignRole(address(999999)._getIdForAddress(), systemContext, LC.ROLE_ENTITY_ADMIN);
 
         // note: deposits must be an existing entity: s.existingEntities[_receiverId]
         changePrank(address(999999));
@@ -181,21 +193,14 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         bytes32 signer1Id = LibHelpers._getIdForAddress(_signer1);
         bytes32 signer2Id = LibHelpers._getIdForAddress(_signer2);
 
+        changePrank(sm.addr);
         nayms.createEntity(_entity1, signer1Id, initEntity(wethId, collateralRatio_500, maxCapital_3000eth, true), "entity test hash");
         nayms.createEntity(_entity2, signer2Id, initEntity(wethId, collateralRatio_500, maxCapital_3000eth, true), "entity test hash");
 
         uint256 externalDepositAmount = depositAmount / 5;
 
-        // note: deposits must be an existing entity: s.existingEntities[_receiverId]
-        changePrank(address(999999));
-        writeTokenBalance(address(999999), naymsAddress, wethAddress, depositAmount);
-
-        vm.expectRevert("extDeposit: invalid receiver");
-        nayms.externalDeposit(wethAddress, depositAmount);
-        vm.stopPrank();
-
         // deposit to entity1
-        vm.startPrank(_signer1);
+        changePrank(_signer1);
         writeTokenBalance(_signer1, naymsAddress, wethAddress, depositAmount);
         nayms.externalDeposit(wethAddress, externalDepositAmount);
         vm.stopPrank();
@@ -216,6 +221,9 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
     }
 
     function testSingleInternalTransferFromEntity() public {
+        // note Add a role to GROUP_INTERNAL_TRANSFER_FROM_ENTITY to allow internalTransferFromEntity
+        nayms.updateRoleGroup(LC.ROLE_ENTITY_ADMIN, LC.GROUP_INTERNAL_TRANSFER_FROM_ENTITY, true);
+
         bytes32 acc0EntityId = nayms.getEntity(account0Id);
 
         assertEq(nayms.internalBalanceOf(account0Id, nWETH), 0, "account0Id nWETH balance should start at 0");
@@ -253,8 +261,9 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         assertEq(nayms.internalTokenSupply(nWETH), naymsWethInternalTokenSupply - 100, "nayms burned internal WETH");
     }
 
-    function testOnlyEntityAdminCanPayDividend() public {
+    function testOnlyRolesInGroupPayDividendFromEntityCanPayDividend() public {
         bytes32 acc0EntityId = nayms.getEntity(account0Id);
+        changePrank(sm.addr);
         nayms.enableEntityTokenization(acc0EntityId, "E1", "E1");
         nayms.startTokenSale(acc0EntityId, 1 ether, 1 ether);
 
@@ -265,12 +274,13 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         writeTokenBalance(account0, naymsAddress, wethAddress, depositAmount);
         nayms.externalDeposit(wethAddress, 1 ether);
         changePrank(account9);
-        vm.expectRevert("payDividendFromEntity: not the entity's admin");
+        vm.expectRevert(abi.encodeWithSelector(InvalidGroupPrivilege.selector, acc9Id, acc0EntityId, "", LC.GROUP_PAY_DIVIDEND_FROM_ENTITY));
         nayms.payDividendFromEntity(bytes32("0x1"), 1 ether);
     }
 
     function testPayDividendsWithZeroParticipationTokenSupply() public {
         bytes32 acc0EntityId = nayms.getEntity(account0Id);
+        nayms.assignRole(em.id, acc0EntityId, LC.ROLE_ENTITY_MANAGER);
 
         assertEq(nayms.internalBalanceOf(acc0EntityId, nWETH), 0, "account0Id nWETH balance should start at 0");
 
@@ -291,13 +301,15 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
 
         address nonAdminAddress = vm.addr(0xACC9);
         bytes32 nonAdminId = LibHelpers._getIdForAddress(nonAdminAddress);
-        changePrank(systemAdmin);
+        changePrank(sm.addr);
         nayms.setEntity(nonAdminId, acc0EntityId);
 
         changePrank(nonAdminAddress);
-        vm.expectRevert("payDividendFromEntity: not the entity's admin");
+        vm.expectRevert(abi.encodeWithSelector(InvalidGroupPrivilege.selector, nonAdminId, acc0EntityId, "", LC.GROUP_PAY_DIVIDEND_FROM_ENTITY));
         nayms.payDividendFromEntity(randomGuid, 10 ether);
 
+        changePrank(em.addr);
+        nayms.assignRole(account0Id, acc0EntityId, LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
         changePrank(account0);
         vm.expectRevert("payDividendFromEntity: insufficient balance");
         nayms.payDividendFromEntity(randomGuid, 10 ether);
@@ -313,6 +325,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
     // start token sale, pay dividend,
     function testPayDividendsWithNonZeroParticipationTokenSupply() public {
         bytes32 acc0EntityId = nayms.getEntity(account0Id);
+        nayms.assignRole(em.id, acc0EntityId, LC.ROLE_ENTITY_MANAGER);
 
         assertEq(nayms.internalBalanceOf(account0Id, nWETH), 0, "acc0EntityId nWETH balance should start at 0");
 
@@ -327,7 +340,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         // No withdrawable dividends.
         assertEq(withdrawableDiv, 0);
 
-        changePrank(systemAdmin);
+        changePrank(sm.addr);
         // note: starting a token sale which mints participation tokens
         nayms.enableEntityTokenization(eAlice, "eAlice", "eAlice");
         nayms.startTokenSale(acc0EntityId, 1e18, 1e18);
@@ -335,6 +348,9 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         // check token supply of participation token (entity token)
         assertEq(nayms.internalTokenSupply(acc0EntityId), 1 ether, "");
         bytes32 randomGuid = bytes32("0x1");
+
+        changePrank(em.addr);
+        nayms.assignRole(account0Id, acc0EntityId, LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
 
         changePrank(account0);
         nayms.payDividendFromEntity(randomGuid, 1 ether);
@@ -357,14 +373,17 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
 
         // give signer1's entity nWETH
         nayms.externalDeposit(wethAddress, 2 ether);
-        vm.stopPrank();
         assertEq(nayms.internalBalanceOf(signer1EntityId, nWETH), 2 ether, "signer1EntityId nWETH balance should INCREASE (mint)");
         assertEq(nayms.internalBalanceOf(dividendBankId, nWETH), 1 ether, "dividendBankId nWETH balance should STAY THE SAME");
         assertEq(nayms.internalTokenSupply(nWETH), 3 ether, "nWETH total supply should INCREASE (mint)");
 
+        changePrank(sm.addr);
+        nayms.assignRole(signer1Id, systemContext, LC.ROLE_ENTITY_CP);
+
         // the taker's buy amount
         uint256 takerBuyAmount = 1 ether;
-        vm.prank(signer1);
+        changePrank(signer1);
+        nayms.internalBalanceOf(signer1Id, nWETH);
         nayms.executeLimitOffer(nWETH, 1 ether, acc0EntityId, takerBuyAmount);
 
         assertEq(nayms.internalBalanceOf(dividendBankId, nWETH), 1 ether - 1 ether, "The dividend should've been transferred when executeLimitOffer() is called and executed");
@@ -376,7 +395,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         );
         nayms.internalBalanceOf(signer1Id, nWETH); // no change
 
-        vm.startPrank(account0);
+        changePrank(account0);
         nayms.withdrawDividend(acc0EntityId, nWETH, nWETH);
         nayms.withdrawAllDividends(account0Id, nWETH);
         assertEq(nayms.internalBalanceOf(acc0EntityId, nWETH), 2 ether, "acc0EntityId nWETH balance should STAY THE SAME");
@@ -388,7 +407,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         assertEq(nayms.internalBalanceOf(signer1EntityId, nWETH), calculatedTakerAmount, "balance of signer1's entity should be the their buy amount minus the commission fees"); // order filled minus trading commissions)
     }
 
-    function testMultipleDepositDividend() public {
+    function testMultipleDepositDividendss() public {
         // naming conventions for this test:
         // alice == account0
         // aliceId == account0Id
@@ -402,11 +421,13 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         eAlice = nayms.getEntity(account0Id);
         eBob = nayms.getEntity(signer1Id);
 
+        nayms.assignRole(em.id, eAlice, LC.ROLE_ENTITY_MANAGER);
+
         changePrank(alice);
         writeTokenBalance(alice, naymsAddress, wethAddress, depositAmount);
 
         // note: starting a token sale which mints participation tokens
-        changePrank(systemAdmin);
+        changePrank(sm.addr);
         nayms.enableEntityTokenization(eAlice, "eAlice", "eAlice");
         nayms.startTokenSale(eAlice, 1e18, 1e18);
 
@@ -419,6 +440,10 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         assertEq(nayms.internalTokenSupply(nWETH), 1 ether, "nWETH token supply should INCREASE (mint)");
         assertEq(nayms.internalBalanceOf(eAlice, nWETH), 1 ether, "eAlice's nWETH balance should INCREASE (deposit)");
 
+        changePrank(em.addr);
+        nayms.assignRole(aliceId, eAlice, LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
+
+        changePrank(alice);
         bytes32 randomGuid = bytes32("0x1");
         nayms.payDividendFromEntity(randomGuid, 1 ether); // eAlice is paying out a dividend
         assertEq(nayms.internalBalanceOf(eAlice, nWETH), 1 ether - 1 ether, "eAlice's nWETH balance should DECREASE (transfer to dividend bank)");
@@ -439,7 +464,12 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         nayms.externalDeposit(wethAddress, 1 ether + totalFees_);
         assertEq(nayms.internalBalanceOf(eBob, nWETH), 1 ether + totalFees_, "eBob's nWETH balance should INCREASE");
 
+        changePrank(sm.addr);
+        // nayms.assignRole(bobId, eAlice, LC.ROLE_ENTITY_CP);
+        nayms.assignRole(eBob, eBob, LC.ROLE_ENTITY_CP);
+        changePrank(bob);
         nayms.executeLimitOffer(nWETH, 1 ether, eAlice, 1e18);
+        // nayms.executeLimitOffer(nWETH, 1 ether, eBob, 1e18);
         vm.stopPrank();
 
         assertEq(nayms.internalBalanceOf(eBob, nWETH), 0, "eBob's nWETH balance should DECREASE");
@@ -453,6 +483,14 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         eBob = nayms.getEntity(signer1Id);
         address charlie = signer2;
         bytes32 eCharlie = nayms.getEntity(signer2Id);
+
+        changePrank(sm.addr);
+        nayms.assignRole(eBob, eBob, LC.ROLE_ENTITY_CP);
+        nayms.assignRole(eCharlie, eCharlie, LC.ROLE_ENTITY_CP);
+        changePrank(sa.addr);
+        nayms.assignRole(em.id, systemContext, LC.ROLE_ENTITY_MANAGER);
+        changePrank(em.addr);
+        nayms.assignRole(aliceId, nayms.getEntity(aliceId), LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
 
         changePrank(alice);
         writeTokenBalance(alice, naymsAddress, wethAddress, depositAmount);
@@ -472,7 +510,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         nayms.externalDeposit(wethAddress, 17_000 + totalFees_);
 
         // note: starting a token sale which mints participation tokens
-        changePrank(systemAdmin);
+        changePrank(sm.addr);
         nayms.enableEntityTokenization(eAlice, "eAlice", "eAlice");
         nayms.startTokenSale(eAlice, 20_000, 20_000);
 
@@ -535,6 +573,13 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         bobEAliceBuyAmount = bound(bobEAliceBuyAmount, 10_000, type(uint128).max);
         require(bobEAliceBuyAmount >= 10_000 && bobEAliceBuyAmount <= type(uint128).max);
 
+        changePrank(sm.addr);
+        nayms.assignRole(eBob, eBob, LC.ROLE_ENTITY_CP);
+        changePrank(sa.addr);
+        nayms.assignRole(em.id, systemContext, LC.ROLE_ENTITY_MANAGER);
+        changePrank(em.addr);
+        nayms.assignRole(aliceId, nayms.getEntity(aliceId), LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
+
         changePrank(alice);
         writeTokenBalance(alice, naymsAddress, wethAddress, type(uint256).max);
 
@@ -548,7 +593,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         console2.log("commissions amount:", totalFees_);
 
         // note: starting a token sale which mints participation tokens
-        changePrank(systemAdmin);
+        changePrank(sm.addr);
         nayms.enableEntityTokenization(eAlice, "eAlice", "eAlice");
         nayms.startTokenSale(eAlice, eAliceParTokenSaleAmount, eAliceParTokenPrice);
 
@@ -605,6 +650,18 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         address charlie = signer2;
         bytes32 eCharlie = nayms.getEntity(signer2Id);
 
+        changePrank(sm.addr);
+        nayms.assignRole(eBob, eBob, LC.ROLE_ENTITY_CP);
+        nayms.assignRole(eCharlie, eCharlie, LC.ROLE_ENTITY_CP);
+        nayms.assignRole(eDavid, eDavid, LC.ROLE_ENTITY_CP);
+        nayms.assignRole(eEmily, eEmily, LC.ROLE_ENTITY_CP);
+        nayms.assignRole(eFaith, eFaith, LC.ROLE_ENTITY_CP);
+        changePrank(sa.addr);
+        nayms.assignRole(em.id, systemContext, LC.ROLE_ENTITY_MANAGER);
+        changePrank(em.addr);
+        nayms.assignRole(aliceId, nayms.getEntity(aliceId), LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
+        nayms.assignRole(eDavid, eDavid, LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
+
         changePrank(alice);
         writeTokenBalance(alice, naymsAddress, wethAddress, depositAmount);
         writeTokenBalance(alice, naymsAddress, wbtcAddress, depositAmount);
@@ -640,7 +697,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         assertEq(nayms.internalBalanceOf(eBob, nWETH), 3_000 + bobTotalFees_);
         assertEq(nayms.internalBalanceOf(eEmily, nWBTC), 3_000 + emiliyTotalFees_);
 
-        changePrank(systemAdmin);
+        changePrank(sm.addr);
         // note: starting a token sale which mints participation tokens
         nayms.enableEntityTokenization(eAlice, "eAlice", "eAlice");
         nayms.enableEntityTokenization(eDavid, "eDavid", "eDavid");
@@ -750,23 +807,31 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
 
         changePrank(bob);
         writeTokenBalance(bob, naymsAddress, wethAddress, depositAmount);
-        uint256 totalFees = (defaultTradingFeeBP * 3_000) / LibConstants.BP_FACTOR;
+        uint256 totalFees = (defaultTradingFeeBP * 3_000) / LC.BP_FACTOR;
         nayms.externalDeposit(wethAddress, 3_000 + totalFees);
         assertEq(nayms.internalBalanceOf(eBob, nWETH), 3_000 + totalFees);
 
         changePrank(charlie);
         writeTokenBalance(charlie, naymsAddress, wethAddress, depositAmount);
-        totalFees = (defaultTradingFeeBP * 17_000) / LibConstants.BP_FACTOR;
+        totalFees = (defaultTradingFeeBP * 17_000) / LC.BP_FACTOR;
         nayms.externalDeposit(wethAddress, 17_000 + totalFees);
 
         // note: starting a token sale which mints participation tokens
-        changePrank(systemAdmin);
+        changePrank(sm.addr);
         nayms.enableEntityTokenization(eAlice, "eAlice", "eAlice");
         nayms.startTokenSale(eAlice, 20_000, 20_000);
+        changePrank(sa.addr);
+        nayms.assignRole(em.id, systemContext, LC.ROLE_ENTITY_MANAGER);
+        changePrank(em.addr);
+        nayms.assignRole(aliceId, nayms.getEntity(aliceId), LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
 
         // check token supply of participation token (entity token)
         assertEq(nayms.internalTokenSupply(eAlice), 20_000, "eAlice participation token supply should INCREASE (mint)");
         assertEq(nayms.internalBalanceOf(eAlice, eAlice), 20_000, "eAlice's eAlice balance should INCREASE (mint)");
+
+        changePrank(sm.addr);
+        nayms.assignRole(eBob, eBob, LC.ROLE_ENTITY_CP);
+        nayms.assignRole(eCharlie, eCharlie, LC.ROLE_ENTITY_CP);
 
         changePrank(bob);
         nayms.executeLimitOffer(nWETH, 3_000, eAlice, 3_000); // 1:1 purchase price
@@ -781,6 +846,9 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
 
         assertEq(nayms.getWithdrawableDividend(eBob, eAlice, nWETH), 0);
         assertEq(nayms.getWithdrawableDividend(eCharlie, eAlice, nWETH), 0);
+
+        changePrank(em.addr);
+        nayms.assignRole(aliceId, nayms.getEntity(aliceId), LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
 
         changePrank(alice);
         nayms.payDividendFromEntity(bytes32("0x1"), 40_000); // eAlice is paying out a dividend
@@ -852,11 +920,19 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
             simplePolicyEnabled: true 
         });
 
+        changePrank(sm.addr);
         bytes32 entity0Id = bytes32("0xe1");
         bytes32 entity1Id = bytes32("0xe2");
         nayms.createEntity(entity0Id, account0Id, e, "test");
         nayms.createEntity(entity1Id, signer1Id, e, "test");
 
+        nayms.assignRole(nayms.getEntity(signer1Id), nayms.getEntity(signer1Id), LC.ROLE_ENTITY_CP);
+        changePrank(sa.addr);
+        nayms.assignRole(em.id, systemContext, LC.ROLE_ENTITY_MANAGER);
+        changePrank(em.addr);
+        nayms.assignRole(aliceId, nayms.getEntity(aliceId), LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
+
+        changePrank(sm.addr);
         // 1. ---- start token sale ----
         nayms.enableEntityTokenization(entity0Id, "e0token", "e0token");
 
@@ -939,12 +1015,19 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         bob = signer1;
         eAlice = nayms.getEntity(account0Id);
         eBob = nayms.getEntity(signer1Id);
-        nayms.enableEntityTokenization(eAlice, "eAlice", "eAlice");
         changePrank(alice);
         writeTokenBalance(alice, naymsAddress, wethAddress, depositAmount);
+        changePrank(sm.addr);
+        nayms.assignRole(eAlice, eAlice, LC.ROLE_ENTITY_CP);
+        nayms.assignRole(eBob, eBob, LC.ROLE_ENTITY_CP);
+        changePrank(sa.addr);
+        nayms.assignRole(em.id, systemContext, LC.ROLE_ENTITY_MANAGER);
+        changePrank(em.addr);
+        nayms.assignRole(aliceId, eAlice, LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
 
         // STAGE 1: Alice is starting an eAlice token sale.
-        changePrank(systemAdmin);
+        changePrank(sm.addr);
+        nayms.enableEntityTokenization(eAlice, "eAlice", "eAlice");
         uint256 tokenAmount = 1e18;
         nayms.startTokenSale(eAlice, tokenAmount, tokenAmount);
         changePrank(alice);
@@ -998,7 +1081,14 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         bob = signer1;
         eAlice = nayms.getEntity(account0Id);
         eBob = nayms.getEntity(signer1Id);
+        changePrank(sm.addr);
         nayms.enableEntityTokenization(eAlice, "eAlice", "eAlice");
+        nayms.assignRole(eBob, eBob, LC.ROLE_ENTITY_CP);
+        changePrank(sa.addr);
+        nayms.assignRole(em.id, systemContext, LC.ROLE_ENTITY_MANAGER);
+        changePrank(em.addr);
+        nayms.assignRole(aliceId, nayms.getEntity(aliceId), LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
+
         changePrank(alice);
         writeTokenBalance(alice, naymsAddress, wethAddress, depositAmount);
 
@@ -1007,7 +1097,7 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         assertEq(nayms.internalBalanceOf(eAlice, nWETH), eAliceStartAmount, "eAlice's nWETH balance should INCREASE");
 
         // 2. Alice starts a sale, selling 100 ALICE tokens for 100 WETH;
-        changePrank(systemAdmin);
+        changePrank(sm.addr);
         uint256 tokenAmount = 100e18;
         nayms.startTokenSale(eAlice, tokenAmount, tokenAmount);
 

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -43,6 +43,8 @@ contract T04EntityTest is D03ProtocolDefaults {
         cut[0] = IDiamondCut.FacetCut({ facetAddress: address(simplePolicyFixture), action: IDiamondCut.FacetCutAction.Add, functionSelectors: funcSelectors });
 
         scheduleAndUpgradeDiamond(cut);
+
+        changePrank(sm.addr);
     }
 
     function getSimplePolicy(bytes32 _policyId) internal returns (SimplePolicy memory) {
@@ -70,7 +72,7 @@ contract T04EntityTest is D03ProtocolDefaults {
         assertEq(weth.balanceOf(account0), amount);
         nayms.externalDeposit(wethAddress, amount);
         assertEq(nayms.internalBalanceOf(entityId1, wethId), amount);
-        changePrank(systemAdmin);
+        changePrank(su.addr);
     }
 
     function testDomainSeparator() public {
@@ -128,9 +130,9 @@ contract T04EntityTest is D03ProtocolDefaults {
         nayms.enableEntityTokenization(entityId1, "1234567890123456", "1234567890123456");
 
         changePrank(signer1);
-        vm.expectRevert("not a system admin");
+        vm.expectRevert("not a system manager");
         nayms.enableEntityTokenization(entityId1, "123456789012345", "1234567890123456");
-        changePrank(systemAdmin);
+        changePrank(sm.addr);
 
         vm.expectRevert("name must not be empty");
         nayms.enableEntityTokenization(entityId1, "123456789012345", "");
@@ -149,9 +151,9 @@ contract T04EntityTest is D03ProtocolDefaults {
         string memory newTokenName = "New Test Token";
 
         changePrank(signer1);
-        vm.expectRevert("not a system admin");
+        vm.expectRevert("not a system manager");
         nayms.updateEntityTokenInfo(entityId1, newTokenSymbol, newTokenName);
-        changePrank(systemAdmin);
+        changePrank(sm.addr);
 
         vm.recordLogs();
         nayms.updateEntityTokenInfo(entityId1, newTokenSymbol, newTokenName);
@@ -173,7 +175,9 @@ contract T04EntityTest is D03ProtocolDefaults {
         nayms.createEntity(entityId1, account0Id, initEntity(0, 0, 0, false), testPolicyDataHash);
         console2.log(" >>> CREATED");
 
+        changePrank(systemAdmin);
         nayms.addSupportedExternalToken(address(wbtc));
+        changePrank(sm.addr);
         vm.expectRevert("assetId change not allowed");
         nayms.updateEntity(entityId1, initEntity(wbtcId, 10_000, 0, false));
 
@@ -216,7 +220,9 @@ contract T04EntityTest is D03ProtocolDefaults {
     }
 
     function testUpdateCellCollateralRatio() public {
+        changePrank(sm.addr);
         nayms.createEntity(entityId1, account0Id, initEntity(wethId, 5_000, 30_000, true), "test entity");
+        changePrank(systemAdmin);
         nayms.assignRole(account0Id, entityId1, LC.ROLE_ENTITY_ADMIN);
 
         // fund the entity balance
@@ -228,7 +234,7 @@ contract T04EntityTest is D03ProtocolDefaults {
 
         assertEq(nayms.getLockedBalance(entityId1, wethId), 0, "NO FUNDS should be locked");
 
-        changePrank(systemAdmin);
+        changePrank(su.addr);
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
         uint256 expectedLockedBalance = (simplePolicy.limit * 5_000) / LC.BP_FACTOR;
         assertEq(nayms.getLockedBalance(entityId1, wethId), expectedLockedBalance, "funds SHOULD BE locked");
@@ -236,6 +242,7 @@ contract T04EntityTest is D03ProtocolDefaults {
         Entity memory entity1 = nayms.getEntityInfo(entityId1);
         assertEq(entity1.utilizedCapacity, (simplePolicy.limit * 5_000) / LC.BP_FACTOR, "utilized capacity should increase");
 
+        changePrank(sm.addr);
         entity1.collateralRatio = 7_000;
         vm.expectRevert("collateral ratio invalid, not enough balance");
         nayms.updateEntity(entityId1, entity1);
@@ -258,6 +265,7 @@ contract T04EntityTest is D03ProtocolDefaults {
         Entity memory entity1AfterUpdate = nayms.getEntityInfo(entityId1);
         assertEq(entity1AfterUpdate.utilizedCapacity, (simplePolicy.limit * 4_000) / LC.BP_FACTOR, "utilized capacity should increase");
 
+        changePrank(su.addr);
         nayms.cancelSimplePolicy(policyId1);
         assertEq(nayms.getLockedBalance(entityId1, wethId), 0, "locked balance SHOULD be released");
         Entity memory entity1After2ndUpdate = nayms.getEntityInfo(entityId1);
@@ -308,7 +316,7 @@ contract T04EntityTest is D03ProtocolDefaults {
 
         Stakeholders memory stakeholders2 = Stakeholders(roles, entityIds, signatures);
 
-        changePrank(systemAdmin);
+        changePrank(su.addr);
         vm.expectRevert(abi.encodeWithSelector(DuplicateSignerCreatingSimplePolicy.selector, alice, bob));
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders2, simplePolicy, testPolicyDataHash);
     }
@@ -358,17 +366,20 @@ contract T04EntityTest is D03ProtocolDefaults {
 
         Stakeholders memory stakeholders2 = Stakeholders(roles, entityIds, signatures);
 
-        changePrank(systemAdmin);
+        changePrank(su.addr);
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders2, simplePolicy, testPolicyDataHash);
     }
 
     function testCreateSimplePolicyValidation() public {
         nayms.createEntity(entityId1, account0Id, initEntity(wethId, LC.BP_FACTOR, LC.BP_FACTOR, false), "entity test hash");
 
+        changePrank(su.addr);
         // enable simple policy creation
         vm.expectRevert("simple policy creation disabled");
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
+        changePrank(sm.addr);
         nayms.updateEntity(entityId1, initEntity(wethId, LC.BP_FACTOR, LC.BP_FACTOR, true));
+        changePrank(su.addr);
 
         // stakeholders entity ids array different length to signatures array
         bytes[] memory sig = stakeholders.signatures;
@@ -395,29 +406,33 @@ contract T04EntityTest is D03ProtocolDefaults {
         simplePolicy.asset = LibHelpers._getIdForAddress(wbtcAddress);
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
 
+        changePrank(sa.addr);
         nayms.addSupportedExternalToken(wbtcAddress);
         simplePolicy.asset = wbtcId;
+        changePrank(su.addr);
         vm.expectRevert("asset not matching with entity");
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
         simplePolicy.asset = wethId;
 
-        // test caller is system manager
-        vm.expectRevert("not a system manager");
+        // test caller is not system underwriter
         changePrank(account9);
+        vm.expectRevert(abi.encodeWithSelector(NotSystemUnderwriter.selector, account9));
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
 
-        changePrank(systemAdmin);
+        changePrank(su.addr);
         // test capacity
         vm.expectRevert("not enough available capacity");
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
 
+        changePrank(sm.addr);
         // update max capacity
         nayms.updateEntity(entityId1, initEntity(wethId, 5000, 300000, true));
-
+        changePrank(su.addr);
         // test collateral ratio constraint
         vm.expectRevert("not enough capital");
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
 
+        changePrank(sm.addr);
         // fund the policy sponsor entity
         nayms.updateEntity(entityId1, initEntity(wethId, 5000, 300000, true));
         changePrank(account0);
@@ -426,7 +441,7 @@ contract T04EntityTest is D03ProtocolDefaults {
         nayms.externalDeposit(wethAddress, 100000);
         assertEq(nayms.internalBalanceOf(entityId1, wethId), 100000);
 
-        changePrank(systemAdmin);
+        changePrank(su.addr);
 
         // start date too early
         uint256 blockTimestampBeforeWarp;
@@ -459,15 +474,19 @@ contract T04EntityTest is D03ProtocolDefaults {
         bytes32[] memory r;
         uint16[] memory bp;
 
+        changePrank(systemAdmin);
         nayms.addFeeSchedule(LC.DEFAULT_FEE_SCHEDULE, LC.FEE_TYPE_PREMIUM, r, bp);
+        changePrank(su.addr);
         vm.expectRevert("must have fee schedule receivers");
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
 
         // add back fee receiver
         r = b32Array1(NAYMS_LTD_IDENTIFIER);
         bp = u16Array1(300);
+        changePrank(systemAdmin);
         nayms.addFeeSchedule(LC.DEFAULT_FEE_SCHEDULE, LC.FEE_TYPE_PREMIUM, r, bp);
 
+        changePrank(su.addr);
         vm.expectRevert("number of commissions don't match");
         bytes32[] memory commissionReceiversOrig = simplePolicy.commissionReceivers;
         simplePolicy.commissionReceivers = new bytes32[](0);
@@ -572,13 +591,15 @@ contract T04EntityTest is D03ProtocolDefaults {
             // check permissions
             assertEq(nayms.getEntity(signerId), stakeholders.entityIds[i], "must be parent");
 
+            changePrank(sm.addr);
             // change parent
             nayms.setEntity(signerId, bytes32("e0"));
-
+            changePrank(su.addr);
             // try creating
             vm.expectRevert();
             nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
 
+            changePrank(sm.addr);
             nayms.setEntity(signerId, stakeholders.entityIds[i]);
         }
     }
@@ -624,6 +645,7 @@ contract T04EntityTest is D03ProtocolDefaults {
         // create entity with 100% collateral ratio
         nayms.createEntity(entityId1, account0Id, initEntity(wethId, 10_000, 30_000, true), "test entity");
 
+        changePrank(systemAdmin);
         // assign entity admin
         nayms.assignRole(account0Id, entityId1, LC.ROLE_ENTITY_ADMIN);
 
@@ -633,7 +655,7 @@ contract T04EntityTest is D03ProtocolDefaults {
         writeTokenBalance(account0, naymsAddress, wethAddress, amount);
         nayms.externalDeposit(wethAddress, amount);
 
-        changePrank(systemAdmin);
+        changePrank(su.addr);
         // create policyId1 with limit of 21000
         (stakeholders, simplePolicy) = initPolicyWithLimit(testPolicyDataHash, 21000);
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
@@ -641,6 +663,12 @@ contract T04EntityTest is D03ProtocolDefaults {
         assertEq(nayms.getEntityInfo(entityId1).utilizedCapacity, 21000, "entity utilization should INCREASE when a policy is created");
         assertEq(nayms.getLockedBalance(entityId1, simplePolicy.asset), 21000, "entity locked balance should INCREASE when a policy is created");
 
+        changePrank(sa.addr);
+        nayms.assignRole(em.id, systemContext, LC.ROLE_ENTITY_MANAGER);
+        changePrank(em.addr);
+        nayms.assignRole(account0Id, nayms.getEntity(account0Id), LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
+
+        changePrank(account0);
         // note: entity with 100% CR should be able to pay the claim - claim amount comes from the locked balance (locked in the policy)
         nayms.paySimpleClaim(LibHelpers._stringToBytes32("claimId"), policyId1, DEFAULT_INSURED_PARTY_ENTITY_ID, 2);
         assertEq(nayms.internalBalanceOf(entityId1, simplePolicy.asset), 21000 - 2, "entity balance of nWETH should DECREASE by pay claim amount");
@@ -650,6 +678,7 @@ contract T04EntityTest is D03ProtocolDefaults {
         // increase max cap from 30_000 to 221_000
         Entity memory newEInfo = nayms.getEntityInfo(entityId1);
         newEInfo.maxCapacity = 221_000;
+        changePrank(sm.addr);
         nayms.updateEntity(entityId1, newEInfo);
 
         changePrank(account0);
@@ -657,7 +686,7 @@ contract T04EntityTest is D03ProtocolDefaults {
         nayms.externalDeposit(wethAddress, 200_000);
         assertEq(nayms.internalBalanceOf(entityId1, simplePolicy.asset), 20998 + 200_000, "after deposit, entity balance of nWETH should INCREASE");
 
-        changePrank(systemAdmin);
+        changePrank(su.addr);
         bytes32 policyId2 = LibHelpers._stringToBytes32("policyId2");
 
         (stakeholders, simplePolicy) = initPolicyWithLimit(testPolicyDataHash, 200_001);
@@ -669,10 +698,12 @@ contract T04EntityTest is D03ProtocolDefaults {
         nayms.createSimplePolicy(policyId2, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
         assertEq(nayms.getLockedBalance(entityId1, simplePolicy.asset), 21000 - 2 + 200_000, "locked balance should INCREASE");
 
+        changePrank(account0);
         nayms.paySimpleClaim(LibHelpers._stringToBytes32("claimId2"), policyId1, DEFAULT_INSURED_PARTY_ENTITY_ID, 3);
 
         nayms.paySimpleClaim(LibHelpers._stringToBytes32("claimId3"), policyId2, DEFAULT_INSURED_PARTY_ENTITY_ID, 3);
 
+        changePrank(su.addr);
         nayms.cancelSimplePolicy(policyId1);
 
         assertEq(nayms.getLockedBalance(entityId1, simplePolicy.asset), 200_000 - 3, "after cancelling policy, the locked balance should DECREASE");
@@ -686,7 +717,12 @@ contract T04EntityTest is D03ProtocolDefaults {
 
     function testSimplePolicyEntityCapitalUtilization50CR() public {
         getReadyToCreatePolicies();
+        changePrank(sa.addr);
+        nayms.assignRole(em.id, systemContext, LC.ROLE_ENTITY_MANAGER);
+        changePrank(em.addr);
+        nayms.assignRole(account0Id, nayms.getEntity(account0Id), LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
 
+        changePrank(su.addr);
         (stakeholders, simplePolicy) = initPolicyWithLimit(testPolicyDataHash, 42002);
         vm.expectRevert("not enough capital");
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
@@ -696,15 +732,14 @@ contract T04EntityTest is D03ProtocolDefaults {
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
         assertEq(nayms.getLockedBalance(entityId1, simplePolicy.asset), 21000, "locked balance should INCREASE");
 
+        changePrank(account0);
         vm.expectRevert("_internalTransfer: insufficient balance available, funds locked");
         nayms.paySimpleClaim(LibHelpers._stringToBytes32("claimId"), policyId1, DEFAULT_INSURED_PARTY_ENTITY_ID, 2);
 
-        changePrank(account0);
         writeTokenBalance(account0, naymsAddress, wethAddress, 1);
         nayms.externalDeposit(wethAddress, 1);
         assertEq(nayms.internalBalanceOf(entityId1, simplePolicy.asset), 21001, "entity balance of nWETH should INCREASE by deposit amount");
 
-        changePrank(systemAdmin);
         nayms.paySimpleClaim(LibHelpers._stringToBytes32("claimId"), policyId1, DEFAULT_INSURED_PARTY_ENTITY_ID, 2); // claiming 2
         assertEq(nayms.internalBalanceOf(entityId1, simplePolicy.asset), 20999, "entity balance of nWETH should DECREASE by pay claim amount");
         assertEq(nayms.getEntityInfo(entityId1).utilizedCapacity, 21000 - 1, "entity utilization should DECREASE when a claim is made");
@@ -718,11 +753,12 @@ contract T04EntityTest is D03ProtocolDefaults {
         // increase max cap from 30_000 to 221_000
         Entity memory newEInfo = nayms.getEntityInfo(entityId1);
         newEInfo.maxCapacity = 221_000;
-        changePrank(systemAdmin);
+        changePrank(sm.addr);
         nayms.updateEntity(entityId1, newEInfo);
 
         bytes32 policyId2 = LibHelpers._stringToBytes32("policyId2");
 
+        changePrank(su.addr);
         (stakeholders, simplePolicy) = initPolicyWithLimit(testPolicyDataHash, 400_003);
         vm.expectRevert("not enough capital");
         nayms.createSimplePolicy(policyId2, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
@@ -732,12 +768,14 @@ contract T04EntityTest is D03ProtocolDefaults {
         nayms.createSimplePolicy(policyId2, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
         assertEq(nayms.getLockedBalance(entityId1, simplePolicy.asset), 21000 - 1 + 200_000, "locked balance should INCREASE");
 
+        changePrank(account0);
         vm.expectRevert("_internalTransfer: insufficient balance available, funds locked");
         nayms.paySimpleClaim(LibHelpers._stringToBytes32("claimId2"), policyId1, DEFAULT_INSURED_PARTY_ENTITY_ID, 3);
 
         vm.expectRevert("_internalTransfer: insufficient balance available, funds locked");
         nayms.paySimpleClaim(LibHelpers._stringToBytes32("claimId2"), policyId2, DEFAULT_INSURED_PARTY_ENTITY_ID, 3);
 
+        changePrank(su.addr);
         nayms.cancelSimplePolicy(policyId1);
 
         assertEq(nayms.getLockedBalance(entityId1, simplePolicy.asset), 21000 - 1 + 200_000 - 20999, "after cancelling policy, the locked balance should DECREASE");
@@ -748,7 +786,6 @@ contract T04EntityTest is D03ProtocolDefaults {
 
         nayms.externalWithdrawFromEntity(entityId1, account0, wethAddress, 21_000 - 1);
 
-        changePrank(systemAdmin);
         vm.expectRevert("_internalTransfer: insufficient balance available, funds locked");
         nayms.paySimpleClaim(LibHelpers._stringToBytes32("claimId2"), policyId2, DEFAULT_INSURED_PARTY_ENTITY_ID, 1);
 
@@ -756,7 +793,6 @@ contract T04EntityTest is D03ProtocolDefaults {
         writeTokenBalance(account0, naymsAddress, wethAddress, 1);
         nayms.externalDeposit(wethAddress, 1);
 
-        changePrank(systemAdmin);
         vm.expectRevert("_internalTransfer: insufficient balance available, funds locked");
         nayms.paySimpleClaim(LibHelpers._stringToBytes32("claimId2"), policyId2, DEFAULT_INSURED_PARTY_ENTITY_ID, 3);
 
@@ -765,7 +801,12 @@ contract T04EntityTest is D03ProtocolDefaults {
 
     function testSimplePolicyLockedBalancesAfterPaySimpleClaim() public {
         getReadyToCreatePolicies();
+        changePrank(sa.addr);
+        nayms.assignRole(em.id, systemContext, LC.ROLE_ENTITY_MANAGER);
+        changePrank(em.addr);
+        nayms.assignRole(account0Id, nayms.getEntity(account0Id), LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
 
+        changePrank(su.addr);
         (stakeholders, simplePolicy) = initPolicyWithLimit(testPolicyDataHash, 42002);
         vm.expectRevert("not enough capital");
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
@@ -775,14 +816,13 @@ contract T04EntityTest is D03ProtocolDefaults {
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
         assertEq(nayms.getLockedBalance(entityId1, simplePolicy.asset), 21000, "locked balance should INCREASE");
 
+        changePrank(account0);
         vm.expectRevert("_internalTransfer: insufficient balance available, funds locked");
         nayms.paySimpleClaim(LibHelpers._stringToBytes32("claimId"), policyId1, DEFAULT_INSURED_PARTY_ENTITY_ID, 21000);
 
         changePrank(account0);
         writeTokenBalance(account0, naymsAddress, wethAddress, 20000);
         nayms.externalDeposit(wethAddress, 20000);
-
-        changePrank(systemAdmin);
 
         nayms.paySimpleClaim(LibHelpers._stringToBytes32("claimId"), policyId1, DEFAULT_INSURED_PARTY_ENTITY_ID, 21000);
         assertEq(nayms.getLockedBalance(entityId1, simplePolicy.asset), 10500, "locked balance should DECREASE by half");
@@ -802,9 +842,16 @@ contract T04EntityTest is D03ProtocolDefaults {
 
     function testSimplePolicyPremiumsCommissionsClaims() public {
         getReadyToCreatePolicies();
+        changePrank(sa.addr);
+        nayms.assignRole(em.id, systemContext, LC.ROLE_ENTITY_MANAGER);
+        changePrank(em.addr);
+        nayms.assignRole(account0Id, nayms.getEntity(account0Id), LC.ROLE_ENTITY_COMPTROLLER_COMBINED);
+
+        changePrank(su.addr);
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
 
-        vm.expectRevert("not a policy handler");
+        changePrank(account0);
+        vm.expectRevert(); // u
         nayms.paySimplePremium(policyId1, 1000);
 
         changePrank(signer2);
@@ -850,7 +897,7 @@ contract T04EntityTest is D03ProtocolDefaults {
             assertEq(nayms.internalBalanceOf(DEFAULT_INSURED_PARTY_ENTITY_ID, wethId), balanceBeforePremium - premiumAmount);
         }
 
-        vm.startPrank(systemAdmin);
+        vm.startPrank(account0);
 
         simplePolicy.cancelled = true;
         updateSimplePolicy(policyId1, simplePolicy);
@@ -861,21 +908,18 @@ contract T04EntityTest is D03ProtocolDefaults {
         updateSimplePolicy(policyId1, simplePolicy);
 
         changePrank(account9);
-        vm.expectRevert("not a system manager");
+        vm.expectRevert();
         nayms.paySimpleClaim(LibHelpers._stringToBytes32("claimId"), policyId1, DEFAULT_INSURED_PARTY_ENTITY_ID, 10000);
 
-        changePrank(systemAdmin);
-
-        vm.expectRevert("not an insured party");
+        vm.expectRevert(); // does not have comptroller combined | comptroller cliam role
         nayms.paySimpleClaim(LibHelpers._stringToBytes32("claimId"), policyId1, 0, 10000);
+
+        changePrank(account0);
 
         vm.expectRevert("invalid claim amount");
         nayms.paySimpleClaim(LibHelpers._stringToBytes32("claimId"), policyId1, DEFAULT_INSURED_PARTY_ENTITY_ID, 0);
 
-        // setup insured party account
-        nayms.assignRole(LibHelpers._getIdForAddress(signer4), DEFAULT_INSURED_PARTY_ENTITY_ID, LC.ROLE_INSURED_PARTY);
-        assertTrue(nayms.isInGroup(LibHelpers._getIdForAddress(signer4), DEFAULT_INSURED_PARTY_ENTITY_ID, LC.GROUP_INSURED_PARTIES));
-        nayms.setEntity(LibHelpers._getIdForAddress(signer4), DEFAULT_INSURED_PARTY_ENTITY_ID);
+        changePrank(account0);
 
         vm.expectRevert("exceeds policy limit");
         nayms.paySimpleClaim(LibHelpers._stringToBytes32("claimId"), policyId1, DEFAULT_INSURED_PARTY_ENTITY_ID, 100001);
@@ -906,11 +950,11 @@ contract T04EntityTest is D03ProtocolDefaults {
         nayms.enableEntityTokenization(entityId1, "e1token", "e1token");
 
         changePrank(account9);
-        vm.expectRevert("not a system manager");
+        vm.expectRevert();
         nayms.startTokenSale(entityId1, sellAmount, sellAtPrice);
         vm.stopPrank();
 
-        vm.startPrank(systemAdmin);
+        vm.startPrank(sm.addr);
         vm.expectRevert("mint amount must be > 0");
         nayms.startTokenSale(entityId1, 0, sellAtPrice);
 

--- a/test/T05TokenWrapper.t.sol
+++ b/test/T05TokenWrapper.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import { Vm } from "forge-std/Vm.sol";
 
-import { D03ProtocolDefaults, console2 } from "./defaults/D03ProtocolDefaults.sol";
+import { D03ProtocolDefaults, console2 as console, LC } from "./defaults/D03ProtocolDefaults.sol";
 import { Entity } from "src/diamonds/nayms/interfaces/FreeStructs.sol";
 import { ERC20Wrapper } from "../src/erc20/ERC20Wrapper.sol";
 
@@ -26,15 +26,22 @@ contract T05TokenWrapper is D03ProtocolDefaults {
     }
 
     function testWrapEntityToken() public {
+        changePrank(sm.addr);
         nayms.createEntity(entityId1, account0Id, initEntity(wethId, 5_000, 30_000, true), "test");
         nayms.createEntity(entityId2, signer2Id, initEntity(wethId, 5_000, 30_000, true), "test");
 
+        bytes32 eSigner2 = nayms.getEntity(signer2Id);
+        nayms.assignRole(eSigner2, eSigner2, LC.ROLE_ENTITY_CP);
+
+        changePrank(sa.addr);
         vm.expectRevert("must be tokenizable");
         nayms.wrapToken(entityId1);
 
+        changePrank(sm.addr);
         nayms.enableEntityTokenization(entityId1, testSymbol, testName);
-
         nayms.startTokenSale(entityId1, tokenAmount, tokenAmount);
+
+        changePrank(sa.addr);
 
         vm.recordLogs();
 

--- a/test/TNaymsToken.t.sol
+++ b/test/TNaymsToken.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import { Vm } from "forge-std/Vm.sol";
 
-import { D03ProtocolDefaults, LibAdmin, LibConstants } from "./defaults/D03ProtocolDefaults.sol";
+import { D03ProtocolDefaults, LibAdmin } from "./defaults/D03ProtocolDefaults.sol";
 import { INayms, IDiamondCut } from "src/diamonds/nayms/INayms.sol";
 
 /// @notice Contains tests for Nayms ERC20 token

--- a/test/defaults/D01Deployment.sol
+++ b/test/defaults/D01Deployment.sol
@@ -32,7 +32,6 @@ abstract contract D01Deployment is D00GlobalDefaults, DeploymentHelpers {
     address public systemAdmin;
     bytes32 public systemAdminId;
 
-    string constant GROUP_ADMINS = "new admin group";
     struct NaymsAccount {
         bytes32 id;
         bytes32 entityId;
@@ -119,12 +118,10 @@ abstract contract D01Deployment is D00GlobalDefaults, DeploymentHelpers {
             nayms.updateRoleAssigner(LC.ROLE_ENTITY_COMPTROLLER_CLAIM, LC.GROUP_ENTITY_MANAGERS);
             nayms.updateRoleAssigner(LC.ROLE_ENTITY_COMPTROLLER_DIVIDEND, LC.GROUP_ENTITY_MANAGERS);
 
-            nayms.updateRoleGroup(LC.ROLE_SYSTEM_ADMIN, GROUP_ADMINS, true);
-            nayms.updateRoleAssigner(LC.ROLE_SYSTEM_ADMIN, GROUP_ADMINS);
-            nayms.updateRoleAssigner(LC.ROLE_SYSTEM_MANAGER, GROUP_ADMINS);
-            nayms.updateRoleAssigner(LC.ROLE_SYSTEM_UNDERWRITER, GROUP_ADMINS);
-            nayms.updateRoleAssigner(LC.ROLE_ENTITY_ADMIN, GROUP_ADMINS);
-            nayms.updateRoleAssigner(LC.ROLE_ENTITY_MANAGER, GROUP_ADMINS);
+            nayms.updateRoleAssigner(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_SYSTEM_ADMINS);
+            nayms.updateRoleAssigner(LC.ROLE_SYSTEM_UNDERWRITER, LC.GROUP_SYSTEM_ADMINS);
+            nayms.updateRoleAssigner(LC.ROLE_ENTITY_ADMIN, LC.GROUP_SYSTEM_ADMINS);
+            nayms.updateRoleAssigner(LC.ROLE_ENTITY_MANAGER, LC.GROUP_SYSTEM_ADMINS);
 
             // Setup roles which can call functions
             nayms.updateRoleGroup(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_START_TOKEN_SALE, true);

--- a/test/defaults/D01Deployment.sol
+++ b/test/defaults/D01Deployment.sol
@@ -13,6 +13,7 @@ import { LibHelpers } from "src/diamonds/nayms/libs/LibHelpers.sol";
 
 import { LibGeneratedNaymsFacetHelpers } from "script/utils/LibGeneratedNaymsFacetHelpers.sol";
 import { DeploymentHelpers } from "script/utils/DeploymentHelpers.sol";
+import { LibConstants as LC } from "src/diamonds/nayms/libs/LibConstants.sol";
 
 /// @notice Default test setup part 01
 ///         Deploy and initialize Nayms platform
@@ -31,6 +32,7 @@ abstract contract D01Deployment is D00GlobalDefaults, DeploymentHelpers {
     address public systemAdmin;
     bytes32 public systemAdminId;
 
+    string constant GROUP_ADMINS = "new admin group";
     struct NaymsAccount {
         bytes32 id;
         bytes32 entityId;
@@ -97,6 +99,56 @@ abstract contract D01Deployment is D00GlobalDefaults, DeploymentHelpers {
             // initialize the diamond as well as cut in all facets
             INayms.FacetCut[] memory cut = LibGeneratedNaymsFacetHelpers.createNaymsDiamondFunctionsCut(naymsFacetAddresses);
             scheduleAndUpgradeDiamond(cut, address(initDiamond), abi.encodeCall(initDiamond.initialize, ()));
+
+            // Remove system admin from system managers group
+            nayms.updateRoleGroup(LC.ROLE_SYSTEM_ADMIN, LC.GROUP_SYSTEM_MANAGERS, false);
+
+            nayms.updateRoleGroup(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_SYSTEM_MANAGERS, true);
+            nayms.updateRoleAssigner(LC.ROLE_ENTITY_CP, LC.GROUP_SYSTEM_MANAGERS);
+
+            nayms.updateRoleGroup(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_MANAGERS, true);
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_MANAGER, LC.GROUP_MANAGERS, true);
+            nayms.updateRoleAssigner(LC.ROLE_ENTITY_BROKER, LC.GROUP_MANAGERS);
+            nayms.updateRoleAssigner(LC.ROLE_ENTITY_INSURED, LC.GROUP_MANAGERS);
+
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_MANAGER, LC.GROUP_ENTITY_MANAGERS, true);
+            nayms.updateRoleAssigner(LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.GROUP_ENTITY_MANAGERS);
+            nayms.updateRoleAssigner(LC.ROLE_ENTITY_COMPTROLLER_WITHDRAW, LC.GROUP_ENTITY_MANAGERS);
+            nayms.updateRoleAssigner(LC.ROLE_ENTITY_COMPTROLLER_CLAIM, LC.GROUP_ENTITY_MANAGERS);
+            nayms.updateRoleAssigner(LC.ROLE_ENTITY_COMPTROLLER_DIVIDEND, LC.GROUP_ENTITY_MANAGERS);
+
+            nayms.updateRoleGroup(LC.ROLE_SYSTEM_ADMIN, GROUP_ADMINS, true);
+            nayms.updateRoleAssigner(LC.ROLE_SYSTEM_ADMIN, GROUP_ADMINS);
+            nayms.updateRoleAssigner(LC.ROLE_SYSTEM_MANAGER, GROUP_ADMINS);
+            nayms.updateRoleAssigner(LC.ROLE_SYSTEM_UNDERWRITER, GROUP_ADMINS);
+            nayms.updateRoleAssigner(LC.ROLE_ENTITY_ADMIN, GROUP_ADMINS);
+            nayms.updateRoleAssigner(LC.ROLE_ENTITY_MANAGER, GROUP_ADMINS);
+
+            // Setup roles which can call functions
+            nayms.updateRoleGroup(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_START_TOKEN_SALE, true);
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_MANAGER, LC.GROUP_START_TOKEN_SALE, true);
+
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_MANAGER, LC.GROUP_CANCEL_OFFER, true);
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_CP, LC.GROUP_CANCEL_OFFER, true);
+
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_CP, LC.GROUP_EXECUTE_LIMIT_OFFER, true);
+
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_BROKER, LC.GROUP_PAY_SIMPLE_PREMIUM, true);
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_INSURED, LC.GROUP_PAY_SIMPLE_PREMIUM, true);
+
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.GROUP_PAY_SIMPLE_CLAIM, true);
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_CLAIM, LC.GROUP_PAY_SIMPLE_CLAIM, true);
+
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.GROUP_PAY_DIVIDEND_FROM_ENTITY, true);
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_DIVIDEND, LC.GROUP_PAY_DIVIDEND_FROM_ENTITY, true);
+
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_ADMIN, LC.GROUP_EXTERNAL_DEPOSIT, true);
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.GROUP_EXTERNAL_DEPOSIT, true);
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_WITHDRAW, LC.GROUP_EXTERNAL_DEPOSIT, true);
+
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_ADMIN, LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY, true);
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_COMBINED, LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY, true);
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_COMPTROLLER_WITHDRAW, LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY, true);
         }
     }
 

--- a/test/defaults/D01Deployment.sol
+++ b/test/defaults/D01Deployment.sol
@@ -103,6 +103,8 @@ abstract contract D01Deployment is D00GlobalDefaults, DeploymentHelpers {
             // Remove system admin from system managers group
             nayms.updateRoleGroup(LC.ROLE_SYSTEM_ADMIN, LC.GROUP_SYSTEM_MANAGERS, false);
 
+            nayms.updateRoleGroup(LC.ROLE_SYSTEM_UNDERWRITER, LC.GROUP_SYSTEM_UNDERWRITERS, true);
+
             nayms.updateRoleGroup(LC.ROLE_SYSTEM_MANAGER, LC.GROUP_SYSTEM_MANAGERS, true);
             nayms.updateRoleAssigner(LC.ROLE_ENTITY_CP, LC.GROUP_SYSTEM_MANAGERS);
 


### PR DESCRIPTION
**Overview**

The new roles and groups that are set by the system admin can be seen in D01Deployment.

We have new groups used on function calls. The roles added to these groups (via `updateRoleGroup`) are the roles that can call the function. 

**Changes**
Updated behavior of `isInGroup`

- Previous Behavior: This method checked the user's role in both the given context and, if unsuccessful, the system context as a fallback.

- New Behavior: It now solely checks the user's role in the provided context, with no fallbacks.

Updated behavior of `canAssign`. 

- Previous Behavior: If a user's parent possessed an assigner role, the user was inherently granted the capability to assign a role to an object.

- New Behavior: The role of a user's parent has been decoupled and now bears no influence on the user's ability to assign roles.

Added the modifier `assertHasGroupPrivilege`. 

- This modifier restricts function calls to certain roles.

Added `hasGroupPrivilege` 

`hasGroupPrivilege` has checks in this order:

- User's parent's role is in the given group, context.

- User's role is in the given group, context.

- User's role is in the given group, system context.

**Todo**
- [x] Make a decision: either remove `canAssign` or `canAssignRole`. Both methods currently do the same thing. 
	- Decision: removed `canAssignRole`
- [ ] Cleanup old roles and groups from `LibConstants`
