### PR TITLE
NAY-1 Boost reset when staking again 

### DIFF
--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -167,8 +167,8 @@ library LibTokenizedVaultStaking {
         // set boost and balances to zero
         s.stakeBoost[vTokenId][_stakerId] = 0;
         s.stakeBoost[vTokenIdNext][_stakerId] = 0;
+
         s.stakeBalance[vTokenId][_stakerId] = 0;
-        s.stakeBalance[vTokenIdNext][_stakerId] = 0;
 
         uint256 originalAmountStaked = s.stakeBalance[vTokenIdMax][_stakerId];
         s.stakeBalance[vTokenIdMax][_stakerId] = 0;

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -161,6 +161,7 @@ library LibTokenizedVaultStaking {
 
         // collect your rewards first
         _collectRewards(_stakerId, _entityId, currentInterval);
+        s.stakeCollected[_entityId][_stakerId] = currentInterval;
 
         // set boost and balances to zero
         s.stakeBoost[vTokenId][_stakerId] = 0;

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -158,13 +158,16 @@ library LibTokenizedVaultStaking {
         uint64 currentInterval = _currentInterval(_entityId);
         bytes32 vTokenIdMax = _vTokenIdBucket(tokenId);
         bytes32 vTokenId = _vTokenId(tokenId, currentInterval);
+        bytes32 vTokenIdNext = _vTokenId(tokenId, currentInterval + 1);
 
         // collect your rewards first
         _collectRewards(_stakerId, _entityId, currentInterval);
 
         // set boost and balances to zero
         s.stakeBoost[vTokenId][_stakerId] = 0;
+        s.stakeBoost[vTokenIdNext][_stakerId] = 0;
         s.stakeBalance[vTokenId][_stakerId] = 0;
+        s.stakeBalance[vTokenIdNext][_stakerId] = 0;
 
         uint256 originalAmountStaked = s.stakeBalance[vTokenIdMax][_stakerId];
         s.stakeBalance[vTokenIdMax][_stakerId] = 0;

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -191,39 +191,6 @@ contract T06Staking is D03ProtocolDefaults {
         assertEq(nayms.currentInterval(nlf.entityId), 2, "current interval not 2");
     }
 
-    function test_NAY1_boostReset() public {
-        initStaking(block.timestamp + 1);
-
-        uint256 bobsBoost = (bobStakeAmount * A) / (A + R);
-
-        startPrank(bob);
-        nayms.stake(nlf.entityId, bobStakeAmount);
-        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 0), bobStakeAmount, "Bob's stake should increase");
-        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 0), bobsBoost, "Bob's boost should increase");
-
-        nayms.unstake(nlf.entityId);
-        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 0), 0, "Bob's stake[0] should decrease");
-        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 1), 0, "Bob's stake[0] should decrease");
-        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 0), 0, "Bob's boost[1] should decrease");
-        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 1), 0, "Bob's boost[1] should decrease");
-
-        vm.warp(40 days);
-        nayms.stake(nlf.entityId, bobStakeAmount);
-
-        uint64 currentInterval = nayms.currentInterval(nlf.entityId);
-        uint256 startCurrent = nayms.calculateStartTimeOfInterval(nlf.entityId, currentInterval);
-
-        uint256 bobsBoost2 = (bobsBoost * (block.timestamp - startCurrent)) / I;
-        uint256 bobsBoost1 = bobsBoost - bobsBoost2;
-
-        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 0), 0, "Bob's stake[0] should not change");
-        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 1), bobStakeAmount, "Bob's stake[1] should increase");
-        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 2), 0, "Bob's stake[2] should not change");
-        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 0), 0, "Bob's boost[0] should not change");
-        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 1), bobsBoost1, "Bob's boost[1] should increase");
-        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 2), bobsBoost2, "Bob's boost[2] should increase");
-    }
-
     function test_stake() public {
         uint256 start = block.timestamp + 1;
 
@@ -788,5 +755,38 @@ contract T06Staking is D03ProtocolDefaults {
         }
 
         return result;
+    }
+
+    function test_NAY1_boostReset() public {
+        initStaking(block.timestamp + 1);
+
+        uint256 bobsBoost = (bobStakeAmount * A) / (A + R);
+
+        startPrank(bob);
+        nayms.stake(nlf.entityId, bobStakeAmount);
+        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 0), bobStakeAmount, "Bob's stake should increase");
+        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 0), bobsBoost, "Bob's boost should increase");
+
+        nayms.unstake(nlf.entityId);
+        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 0), 0, "Bob's stake[0] should decrease");
+        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 1), 0, "Bob's stake[0] should decrease");
+        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 0), 0, "Bob's boost[1] should decrease");
+        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 1), 0, "Bob's boost[1] should decrease");
+
+        vm.warp(40 days);
+        nayms.stake(nlf.entityId, bobStakeAmount);
+
+        uint64 currentInterval = nayms.currentInterval(nlf.entityId);
+        uint256 startCurrent = nayms.calculateStartTimeOfInterval(nlf.entityId, currentInterval);
+
+        uint256 bobsBoost2 = (bobsBoost * (block.timestamp - startCurrent)) / I;
+        uint256 bobsBoost1 = bobsBoost - bobsBoost2;
+
+        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 0), 0, "Bob's stake[0] should not change");
+        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 1), bobStakeAmount, "Bob's stake[1] should increase");
+        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 2), 0, "Bob's stake[2] should not change");
+        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 0), 0, "Bob's boost[0] should not change");
+        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 1), bobsBoost1, "Bob's boost[1] should increase");
+        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 2), bobsBoost2, "Bob's boost[2] should increase");
     }
 }

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -123,13 +123,13 @@ contract T06Staking is D03ProtocolDefaults {
 
     function boostAtInterval(bytes32 stakerId, bytes32 entityId, uint64 interval) internal returns (uint256) {
         (bool success, bytes memory result) = address(nayms).call(abi.encodeWithSelector(stakingFixture.boostAtInterval.selector, stakerId, entityId, interval));
-        require(success, "Should get commissions from app storage");
+        require(success, "Should get boost at interval from app storage");
         return abi.decode(result, (uint256));
     }
 
     function balaceAtInterval(bytes32 stakerId, bytes32 entityId, uint64 interval) internal returns (uint256) {
         (bool success, bytes memory result) = address(nayms).call(abi.encodeWithSelector(stakingFixture.balanceAtInterval.selector, stakerId, entityId, interval));
-        require(success, "Should get commissions from app storage");
+        require(success, "Should get balance at interval from app storage");
         return abi.decode(result, (uint256));
     }
 

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -163,6 +163,20 @@ contract T06Staking is D03ProtocolDefaults {
         assertEq(nayms.currentInterval(nlf.entityId), 2, "current interval not 2");
     }
 
+    function test_NAY1_boostReset() public {
+        initStaking(block.timestamp + 1);
+
+        vm.warp(20 days);
+        startPrank(bob);
+        nayms.stake(nlf.entityId, 1 ether);
+        printBoosts(nlf.entityId, bob.entityId, "Bob");
+        vm.warp(40 days);
+        nayms.unstake(nlf.entityId);
+        printBoosts(nlf.entityId, bob.entityId, "Bob");
+        nayms.stake(nlf.entityId, 1 ether);
+        printBoosts(nlf.entityId, bob.entityId, "Bob");
+    }
+
     function test_stake() public {
         uint256 start = block.timestamp + 1;
 

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -698,6 +698,28 @@ contract T06Staking is D03ProtocolDefaults {
         assertEq(nayms.internalBalanceOf(bob.entityId, wethId), 1 ether);
     }
 
+    function testStakingScenario2() public {
+        initStaking(block.timestamp + 10);
+
+        assertEq(nayms.internalBalanceOf(bob.entityId, NAYMSID), 10_000_000e18, "Bob's intial balance incorrect");
+
+        startPrank(bob);
+        nayms.stake(nlf.entityId, bobStakeAmount);
+        StakingState memory s = nayms.getStakingState(bob.entityId, nlf.entityId);
+        assertEq(s.balance, bobStakeAmount, "stake amount should increase");
+        assertEq(nayms.internalBalanceOf(bob.entityId, NAYMSID), 10_000_000e18 - bobStakeAmount, "Bob's balance show decrease");
+
+        vm.warp(60 days);
+        nayms.unstake(nlf.entityId);
+        s = nayms.getStakingState(bob.entityId, nlf.entityId);
+        assertEq(s.balance, 0, "stake amount should decrease");
+        assertEq(nayms.internalBalanceOf(bob.entityId, NAYMSID), 10_000_000e18, "Bob's balance show increase");
+
+        nayms.stake(nlf.entityId, bobStakeAmount);
+        s = nayms.getStakingState(bob.entityId, nlf.entityId);
+        assertEq(s.balance, bobStakeAmount, "stake(2) amount should increase");
+    }
+
     function calculateBalanceAtTime(uint256 t, uint256 initialBalance) public pure returns (uint256 boostedBalanceAtTime) {
         uint256 Xm = calculateMultiplier(t, I, A, R);
         boostedBalanceAtTime = (initialBalance * Xm) / SCALE_FACTOR;

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -5,11 +5,10 @@ import { StdStorage, stdStorage, StdStyle } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { D03ProtocolDefaults, c, LC, LibHelpers } from "./defaults/D03ProtocolDefaults.sol";
 import { StakingConfig, StakingState } from "src/shared/FreeStructs.sol";
-
+import { IDiamondCut } from "lib/diamond-2-hardhat/contracts/interfaces/IDiamondCut.sol";
+import { StakingFixture } from "test/fixtures/StakingFixture.sol";
 import { DummyToken } from "./utils/DummyToken.sol";
-
 import { LibTokenizedVaultStaking } from "src/libs/LibTokenizedVaultStaking.sol";
-
 import { IntervalRewardPayedOutAlready, InvalidTokenRewardAmount } from "src/shared/CustomErrors.sol";
 
 function makeId2(bytes12 _objecType, bytes20 randomBytes) pure returns (bytes32) {
@@ -50,12 +49,29 @@ contract T06Staking is D03ProtocolDefaults {
 
     uint256 constant stakingStart = 100 days;
 
+    StakingFixture internal stakingFixture;
+
     mapping(bytes32 stakerId => mapping(uint64 interval => StakingState)) public stakingStates;
     function recordStakingState(bytes32 stakerId) public {
         stakingStates[stakerId][nayms.currentInterval(nlf.entityId)] = nayms.getStakingState(stakerId, nlf.entityId);
     }
 
     function setUp() public {
+        stakingFixture = new StakingFixture();
+        bytes4[] memory sSelectors = new bytes4[](2);
+        sSelectors[0] = StakingFixture.boostAtInterval.selector;
+        sSelectors[1] = StakingFixture.balanceAtInterval.selector;
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        // prettier-ignore
+        cut[0] = IDiamondCut.FacetCut({ 
+            facetAddress: address(stakingFixture), 
+            action: IDiamondCut.FacetCutAction.Add, 
+            functionSelectors: sSelectors 
+        });
+
+        scheduleAndUpgradeDiamond(cut);
+
         naymToken = new DummyToken();
 
         nlf = makeNaymsAcc(LC.NLF_IDENTIFIER);
@@ -103,6 +119,18 @@ contract T06Staking is D03ProtocolDefaults {
 
         fundEntityWeth(sm, wethTotal);
         nayms.internalTransferFromEntity(nlf.entityId, wethId, wethTotal);
+    }
+
+    function boostAtInterval(bytes32 stakerId, bytes32 entityId, uint64 interval) internal returns (uint256) {
+        (bool success, bytes memory result) = address(nayms).call(abi.encodeWithSelector(stakingFixture.boostAtInterval.selector, stakerId, entityId, interval));
+        require(success, "Should get commissions from app storage");
+        return abi.decode(result, (uint256));
+    }
+
+    function balaceAtInterval(bytes32 stakerId, bytes32 entityId, uint64 interval) internal returns (uint256) {
+        (bool success, bytes memory result) = address(nayms).call(abi.encodeWithSelector(stakingFixture.balanceAtInterval.selector, stakerId, entityId, interval));
+        require(success, "Should get commissions from app storage");
+        return abi.decode(result, (uint256));
     }
 
     function vtokenId(bytes32 _tokenId, uint64 _interval) internal pure returns (bytes32) {
@@ -166,15 +194,34 @@ contract T06Staking is D03ProtocolDefaults {
     function test_NAY1_boostReset() public {
         initStaking(block.timestamp + 1);
 
-        vm.warp(20 days);
+        uint256 bobsBoost = (bobStakeAmount * A) / (A + R);
+
         startPrank(bob);
-        nayms.stake(nlf.entityId, 1 ether);
-        printBoosts(nlf.entityId, bob.entityId, "Bob");
-        vm.warp(40 days);
+        nayms.stake(nlf.entityId, bobStakeAmount);
+        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 0), bobStakeAmount, "Bob's stake should increase");
+        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 0), bobsBoost, "Bob's boost should increase");
+
         nayms.unstake(nlf.entityId);
-        printBoosts(nlf.entityId, bob.entityId, "Bob");
-        nayms.stake(nlf.entityId, 1 ether);
-        printBoosts(nlf.entityId, bob.entityId, "Bob");
+        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 0), 0, "Bob's stake[0] should decrease");
+        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 1), 0, "Bob's stake[0] should decrease");
+        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 0), 0, "Bob's boost[1] should decrease");
+        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 1), 0, "Bob's boost[1] should decrease");
+
+        vm.warp(40 days);
+        nayms.stake(nlf.entityId, bobStakeAmount);
+
+        uint64 currentInterval = nayms.currentInterval(nlf.entityId);
+        uint256 startCurrent = nayms.calculateStartTimeOfInterval(nlf.entityId, currentInterval);
+
+        uint256 bobsBoost2 = (bobsBoost * (block.timestamp - startCurrent)) / I;
+        uint256 bobsBoost1 = bobsBoost - bobsBoost2;
+
+        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 0), 0, "Bob's stake[0] should not change");
+        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 1), bobStakeAmount, "Bob's stake[1] should increase");
+        assertEq(balaceAtInterval(bob.entityId, nlf.entityId, 2), 0, "Bob's stake[2] should not change");
+        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 0), 0, "Bob's boost[0] should not change");
+        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 1), bobsBoost1, "Bob's boost[1] should increase");
+        assertEq(boostAtInterval(bob.entityId, nlf.entityId, 2), bobsBoost2, "Bob's boost[2] should increase");
     }
 
     function test_stake() public {
@@ -710,28 +757,6 @@ contract T06Staking is D03ProtocolDefaults {
         nayms.collectRewards(nlf.entityId);
         assertEq(nayms.internalBalanceOf(bob.entityId, usdcId), rewardAmount);
         assertEq(nayms.internalBalanceOf(bob.entityId, wethId), 1 ether);
-    }
-
-    function testStakingScenario2() public {
-        initStaking(block.timestamp + 10);
-
-        assertEq(nayms.internalBalanceOf(bob.entityId, NAYMSID), 10_000_000e18, "Bob's intial balance incorrect");
-
-        startPrank(bob);
-        nayms.stake(nlf.entityId, bobStakeAmount);
-        StakingState memory s = nayms.getStakingState(bob.entityId, nlf.entityId);
-        assertEq(s.balance, bobStakeAmount, "stake amount should increase");
-        assertEq(nayms.internalBalanceOf(bob.entityId, NAYMSID), 10_000_000e18 - bobStakeAmount, "Bob's balance show decrease");
-
-        vm.warp(60 days);
-        nayms.unstake(nlf.entityId);
-        s = nayms.getStakingState(bob.entityId, nlf.entityId);
-        assertEq(s.balance, 0, "stake amount should decrease");
-        assertEq(nayms.internalBalanceOf(bob.entityId, NAYMSID), 10_000_000e18, "Bob's balance show increase");
-
-        nayms.stake(nlf.entityId, bobStakeAmount);
-        s = nayms.getStakingState(bob.entityId, nlf.entityId);
-        assertEq(s.balance, bobStakeAmount, "stake(2) amount should increase");
     }
 
     function calculateBalanceAtTime(uint256 t, uint256 initialBalance) public pure returns (uint256 boostedBalanceAtTime) {

--- a/test/fixtures/StakingFixture.sol
+++ b/test/fixtures/StakingFixture.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import { LibTokenizedVaultStaking } from "src/libs/LibTokenizedVaultStaking.sol";
+import { AppStorage, LibAppStorage } from "src/shared/AppStorage.sol";
+
+contract StakingFixture {
+    function boostAtInterval(bytes32 _stakerId, bytes32 _entityId, uint64 _interval) public view returns (uint256) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        bytes32 tokenId = s.stakingConfigs[_entityId].tokenId;
+        bytes32 vTokenId = LibTokenizedVaultStaking._vTokenId(tokenId, _interval);
+
+        return s.stakeBoost[vTokenId][_stakerId];
+    }
+
+    function balanceAtInterval(bytes32 _stakerId, bytes32 _entityId, uint64 _interval) public view returns (uint256) {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        bytes32 tokenId = s.stakingConfigs[_entityId].tokenId;
+        bytes32 vTokenId = LibTokenizedVaultStaking._vTokenId(tokenId, _interval);
+
+        return s.stakeBalance[vTokenId][_stakerId];
+    }
+}


### PR DESCRIPTION
Boost is not properly reset after unstaking, causing more boost to be assigned to the user than it should.

> In _unstake() , we only set s.stakeBoost[vTokenId][_stakerId] = 0; back to zero, but we do not set the stake boost for the next vTokenId back to zero. When a user stake in the current interval, part of the stake boost will be allocated to the next vTokenId proportional to the time it was staked between the current interval and the next interval

It would add up the the boost from previous staking, since it was not reset back to zero.