### PR TITLE
NAY-11 Fix accounting of deposit total

### DIFF
--- a/src/libs/LibTokenizedVaultIO.sol
+++ b/src/libs/LibTokenizedVaultIO.sol
@@ -35,10 +35,10 @@ library LibTokenizedVaultIO {
         LibTokenizedVault._internalMint(_receiverId, internalTokenId, mintAmount);
 
         AppStorage storage s = LibAppStorage.diamondStorage();
-        s.depositTotal[internalTokenId] += _amount;
+        s.depositTotal[internalTokenId] += mintAmount;
 
         // emit event
-        emit ExternalDeposit(_receiverId, _externalTokenAddress, _amount);
+        emit ExternalDeposit(_receiverId, _externalTokenAddress, mintAmount);
     }
 
     function _externalWithdraw(bytes32 _entityId, address _receiver, address _externalTokenAddress, uint256 _amount) internal {


### PR DESCRIPTION
When considering fee on transfer tokens, the variable `depositTotal` should be updated with the actual amounts transferred in and out. 

In the case of deposits, that would be the amount after the fee has been taken off. 

In the case of withdraws, that would be the amount that is transferred out of the Nayms platform.