### PR TITLE
Double release funds

### DIFF
--- a/src/diamonds/nayms/interfaces/CustomErrors.sol
+++ b/src/diamonds/nayms/interfaces/CustomErrors.sol
@@ -92,7 +92,7 @@ error CancelCannotBeTrueWhenCreatingSimplePolicy();
 /// @dev (non specific) The policyId must exist.
 error PolicyDoesNotExist(bytes32 policyId);
 
-/// @dev It is not possible to cancel policyId after maturation date has past
+/// @dev It is not possible to cancel policyId after maturation date has passed
 error PolicyCannotCancelAfterMaturation(bytes32 policyId);
 
 /// @dev There is a duplicate address in the list of signers (the previous signer in the list is not < the next signer in the list).

--- a/src/diamonds/nayms/interfaces/CustomErrors.sol
+++ b/src/diamonds/nayms/interfaces/CustomErrors.sol
@@ -92,5 +92,8 @@ error CancelCannotBeTrueWhenCreatingSimplePolicy();
 /// @dev (non specific) The policyId must exist.
 error PolicyDoesNotExist(bytes32 policyId);
 
+/// @dev It is not possible to cancel policyId after maturation date has past
+error PolicyCannotCancelAfterMaturation(bytes32 policyId);
+
 /// @dev There is a duplicate address in the list of signers (the previous signer in the list is not < the next signer in the list).
 error DuplicateSignerCreatingSimplePolicy(address previousSigner, address nextSigner);

--- a/src/diamonds/nayms/libs/LibSimplePolicy.sol
+++ b/src/diamonds/nayms/libs/LibSimplePolicy.sol
@@ -11,7 +11,7 @@ import { LibFeeRouter } from "./LibFeeRouter.sol";
 import { LibHelpers } from "./LibHelpers.sol";
 import { LibEIP712 } from "src/diamonds/nayms/libs/LibEIP712.sol";
 
-import { EntityDoesNotExist, PolicyDoesNotExist } from "src/diamonds/nayms/interfaces/CustomErrors.sol";
+import { EntityDoesNotExist, PolicyDoesNotExist, PolicyCannotCancelAfterMaturation } from "src/diamonds/nayms/interfaces/CustomErrors.sol";
 
 library LibSimplePolicy {
     event SimplePolicyMatured(bytes32 indexed id);
@@ -98,6 +98,10 @@ library LibSimplePolicy {
         AppStorage storage s = LibAppStorage.diamondStorage();
         SimplePolicy storage simplePolicy = s.simplePolicies[_policyId];
         require(!simplePolicy.cancelled, "Policy already cancelled");
+
+        if (block.timestamp >= simplePolicy.maturationDate) {
+            revert PolicyCannotCancelAfterMaturation(_policyId);
+        }
 
         releaseFunds(_policyId);
         simplePolicy.cancelled = true;

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -1071,26 +1071,19 @@ contract T04EntityTest is D03ProtocolDefaults {
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
 
         uint256 lockedAmount = nayms.getLockedBalance(entityId1, wethId);
-        c.log(" -[ POLICY ]- locked balance:", lockedAmount.green());
 
         bytes32 policyId2 = makeId(LC.OBJECT_TYPE_POLICY, address(bytes20("0xC0FFEF")));
         (stakeholders, simplePolicy) = initPolicyWithLimit(testPolicyDataHash, limitAmount);
         nayms.createSimplePolicy(policyId2, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
 
         lockedAmount = nayms.getLockedBalance(entityId1, wethId);
-        c.log(" -[ POLICY2 ]- locked balance:", lockedAmount.green());
 
         vm.warp(block.timestamp + 3 days);
         nayms.checkAndUpdateSimplePolicyState(policyId1);
-        c.log(" -[ HEARTBEAT ]- done".yellow());
 
         lockedAmount = nayms.getLockedBalance(entityId1, wethId);
-        // assertEq(lockedAmount, 0, "Invalid locked amount after maturation");
-        c.log(" -[ HEARTBEAT ]- locked balance:", lockedAmount.green());
 
+        vm.expectRevert(abi.encodeWithSelector(PolicyCannotCancelAfterMaturation.selector, policyId1));
         nayms.cancelSimplePolicy(policyId1);
-        lockedAmount = nayms.getLockedBalance(entityId1, wethId);
-
-        c.log(" -[ CANCEL ]- locked balance:", lockedAmount.green());
     }
 }


### PR DESCRIPTION
The issue occurs when cancelling a simple policy which has passed it's maturation date and collateral funds have been unlocked already.

Solution is not to allow a policy to be cancelled after the maturation date.

Bug was originally reported through Immunefi: [IM-25167](https://bugs.immunefi.com/dashboard/submission/25167)