### PR TITLE
Reset staked amount

### DIFF
--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -161,6 +161,7 @@ library LibTokenizedVaultStaking {
 
         // collect your rewards first
         _collectRewards(_stakerId, _entityId, currentInterval);
+        s.stakeCollected[_entityId][_stakerId] = currentInterval;
 
         // set boost and balances to zero
         s.stakeBoost[vTokenId][_stakerId] = 0;

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -698,6 +698,28 @@ contract T06Staking is D03ProtocolDefaults {
         assertEq(nayms.internalBalanceOf(bob.entityId, wethId), 1 ether);
     }
 
+    function testStakingScenario2() public {
+        initStaking(block.timestamp + 10);
+
+        assertEq(nayms.internalBalanceOf(bob.entityId, NAYMSID), 10_000_000e18, "Bob's intial balance incorrect");
+
+        startPrank(bob);
+        nayms.stake(nlf.entityId, bobStakeAmount);
+        StakingState memory s = nayms.getStakingState(bob.entityId, nlf.entityId);
+        assertEq(s.balance, bobStakeAmount, "stake amount should increase");
+        assertEq(nayms.internalBalanceOf(bob.entityId, NAYMSID), 10_000_000e18 - bobStakeAmount, "Bob's balance show decrease");
+
+        vm.warp(60 days);
+        nayms.unstake(nlf.entityId);
+        s = nayms.getStakingState(bob.entityId, nlf.entityId);
+        assertEq(s.balance, 0, "stake amount should decrease");
+        assertEq(nayms.internalBalanceOf(bob.entityId, NAYMSID), 10_000_000e18, "Bob's balance show increase");
+
+        nayms.stake(nlf.entityId, bobStakeAmount);
+        s = nayms.getStakingState(bob.entityId, nlf.entityId);
+        assertEq(s.balance, bobStakeAmount, "stake(2) amount should increase");
+    }
+
     function calculateBalanceAtTime(uint256 t, uint256 initialBalance) public pure returns (uint256 boostedBalanceAtTime) {
         uint256 Xm = calculateMultiplier(t, I, A, R);
         boostedBalanceAtTime = (initialBalance * Xm) / SCALE_FACTOR;


### PR DESCRIPTION
When a user unstakes his amount, that interval has to be marked as if the reward was collected. Reason for that is because that point in time is used as a starting point to calculate the staking state. 