### PR TITLE
NAY-9 Emit key state change events

### DIFF
--- a/src/facets/MarketFacet.sol
+++ b/src/facets/MarketFacet.sol
@@ -142,6 +142,6 @@ contract MarketFacet is Modifiers, ReentrancyGuard {
      * @param _minimumSell The minimum amount of tokens that can be sold on the market.
      */
     function setMinimumSell(bytes32 _objectId, uint256 _minimumSell) external assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_MANAGERS) {
-        LibMarket._setMinimumSell(_objectId, _minimumSell);
+        LibAdmin._setMinimumSell(_objectId, _minimumSell);
     }
 }

--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -35,6 +35,9 @@ library LibAdmin {
     event SelfOnboardingCompleted(address indexed userAddress);
     event SelfOnboardingCancelled(address indexed userAddress);
 
+    /// @notice The minimum amount of an object (par token, external token) that can be sold on the market
+    event MinimumSellUpdated(bytes32 objectId, uint256 minimumSell);
+
     function _getSystemId() internal pure returns (bytes32) {
         return LibHelpers._stringToBytes32(LC.SYSTEM_IDENTIFIER);
     }
@@ -90,6 +93,7 @@ library LibAdmin {
         s.objectMinimumSell[tokenId] = _minimumSell;
 
         emit SupportedTokenAdded(_tokenAddress);
+        emit MinimumSellUpdated(tokenId, _minimumSell);
     }
 
     function _getSupportedExternalTokens() internal view returns (address[] memory) {
@@ -266,5 +270,14 @@ library LibAdmin {
         delete s.selfOnboarding[_userAddress];
 
         emit SelfOnboardingCancelled(_userAddress);
+    }
+
+    function _setMinimumSell(bytes32 _objectId, uint256 _minimumSell) internal {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        if (_minimumSell == 0) revert MinimumSellCannotBeZero();
+
+        s.objectMinimumSell[_objectId] = _minimumSell;
+
+        emit MinimumSellUpdated(_objectId, _minimumSell);
     }
 }

--- a/src/libs/LibFeeRouter.sol
+++ b/src/libs/LibFeeRouter.sol
@@ -12,6 +12,7 @@ library LibFeeRouter {
 
     event MakerBasisPointsUpdated(uint16 tradingCommissionMakerBP);
     event FeeScheduleAdded(bytes32 entityId, uint256 feeType, FeeSchedule feeSchedule);
+    event FeeScheduleRemoved(bytes32 entityId, uint256 feeType);
 
     function _calculatePremiumFees(bytes32 _policyId, uint256 _premiumPaid) internal view returns (CalculatedFees memory cf) {
         AppStorage storage s = LibAppStorage.diamondStorage();
@@ -205,6 +206,7 @@ library LibFeeRouter {
         require(_entityId != LibConstants.DEFAULT_FEE_SCHEDULE, "cannot remove default fees");
         AppStorage storage s = LibAppStorage.diamondStorage();
         delete s.feeSchedules[_entityId][_feeScheduleType];
+        emit FeeScheduleRemoved(_entityId, _feeScheduleType);
     }
 
     function _getMakerBP() internal view returns (uint16) {

--- a/src/libs/LibMarket.sol
+++ b/src/libs/LibMarket.sol
@@ -41,9 +41,6 @@ library LibMarket {
     /// @notice order has been cancelled
     event OrderCancelled(uint256 indexed orderId, bytes32 indexed taker, bytes32 sellToken);
 
-    /// @notice The minimum amount of an object (par token, external token) that can be sold on the market
-    event MinimumSellUpdated(bytes32 objectId, uint256 minimumSell);
-
     function _getBestOfferId(bytes32 _sellToken, bytes32 _buyToken) internal view returns (uint256) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         return s.bestOfferId[_sellToken][_buyToken];
@@ -507,14 +504,5 @@ library LibMarket {
     function _objectMinimumSell(bytes32 _objectId) internal view returns (uint256) {
         AppStorage storage s = LibAppStorage.diamondStorage();
         return s.objectMinimumSell[_objectId];
-    }
-
-    function _setMinimumSell(bytes32 _objectId, uint256 _minimumSell) internal {
-        AppStorage storage s = LibAppStorage.diamondStorage();
-        if (_minimumSell == 0) revert MinimumSellCannotBeZero();
-
-        s.objectMinimumSell[_objectId] = _minimumSell;
-
-        emit MinimumSellUpdated(_objectId, _minimumSell);
     }
 }


### PR DESCRIPTION
To validate the proper deployment and initialization of the contracts, it is a good practice to emit events. Also, any
important state transitions can be logged, which is beneficial for monitoring the contract and tracking eventual bugs or hacks.

Added events emitting when the initial amount of `minimumSell` is set in `LibAdmin._addSupportedExternalToken()` and when fee schedule is removed.