### PR TITLE
NAY-32 Remove rebaseERC20 method

### DIFF
--- a/src/facets/TokenizedVaultFacet.sol
+++ b/src/facets/TokenizedVaultFacet.sol
@@ -171,8 +171,4 @@ contract TokenizedVaultFacet is Modifiers, ReentrancyGuard {
         LibTokenizedVault._claimRebasingInterest(_tokenId, _amount);
         LibTokenizedVault._payDividend(_guid, _tokenId, _tokenId, _tokenId, _amount);
     }
-
-    function rebaseERC20(bytes32 _tokenId, uint256 _amount) external assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_ADMINS) {
-        LibTokenizedVault._rebaseERC20(_tokenId, _amount);
-    }
 }

--- a/src/libs/LibTokenizedVault.sol
+++ b/src/libs/LibTokenizedVault.sol
@@ -296,18 +296,4 @@ library LibTokenizedVault {
         s.tokenBalances[_tokenId][_tokenId] += _amount;
         s.depositTotal[_tokenId] += _amount;
     }
-
-    // This should only be called once for all coins on the network, then deleted in a future upgrade
-    function _rebaseERC20(bytes32 _tokenId, uint256 _amount) internal {
-        AppStorage storage s = LibAppStorage.diamondStorage();
-        address tokenAddress = LibHelpers._getAddressFromId(_tokenId);
-
-        uint256 currentBalance = LibERC20.balanceOf(tokenAddress, address(this));
-
-        if (_amount > currentBalance) {
-            revert RebasingAmountInvalid(_tokenId, _amount, currentBalance);
-        }
-
-        s.depositTotal[_tokenId] = _amount;
-    }
 }


### PR DESCRIPTION
Following was reported during the latest smart contract audit:

> In `LibTokenizedVault` , function `_rebaseERC20()` , the rationale of providing an `_amount` parameter to the function `_rebaseERC20()` is unclear, and could harm the system, since any value between 0 and currentBalance is a valid input to hardcode the new value of `s.depositTotal[_tokenId]`. An alternative could be to use all the amount available instead.

Amount argument was put in place we decide to take some commission.

This method is removed as it's only purpose was to migrate the existing onchain data to support the rebasing tokens. Since this has been done now, the method is not needed any more and it's being removed here.