### PR TITLE
Limit collecting rewards up to 48 intervals

### DIFF
--- a/src/facets/StakingFacet.sol
+++ b/src/facets/StakingFacet.sol
@@ -70,6 +70,12 @@ contract StakingFacet is Modifiers {
         LibTokenizedVaultStaking._collectRewards(parentId, _entityId, lastPaid);
     }
 
+    function collectRewardsThroughInterval(bytes32 _entityId, uint64 _interval) external notLocked(msg.sig) {
+        bytes32 parentId = LibObject._getParent(msg.sender._getIdForAddress());
+
+        LibTokenizedVaultStaking._collectRewards(parentId, _entityId, _interval);
+    }
+
     function getStakingState(bytes32 _stakerId, bytes32 _entityId) external view returns (StakingState memory) {
         uint64 interval = LibTokenizedVaultStaking._currentInterval(_entityId);
         (StakingState memory state, ) = LibTokenizedVaultStaking._getStakingStateWithRewardsBalances(_stakerId, _entityId, interval);

--- a/src/libs/LibConstants.sol
+++ b/src/libs/LibConstants.sol
@@ -136,6 +136,13 @@ library LibConstants {
     uint256 internal constant MAX_MATURATION_PERIOD = 3650 days; // ~ 10 years
     uint256 internal constant MAX_POLICY_COMMISSION_RECEIVERS = 10;
 
+    /*///////////////////////////////////////////////////////////////////////////
+                            Staking Constants
+    ///////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev The maximum number of intervals that can be collected at once.
+    uint8 internal constant MAX_COLLECTABLE_INTERVALS = 48;
+
     /// _depositFor Types for events
     int128 internal constant STAKING_DEPOSIT_FOR_TYPE = 0;
     int128 internal constant STAKING_CREATE_LOCK_TYPE = 1;

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -212,3 +212,6 @@ error InvalidTokenId();
 
 /// @dev Cannot stake an amount lower than objectMinimumSell[tokenId].
 error InvalidStakingAmount();
+
+/// @dev Exceeded the manximum number of collectable intervals. Collect a smaller number of intervals with the method `collectRewardsThroughInterval`.
+error ExceededMaxCollectableIntervals(uint256 intervals, uint256 maxIntervals);

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -10,7 +10,7 @@ import { StakingFixture } from "test/fixtures/StakingFixture.sol";
 import { DummyToken } from "./utils/DummyToken.sol";
 import { LibTokenizedVaultStaking } from "src/libs/LibTokenizedVaultStaking.sol";
 
-import { IntervalRewardPayedOutAlready, InvalidTokenRewardAmount, InvalidStakingAmount, InvalidStaker } from "src/shared/CustomErrors.sol";
+import { IntervalRewardPayedOutAlready, InvalidTokenRewardAmount, InvalidStakingAmount, InvalidStaker, ExceededMaxCollectableIntervals } from "src/shared/CustomErrors.sol";
 
 function makeId2(bytes12 _objecType, bytes20 randomBytes) pure returns (bytes32) {
     return bytes32((_objecType)) | (bytes32(randomBytes));
@@ -739,6 +739,56 @@ contract T06Staking is D03ProtocolDefaults {
         nayms.collectRewards(nlf.entityId);
         assertEq(nayms.internalBalanceOf(bob.entityId, usdcId), rewardAmount);
         assertEq(nayms.internalBalanceOf(bob.entityId, wethId), 1 ether);
+    }
+
+    function test_collectRewardsThroughInterval() public {
+        initStaking({ initDate: 1 });
+        c.log(" ~ [%s] Staking start".blue(), nayms.currentInterval(nlf.entityId));
+
+        vm.warp(31 days);
+
+        startPrank(bob);
+        nayms.stake(nlf.entityId, bobStakeAmount);
+
+        vm.warp(61 days);
+
+        assertEq(nayms.lastPaidInterval(nlf.entityId), 0, "Last interval paid should be 0");
+
+        startPrank(nlf);
+        nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("1")), nlf.entityId, usdcId, rewardAmount); // 100 USDC
+        c.log(" ~ [%s] Reward paid out".blue(), nayms.currentInterval(nlf.entityId));
+
+        vm.warp(121 days);
+
+        nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("2")), nlf.entityId, wethId, 1 ether);
+        c.log(" ~ [%s] Reward paid out".blue(), nayms.currentInterval(nlf.entityId));
+
+        vm.warp(151 days);
+
+        startPrank(bob);
+        nayms.internalBalanceOf(bob.entityId, usdcId);
+
+        // Collect only the 1st reward
+        nayms.collectRewardsThroughInterval(nlf.entityId, 3);
+        assertEq(nayms.internalBalanceOf(bob.entityId, usdcId), rewardAmount, "Should have 1st reward USDC on balance");
+        assertEq(nayms.internalBalanceOf(bob.entityId, wethId), 0, "Should not have WETH balance");
+
+        // Collect only the 2nd reward
+        nayms.collectRewardsThroughInterval(nlf.entityId, 4);
+        assertEq(nayms.internalBalanceOf(bob.entityId, usdcId), rewardAmount, "Should have 2nd reward USDC on balance");
+        assertEq(nayms.internalBalanceOf(bob.entityId, wethId), 1 ether, "Should have 1 WETH");
+    }
+
+    function test_MaxCollectRewardsThroughInterval() public {
+        initStaking({ initDate: 1 });
+        c.log(" ~ [%s] Staking start".blue(), nayms.currentInterval(nlf.entityId));
+
+        vm.warp(1801 days);
+        startPrank(bob);
+        nayms.stake(nlf.entityId, bobStakeAmount);
+
+        vm.expectRevert(abi.encodeWithSelector(ExceededMaxCollectableIntervals.selector, 60, LC.MAX_COLLECTABLE_INTERVALS));
+        nayms.collectRewardsThroughInterval(nlf.entityId, 60);
     }
 
     function calculateBalanceAtTime(uint256 t, uint256 initialBalance) public pure returns (uint256 boostedBalanceAtTime) {


### PR DESCRIPTION
The motivation is to give the user a better error than out of gas when attempting to collect staking rewards through a large number of reward intervals.

We now limit the max number of intervals that a user can collect to 48 and throw a custom error if the user is attempting to collect more.

We added a method called `collectRewardsThroughInterval` which lets a user collect up to a specific interval. 