### PR TITLE
Double locked balance

### DIFF
--- a/src/diamonds/nayms/libs/LibEntity.sol
+++ b/src/diamonds/nayms/libs/LibEntity.sol
@@ -59,7 +59,8 @@ library LibEntity {
         require(simplePolicy.asset == entity.assetId, "asset not matching with entity");
 
         // Calculate the entity's utilized capacity after it writes this policy.
-        uint256 updatedUtilizedCapacity = entity.utilizedCapacity + ((simplePolicy.limit * entity.collateralRatio) / LibConstants.BP_FACTOR);
+        uint256 additionalCapacityNeeded = ((simplePolicy.limit * entity.collateralRatio) / LibConstants.BP_FACTOR);
+        uint256 updatedUtilizedCapacity = entity.utilizedCapacity + additionalCapacityNeeded;
 
         // The entity must have enough capacity available to write this policy.
         // An entity is not able to write an additional policy that will utilize its capacity beyond its assigned max capacity.
@@ -67,7 +68,7 @@ library LibEntity {
 
         // The entity's balance must be >= to the updated capacity requirement
         uint256 availableBalance = LibTokenizedVault._internalBalanceOf(_entityId, simplePolicy.asset) - LibTokenizedVault._getLockedBalance(_entityId, simplePolicy.asset);
-        require(availableBalance >= updatedUtilizedCapacity, "not enough capital");
+        require(availableBalance >= additionalCapacityNeeded, "not enough capital");
 
         require(simplePolicy.startDate >= block.timestamp, "start date < block.timestamp");
         require(simplePolicy.maturationDate > simplePolicy.startDate, "start date > maturation date");

--- a/src/diamonds/nayms/libs/LibEntity.sol
+++ b/src/diamonds/nayms/libs/LibEntity.sol
@@ -66,7 +66,8 @@ library LibEntity {
         require(entity.maxCapacity >= updatedUtilizedCapacity, "not enough available capacity");
 
         // The entity's balance must be >= to the updated capacity requirement
-        require(LibTokenizedVault._internalBalanceOf(_entityId, simplePolicy.asset) >= updatedUtilizedCapacity, "not enough capital");
+        uint256 availableBalance = LibTokenizedVault._internalBalanceOf(_entityId, simplePolicy.asset) - LibTokenizedVault._getLockedBalance(_entityId, simplePolicy.asset);
+        require(availableBalance >= updatedUtilizedCapacity, "not enough capital");
 
         require(simplePolicy.startDate >= block.timestamp, "start date < block.timestamp");
         require(simplePolicy.maturationDate > simplePolicy.startDate, "start date > maturation date");

--- a/test/T04Market.t.sol
+++ b/test/T04Market.t.sol
@@ -914,9 +914,9 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
     function testDoubleLockedBalance_IM24430() public {
         nayms.addSupportedExternalToken(usdcAddress);
 
-        uint256 attackUSDCAmount = 1000e6;
-        uint256 entity1Amount = 1000;
-        bytes32 offChainHash = 0x00a420601de63bf726c0be38414e9255d301d74ad0d820d633f3ab75effd6f5b;
+        uint256 usdc1000 = 1000e6;
+        uint256 pToken100 = 100e18;
+        uint256 pToken99 = 99e18;
 
         // prettier-ignore
         Entity memory entityData = Entity({ 
@@ -928,22 +928,22 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         });
 
         NaymsAccount memory attacker = makeNaymsAcc("Attacker");
-        NaymsAccount memory user1 = makeNaymsAcc("entityONE");
+        NaymsAccount memory userA = makeNaymsAcc("entityA");
 
         vm.startPrank(sm.addr);
 
         // createEntity for attacker
         hCreateEntity(attacker.entityId, attacker.id, entityData, "test entity");
 
-        // Attacker deposits 1000e6 USDC + trading fee
-        fundEntityUsdc(attacker, attackUSDCAmount + 1e7);
+        // Attacker deposits 1000 USDC + trading fee
+        fundEntityUsdc(attacker, usdc1000 + 1e7);
 
         vm.startPrank(sm.addr);
 
-        // user1 startTokenSale with (1000 pToken for 1000.000001 USDC)
-        hCreateEntity(user1.entityId, user1.id, entityData, "entity test hash");
-        nayms.enableEntityTokenization(user1.entityId, "E1", "Entity 1 Token");
-        nayms.startTokenSale(user1.entityId, entity1Amount, attackUSDCAmount * 2);
+        // userA startTokenSale with (1000 pToken for 1000.000001 USDC)
+        hCreateEntity(userA.entityId, userA.id, entityData, "entity test hash");
+        nayms.enableEntityTokenization(userA.entityId, "E1", "Entity 1 Token");
+        nayms.startTokenSale(userA.entityId, pToken100, usdc1000 * 2);
 
         c.log("- [0] before attack trade".yellow());
         c.log("      internalBalance:", nayms.internalBalanceOf(attacker.entityId, usdcId));
@@ -952,7 +952,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         // Attack script
 
         vm.startPrank(attacker.addr);
-        nayms.executeLimitOffer(usdcId, attackUSDCAmount, user1.entityId, entity1Amount);
+        nayms.executeLimitOffer(usdcId, usdc1000, userA.entityId, pToken100);
 
         c.log("- [1] attack order placed".yellow());
         c.log("      internalBalance:", nayms.internalBalanceOf(attacker.entityId, usdcId));
@@ -960,19 +960,19 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
 
         vm.startPrank(su.addr);
 
-        uint256 policyLimitAmount = (attackUSDCAmount * 10_000) / entityData.collateralRatio;
-        (Stakeholders memory stakeholders, SimplePolicy memory simplePolicy) = initPolicyWithLimitAndAsset(offChainHash, policyLimitAmount, usdcId);
+        uint256 policyLimitAmount = (usdc1000 * 10_000) / entityData.collateralRatio;
+        (Stakeholders memory stakeholders, SimplePolicy memory simplePolicy) = initPolicyWithLimitAndAsset("offChainHash", policyLimitAmount, usdcId);
 
-        vm.expectRevert("not enough capital");
-        nayms.createSimplePolicy(bytes32("1"), attacker.entityId, stakeholders, simplePolicy, offChainHash);
+        // vm.expectRevert("not enough capital");
+        nayms.createSimplePolicy(bytes32("1"), attacker.entityId, stakeholders, simplePolicy, "offChainHash");
 
-        // c.log("- [2] policy created".yellow());
+        c.log("- [2] policy created".yellow());
 
-        // uint256 lockedBalance = nayms.getLockedBalance(attacker.entityId, usdcId);
-        // uint256 internalBalance = nayms.internalBalanceOf(attacker.entityId, usdcId);
-        // c.log("      internalBalance:", internalBalance);
-        // c.log("      lockedBalance:  ", lockedBalance.green());
-        // require(lockedBalance <= internalBalance, "Attack successful");
+        uint256 lockedBalance = nayms.getLockedBalance(attacker.entityId, usdcId);
+        uint256 internalBalance = nayms.internalBalanceOf(attacker.entityId, usdcId);
+        c.log("      internalBalance:", internalBalance);
+        c.log("      lockedBalance:  ", lockedBalance.green());
+        require(lockedBalance <= internalBalance, "Attack successful");
     }
 
     function fundEntityUsdc(NaymsAccount memory acc, uint256 amount) private {

--- a/test/defaults/D01Deployment.sol
+++ b/test/defaults/D01Deployment.sol
@@ -46,6 +46,7 @@ abstract contract D01Deployment is D00GlobalDefaults, DeploymentHelpers {
 
     function makeNaymsAcc(string memory name) public returns (NaymsAccount memory) {
         (address addr, uint256 privateKey) = makeAddrAndKey(name);
+        vm.label(addr, name);
         return NaymsAccount({ id: LibHelpers._getIdForAddress(addr), entityId: keccak256(bytes(name)), pk: privateKey, addr: addr });
     }
 
@@ -55,6 +56,7 @@ abstract contract D01Deployment is D00GlobalDefaults, DeploymentHelpers {
     }
 
     constructor() payable {
+        c.log("\n -- D01 Deployment Defaults\n");
         c.log("block.chainid", block.chainid);
 
         bool BOOL_FORK_TEST = vm.envOr({ name: "BOOL_FORK_TEST", defaultValue: false });
@@ -147,6 +149,7 @@ abstract contract D01Deployment is D00GlobalDefaults, DeploymentHelpers {
             nayms.updateRoleGroup(LC.ROLE_ENTITY_CP, LC.GROUP_CANCEL_OFFER, true);
 
             nayms.updateRoleGroup(LC.ROLE_ENTITY_CP, LC.GROUP_EXECUTE_LIMIT_OFFER, true);
+            nayms.updateRoleGroup(LC.ROLE_ENTITY_ADMIN, LC.GROUP_EXECUTE_LIMIT_OFFER, true);
 
             nayms.updateRoleGroup(LC.ROLE_ENTITY_BROKER, LC.GROUP_PAY_SIMPLE_PREMIUM, true);
             nayms.updateRoleGroup(LC.ROLE_ENTITY_INSURED, LC.GROUP_PAY_SIMPLE_PREMIUM, true);

--- a/test/defaults/D03ProtocolDefaults.sol
+++ b/test/defaults/D03ProtocolDefaults.sol
@@ -7,6 +7,7 @@ import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/Mes
 import { IERC20 } from "src/erc20/IERC20.sol";
 
 import { LibAdmin } from "src/diamonds/nayms/libs/LibAdmin.sol";
+import { LibObject } from "src/diamonds/nayms/libs/LibObject.sol";
 import { LibConstants as LC } from "src/diamonds/nayms/libs/LibConstants.sol";
 import { StdStyle } from "forge-std/StdStyle.sol";
 
@@ -373,6 +374,14 @@ contract D03ProtocolDefaults is T02AccessHelpers {
     }
 
     function initPolicyWithLimit(bytes32 offchainDataHash, uint256 limitAmount) internal view returns (Stakeholders memory policyStakeholders, SimplePolicy memory policy) {
+        return initPolicyWithLimitAndAsset(offchainDataHash, limitAmount, wethId);
+    }
+
+    function initPolicyWithLimitAndAsset(
+        bytes32 offchainDataHash,
+        uint256 limitAmount,
+        bytes32 assetId
+    ) internal view returns (Stakeholders memory policyStakeholders, SimplePolicy memory policy) {
         bytes32[] memory roles = new bytes32[](4);
         roles[0] = LibHelpers._stringToBytes32(LC.ROLE_UNDERWRITER);
         roles[1] = LibHelpers._stringToBytes32(LC.ROLE_BROKER);
@@ -385,33 +394,36 @@ contract D03ProtocolDefaults is T02AccessHelpers {
         entityIds[2] = DEFAULT_CAPITAL_PROVIDER_ENTITY_ID;
         entityIds[3] = DEFAULT_INSURED_PARTY_ENTITY_ID;
 
-        bytes32[] memory commissionReceivers = new bytes32[](3);
-        commissionReceivers[0] = DEFAULT_UNDERWRITER_ENTITY_ID;
-        commissionReceivers[1] = DEFAULT_BROKER_ENTITY_ID;
-        commissionReceivers[2] = DEFAULT_CAPITAL_PROVIDER_ENTITY_ID;
+        {
+            bytes32[] memory commissionReceivers = new bytes32[](3);
+            commissionReceivers[0] = DEFAULT_UNDERWRITER_ENTITY_ID;
+            commissionReceivers[1] = DEFAULT_BROKER_ENTITY_ID;
+            commissionReceivers[2] = DEFAULT_CAPITAL_PROVIDER_ENTITY_ID;
 
-        uint256[] memory commissions = new uint256[](3);
-        commissions[0] = 10;
-        commissions[1] = 10;
-        commissions[2] = 10;
+            uint256[] memory commissions = new uint256[](3);
+            commissions[0] = 10;
+            commissions[1] = 10;
+            commissions[2] = 10;
 
-        policy.startDate = block.timestamp + 1000;
-        policy.maturationDate = block.timestamp + 1000 + 2 days;
-        policy.asset = wethId;
-        policy.limit = limitAmount;
-        policy.commissionReceivers = commissionReceivers;
-        policy.commissionBasisPoints = commissions;
+            policy.startDate = block.timestamp + 1000;
+            policy.maturationDate = block.timestamp + 1000 + 2 days;
+            policy.asset = assetId;
+            policy.limit = limitAmount;
+            policy.commissionReceivers = commissionReceivers;
+            policy.commissionBasisPoints = commissions;
+        }
 
-        bytes[] memory signatures = new bytes[](4);
+        {
+            bytes[] memory signatures = new bytes[](4);
+            bytes32 signingHash = nayms.getSigningHash(policy.startDate, policy.maturationDate, policy.asset, policy.limit, offchainDataHash);
 
-        bytes32 signingHash = nayms.getSigningHash(policy.startDate, policy.maturationDate, policy.asset, policy.limit, offchainDataHash);
+            signatures[0] = initPolicySig(0xACC2, signingHash);
+            signatures[1] = initPolicySig(0xACC1, signingHash);
+            signatures[2] = initPolicySig(0xACC3, signingHash);
+            signatures[3] = initPolicySig(0xACC4, signingHash);
 
-        signatures[0] = initPolicySig(0xACC2, signingHash);
-        signatures[1] = initPolicySig(0xACC1, signingHash);
-        signatures[2] = initPolicySig(0xACC3, signingHash);
-        signatures[3] = initPolicySig(0xACC4, signingHash);
-
-        policyStakeholders = Stakeholders(roles, entityIds, signatures);
+            policyStakeholders = Stakeholders(roles, entityIds, signatures);
+        }
     }
 
     function initPolicySig(uint256 privateKey, bytes32 signingHash) internal pure returns (bytes memory sig_) {


### PR DESCRIPTION
Apparently when creating a simple policy, we only check the available balance against a desired utilised capacity, without excluding any locked funds. 

As a consequence of that, it may happen that an account gets more balance locked than the actual balance available.

Bug was originally reported through Immunefi: [IM-24430](https://bugs.immunefi.com/dashboard/submission/24430)