### PR TITLE
Withdraw restriction

### DIFF
--- a/src/diamonds/nayms/facets/TokenizedVaultIOFacet.sol
+++ b/src/diamonds/nayms/facets/TokenizedVaultIOFacet.sol
@@ -9,6 +9,9 @@ import { LibObject } from "../libs/LibObject.sol";
 import { ReentrancyGuard } from "../../../utils/ReentrancyGuard.sol";
 import { ITokenizedVaultIOFacet } from "../interfaces/ITokenizedVaultIOFacet.sol";
 import { LibConstants as LC } from "../libs/LibConstants.sol";
+import { LibACL } from "../libs/LibACL.sol";
+import { LibHelpers } from "../libs/LibHelpers.sol";
+import { ExternalWithdrawInvalidReceiver } from "../interfaces/CustomErrors.sol";
 
 /**
  * @title Token Vault IO
@@ -52,6 +55,8 @@ contract TokenizedVaultIOFacet is ITokenizedVaultIOFacet, Modifiers, ReentrancyG
         address _externalTokenAddress,
         uint256 _amount
     ) external notLocked(msg.sig) nonReentrant assertHasGroupPrivilege(LibObject._getParentFromAddress(msg.sender), LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY) {
+        if (!LibACL._hasGroupPrivilege(LibHelpers._getIdForAddress(_receiver), _entityId, LibHelpers._stringToBytes32(LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY)))
+            revert ExternalWithdrawInvalidReceiver(_receiver);
         LibTokenizedVaultIO._externalWithdraw(_entityId, _receiver, _externalTokenAddress, _amount);
     }
 }

--- a/src/diamonds/nayms/interfaces/CustomErrors.sol
+++ b/src/diamonds/nayms/interfaces/CustomErrors.sol
@@ -47,6 +47,9 @@ error ExternalDepositAmountCannotBeZero();
 /// @dev Passing in 0 amount for withdraws is not allowed.
 error ExternalWithdrawAmountCannotBeZero();
 
+/// @dev The receiver of the withdraw must haveGroupPriviledge with the roles entity admin, comptroller combined, or comptroller withdraw.
+error ExternalWithdrawInvalidReceiver(address receiver);
+
 /// @dev Cannot create a simple policy with policyId of 0
 error PolicyIdCannotBeZero();
 

--- a/test/T03TokenizedVault.t.sol
+++ b/test/T03TokenizedVault.t.sol
@@ -252,7 +252,13 @@ contract T03TokenizedVaultTest is D03ProtocolDefaults, MockAccounts {
         uint256 entity1WethInternalBalance = nayms.internalBalanceOf(entity1, nWETH);
         uint256 naymsWethInternalTokenSupply = nayms.internalTokenSupply(nWETH);
 
-        vm.prank(signer1);
+        vm.startPrank(sa.addr);
+        nayms.assignRole(em.id, entity1, LC.ROLE_ENTITY_MANAGER);
+
+        changePrank(em);
+        nayms.assignRole(account0Id, entity1, LC.ROLE_ENTITY_COMPTROLLER_WITHDRAW);
+
+        changePrank(signer1);
         nayms.externalWithdrawFromEntity(entity1, account0, wethAddress, 100);
 
         assertEq(weth.balanceOf(account0), account0WethBalanceAccount0 + 100, "account0 got WETH");

--- a/test/defaults/D01Deployment.sol
+++ b/test/defaults/D01Deployment.sol
@@ -44,6 +44,11 @@ abstract contract D01Deployment is D00GlobalDefaults, DeploymentHelpers {
         return NaymsAccount({ id: LibHelpers._getIdForAddress(addr), entityId: keccak256(bytes(name)), pk: privateKey, addr: addr });
     }
 
+    /// @dev Pass in a NaymsAccount to change the prank to NaymsAccount.addr
+    function changePrank(NaymsAccount memory na) public {
+        changePrank(na.addr);
+    }
+
     constructor() payable {
         console2.log("block.chainid", block.chainid);
 


### PR DESCRIPTION
Restrict the receivers of `externalWithdrawFromEntity()` to the user's parent who has one of the following roles: entity admin, comptroller combined, comptroller withdraw.