### PR TITLE
NAY-16 Add additional emergency locking

### DIFF
--- a/src/facets/EntityFacet.sol
+++ b/src/facets/EntityFacet.sol
@@ -48,7 +48,7 @@ contract EntityFacet is Modifiers, ReentrancyGuard {
         Stakeholders calldata _stakeholders,
         SimplePolicy calldata _simplePolicy,
         bytes32 _dataHash
-    ) external assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_UNDERWRITERS) assertSimplePolicyEnabled(_entityId) {
+    ) external notLocked(msg.sig) assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_UNDERWRITERS) assertSimplePolicyEnabled(_entityId) {
         LibEntity._createSimplePolicy(_policyId, _entityId, _stakeholders, _simplePolicy, _dataHash);
     }
 

--- a/src/facets/SimplePolicyFacet.sol
+++ b/src/facets/SimplePolicyFacet.sol
@@ -84,7 +84,7 @@ contract SimplePolicyFacet is Modifiers {
      * @dev Cancel a simple policy
      * @param _policyId Id of the simple policy
      */
-    function cancelSimplePolicy(bytes32 _policyId) external assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_UNDERWRITERS) {
+    function cancelSimplePolicy(bytes32 _policyId) external notLocked(msg.sig) assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_UNDERWRITERS) {
         LibSimplePolicy._cancel(_policyId);
     }
 

--- a/src/facets/SystemFacet.sol
+++ b/src/facets/SystemFacet.sol
@@ -29,7 +29,7 @@ contract SystemFacet is Modifiers, ReentrancyGuard {
         bytes32 _entityAdmin,
         Entity calldata _entityData,
         bytes32 _dataHash
-    ) external assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_MANAGERS) {
+    ) external notLocked(msg.sig) assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_MANAGERS) {
         LibEntity._createEntity(_entityId, _entityAdmin, _entityData, _dataHash);
     }
 

