### PR TITLE
NAY-6 Unrestricted Access Control Rule for Internal Transfers From Objects' Children

### DIFF
--- a/src/facets/TokenizedVaultFacet.sol
+++ b/src/facets/TokenizedVaultFacet.sol
@@ -46,7 +46,11 @@ contract TokenizedVaultFacet is Modifiers, ReentrancyGuard {
      * @param tokenId Internal ID of the token
      * @param amount being transferred
      */
-    function internalTransferFromEntity(bytes32 to, bytes32 tokenId, uint256 amount) external notLocked(msg.sig) nonReentrant {
+    function internalTransferFromEntity(
+        bytes32 to,
+        bytes32 tokenId,
+        uint256 amount
+    ) external notLocked(msg.sig) nonReentrant assertPrivilege(LibObject._getParentFromAddress(msg.sender), LC.GROUP_INTERNAL_TRANSFER_FROM_ENTITY) {
         bytes32 senderEntityId = LibObject._getParentFromAddress(msg.sender);
         LibTokenizedVault._internalTransfer(senderEntityId, to, tokenId, amount);
     }

--- a/src/libs/LibInitDiamond.sol
+++ b/src/libs/LibInitDiamond.sol
@@ -57,6 +57,7 @@ library LibInitDiamond {
         LibACL._updateRoleGroup(LC.ROLE_ONBOARDING_APPROVER, LC.GROUP_ONBOARDING_APPROVERS, true);
         LibACL._updateRoleGroup(LC.ROLE_ENTITY_TOKEN_HOLDER, LC.GROUP_TOKEN_HOLDERS, true);
         LibACL._updateRoleGroup(LC.ROLE_ENTITY_TOKEN_HOLDER, LC.GROUP_EXECUTE_LIMIT_OFFER, true);
+        LibACL._updateRoleGroup(LC.ROLE_ENTITY_ADMIN, LC.GROUP_INTERNAL_TRANSFER_FROM_ENTITY, true);
 
         // setup stakeholder groups
         LibACL._updateRoleGroup(LC.ROLE_UNDERWRITER, LC.GROUP_UNDERWRITERS, true);


### PR DESCRIPTION
The function `TokenizedVaultFacet.internalTransferFromEntity()` is no longer protected by an "onlyEntityAdmin" modifier. Since the fact that the parent of `msg.sender` is not checked to be an entity, any address being the child of an object id owning tokens can trigger a transfer of any token to an arbitrary other internal address. This could lead to unexpected consequences in the current version of the system and future ones as well.

Added an access control check on `internalTransferFromEntity()` which requires the user to have the entity admin role within the context of the entity they are transferring from.

This requires a system manager to add the entity admin role to `GROUP_INTERNAL_TRANSFER_FROM_ENTITY`. This can be done by a system manager prior or during the upgrade. `internalTransferFromEntity()` will revert with the error `InvalidGroupPriviledge` if the system manager forgets to add the entity admin role into this group.