### PR TITLE
Order book sorting problem with small amounts

### DIFF
--- a/src/diamonds/nayms/libs/LibMarket.sol
+++ b/src/diamonds/nayms/libs/LibMarket.sol
@@ -127,11 +127,11 @@ library LibMarket {
     function _isOfferPricedLtOrEq(uint256 _lowOfferId, uint256 _highOfferId) internal view returns (bool) {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
-        uint256 lowSellAmount = s.offers[_lowOfferId].sellAmount;
-        uint256 lowBuyAmount = s.offers[_lowOfferId].buyAmount;
+        uint256 lowSellAmount = s.offers[_lowOfferId].sellAmountInitial;
+        uint256 lowBuyAmount = s.offers[_lowOfferId].buyAmountInitial;
 
-        uint256 highSellAmount = s.offers[_highOfferId].sellAmount;
-        uint256 highBuyAmount = s.offers[_highOfferId].buyAmount;
+        uint256 highSellAmount = s.offers[_highOfferId].sellAmountInitial;
+        uint256 highBuyAmount = s.offers[_highOfferId].buyAmountInitial;
 
         return lowBuyAmount * highSellAmount >= highBuyAmount * lowSellAmount;
     }

--- a/test/T04Market.t.sol
+++ b/test/T04Market.t.sol
@@ -825,6 +825,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         vm.startPrank(signer1);
         writeTokenBalance(signer1, naymsAddress, usdcAddress, dt.entity1StartingBal);
         nayms.externalDeposit(usdcAddress, dt.entity1ExternalDepositAmt);
+        vm.stopPrank();
 
         vm.startPrank(sm.addr);
         nayms.enableEntityTokenization(entity1, "E1", "Entity1");

--- a/test/T04Market.t.sol
+++ b/test/T04Market.t.sol
@@ -867,6 +867,7 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         hAssignRole(signer4Id, entity4, LC.ROLE_ENTITY_CP);
         vm.stopPrank();
 
+        // signer 2 & 3 take all the ptokens
         vm.startPrank(signer2);
         nayms.executeLimitOffer(usdcId, 200, entity1, 200); // it will be the best offer
         vm.stopPrank();
@@ -883,17 +884,14 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         nayms.executeLimitOffer(entity1, 200, usdcId, 100); // it will be the best offer now
         vm.stopPrank();
 
-        vm.startPrank(signer4); //attacker fulfills his offer using another entity with counter offer (sellAmount3, buyAmount3) = (100, 199)
+        // this one causes rounding isseue and is incorrectly added to the order book
+        vm.startPrank(signer4);
         nayms.executeLimitOffer(usdcId, 100, entity1, 199);
         vm.stopPrank();
 
-        //Then partially funfilled offer `(sellAmount2, buyAmount2) = (1, 1)` will still be the best offer
-        vm.startPrank(signer3); //attacker adds an offer (sellAmount4, buyAmount4) = (150, 100) worsethan the honest's but it will be the best one
+        vm.startPrank(signer3);
         nayms.executeLimitOffer(entity1, 150, usdcId, 100);
         vm.stopPrank();
-
-        // Now the worse offer will be shown as the best and the real best offer will be at the bottom of the sorting list
-        // assertEq(nayms.getLastOfferId(), nayms.getBestOfferId(usdcId, entity1), "Not the best offer");
 
         uint256 bestId = nayms.getBestOfferId(entity1, usdcId);
         uint256 prev1 = nayms.getOffer(bestId).rankPrev;

--- a/test/T04Market.t.sol
+++ b/test/T04Market.t.sol
@@ -808,7 +808,6 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
     }
 
     function testMessUpOrderSorting_IM24299() public {
-        nayms.addSupportedExternalToken(usdcAddress);
         assertEq(nayms.getBestOfferId(usdcId, entity1), 0, "invalid best offer, when no offer exists");
 
         vm.startPrank(sm.addr);
@@ -910,5 +909,4 @@ contract T04MarketTest is D03ProtocolDefaults, MockAccounts {
         require(price1 < price2, string.concat("best order incorrect: ", vm.toString(price1)));
         require(price2 < price3, string.concat("second best order incorrect: ", vm.toString(price2)));
     }
-
 }

--- a/test/defaults/D02TestSetup.sol
+++ b/test/defaults/D02TestSetup.sol
@@ -36,5 +36,6 @@ abstract contract D02TestSetup is D01Deployment {
 
         vm.label(wethAddress, "WETH");
         vm.label(wbtcAddress, "WBTC");
+        vm.label(usdcAddress, "USDC");
     }
 }

--- a/test/defaults/D03ProtocolDefaults.sol
+++ b/test/defaults/D03ProtocolDefaults.sol
@@ -243,6 +243,7 @@ contract D03ProtocolDefaults is T02AccessHelpers {
 
         changePrank(systemAdmin);
         nayms.addSupportedExternalToken(wethAddress);
+        nayms.addSupportedExternalToken(usdcAddress);
 
         entity = Entity({
             assetId: LibHelpers._getIdForAddress(wethAddress),


### PR DESCRIPTION
This pull request fixes the issue with order book sorting caused by an edge case when the unsettled amounts on an existing offer are very small.

Bug was originally reported through Immunefi: [IM-24299](https://bugs.immunefi.com/dashboard/submission/24299)