--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -142,8 +142,11 @@ library LibAdmin {
         s.locked[IDiamondProxy.unstake.selector] = true;
         s.locked[IDiamondProxy.collectRewards.selector] = true;
         s.locked[IDiamondProxy.payReward.selector] = true;
+        s.locked[IDiamondProxy.cancelSimplePolicy.selector] = true;
+        s.locked[IDiamondProxy.createSimplePolicy.selector] = true;
+        s.locked[IDiamondProxy.createEntity.selector] = true;
 
-        bytes4[] memory lockedFunctions = new bytes4[](18);
+        bytes4[] memory lockedFunctions = new bytes4[](21);
         lockedFunctions[0] = IDiamondProxy.startTokenSale.selector;
         lockedFunctions[1] = IDiamondProxy.paySimpleClaim.selector;
         lockedFunctions[2] = IDiamondProxy.paySimplePremium.selector;
@@ -162,6 +165,9 @@ library LibAdmin {
         lockedFunctions[15] = IDiamondProxy.unstake.selector;
         lockedFunctions[16] = IDiamondProxy.collectRewards.selector;
         lockedFunctions[17] = IDiamondProxy.payReward.selector;
+        lockedFunctions[18] = IDiamondProxy.cancelSimplePolicy.selector;
+        lockedFunctions[19] = IDiamondProxy.createSimplePolicy.selector;
+        lockedFunctions[20] = IDiamondProxy.createEntity.selector;
 
         emit FunctionsLocked(lockedFunctions);
     }
@@ -186,8 +192,11 @@ library LibAdmin {
         s.locked[IDiamondProxy.unstake.selector] = false;
         s.locked[IDiamondProxy.collectRewards.selector] = false;
         s.locked[IDiamondProxy.payReward.selector] = false;
+        s.locked[IDiamondProxy.cancelSimplePolicy.selector] = false;
+        s.locked[IDiamondProxy.createSimplePolicy.selector] = false;
+        s.locked[IDiamondProxy.createEntity.selector] = false;
 
-        bytes4[] memory lockedFunctions = new bytes4[](18);
+        bytes4[] memory lockedFunctions = new bytes4[](21);
         lockedFunctions[0] = IDiamondProxy.startTokenSale.selector;
         lockedFunctions[1] = IDiamondProxy.paySimpleClaim.selector;
         lockedFunctions[2] = IDiamondProxy.paySimplePremium.selector;
@@ -206,6 +215,9 @@ library LibAdmin {
         lockedFunctions[15] = IDiamondProxy.unstake.selector;
         lockedFunctions[16] = IDiamondProxy.collectRewards.selector;
         lockedFunctions[17] = IDiamondProxy.payReward.selector;
+        lockedFunctions[18] = IDiamondProxy.cancelSimplePolicy.selector;
+        lockedFunctions[19] = IDiamondProxy.createSimplePolicy.selector;
+        lockedFunctions[20] = IDiamondProxy.createEntity.selector;
 
         emit FunctionsUnlocked(lockedFunctions);
     }

--- a/test/T02Admin.t.sol
+++ b/test/T02Admin.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.20;
 
 import { D03ProtocolDefaults, LibHelpers, LC } from "./defaults/D03ProtocolDefaults.sol";
 
-import { Entity } from "../src/shared/FreeStructs.sol";
+import { Entity, Stakeholders, SimplePolicy } from "../src/shared/FreeStructs.sol";
 import { MockAccounts } from "test/utils/users/MockAccounts.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { IDiamondProxy } from "../src/generated/IDiamondProxy.sol";
@@ -241,7 +241,7 @@ contract T02AdminTest is D03ProtocolDefaults, MockAccounts {
         assertEq(entries[0].topics[0], keccak256("FunctionsLocked(bytes4[])"));
         (s_functionSelectors) = abi.decode(entries[0].data, (bytes4[]));
 
-        bytes4[] memory lockedFunctions = new bytes4[](18);
+        bytes4[] memory lockedFunctions = new bytes4[](21);
         lockedFunctions[0] = IDiamondProxy.startTokenSale.selector;
         lockedFunctions[1] = IDiamondProxy.paySimpleClaim.selector;
         lockedFunctions[2] = IDiamondProxy.paySimplePremium.selector;
@@ -260,6 +260,9 @@ contract T02AdminTest is D03ProtocolDefaults, MockAccounts {
         lockedFunctions[15] = IDiamondProxy.unstake.selector;
         lockedFunctions[16] = IDiamondProxy.collectRewards.selector;
         lockedFunctions[17] = IDiamondProxy.payReward.selector;
+        lockedFunctions[18] = IDiamondProxy.cancelSimplePolicy.selector;
+        lockedFunctions[19] = IDiamondProxy.createSimplePolicy.selector;
+        lockedFunctions[20] = IDiamondProxy.createEntity.selector;
 
         for (uint256 i = 0; i < lockedFunctions.length; i++) {
             assertTrue(nayms.isFunctionLocked(lockedFunctions[i]));
@@ -319,6 +322,18 @@ contract T02AdminTest is D03ProtocolDefaults, MockAccounts {
         vm.expectRevert("function is locked");
         nayms.collectRewards(bytes32(0));
 
+        vm.expectRevert("function is locked");
+        nayms.cancelSimplePolicy(bytes32(0));
+
+        Stakeholders memory stakeholders;
+        SimplePolicy memory simplePolicy;
+
+        vm.expectRevert("function is locked");
+        nayms.createSimplePolicy(bytes32(0), bytes32(0), stakeholders, simplePolicy, bytes32(0));
+
+        vm.expectRevert("function is locked");
+        nayms.createEntity(bytes32(0), bytes32(0), entity, bytes32(0));
+
         nayms.unlockAllFundTransferFunctions();
 
         assertFalse(nayms.isFunctionLocked(IDiamondProxy.startTokenSale.selector), "function startTokenSale locked");
@@ -339,5 +354,8 @@ contract T02AdminTest is D03ProtocolDefaults, MockAccounts {
         assertFalse(nayms.isFunctionLocked(IDiamondProxy.unstake.selector), "function unstake locked");
         assertFalse(nayms.isFunctionLocked(IDiamondProxy.payReward.selector), "function payReward locked");
         assertFalse(nayms.isFunctionLocked(IDiamondProxy.collectRewards.selector), "function collectRewards locked");
+        assertFalse(nayms.isFunctionLocked(IDiamondProxy.cancelSimplePolicy.selector), "function cancelSimplePolicy locked");
+        assertFalse(nayms.isFunctionLocked(IDiamondProxy.createSimplePolicy.selector), "function createSimplePolicy locked");
+        assertFalse(nayms.isFunctionLocked(IDiamondProxy.createEntity.selector), "function createEntity locked");
     }
 }


### PR DESCRIPTION
Added emergency locking on the functions {create, cancel} SimplePolicy, createEntity. These are included in {lock, unlock} AllFundTransferFunctions.