### PR TITLE
NAY-20 Emit correct values

### DIFF
--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -41,7 +41,9 @@ library LibTokenizedVaultStaking {
         } else {
             revert StakingAlreadyStarted(_entityId, _config.tokenId);
         }
-        emit TokenStakingStarted(_entityId, _config.tokenId, block.timestamp, _config.a, _config.r, _config.divider, _config.interval);
+
+        // note: Staking starts on the initDate which could be a future date relative to the current block.timestamp
+        emit TokenStakingStarted(_entityId, _config.tokenId, _config.initDate, _config.a, _config.r, _config.divider, _config.interval);
     }
 
     function _isStakingInitialized(bytes32 _entityId) internal view returns (bool) {

--- a/src/shared/FreeStructs.sol
+++ b/src/shared/FreeStructs.sol
@@ -20,6 +20,14 @@ struct TokenAmount {
     uint256 amount;
 }
 
+/// @dev Used in the order matching algorithm.
+struct OrderMatchingCalcs {
+    uint256 currentSellAmount;
+    uint256 currentBuyAmount;
+    uint256 normalizedBuyAmount;
+    uint256 normalizedSellAmount;
+}
+
 /**
  * @param maxCapacity Maximum allowable amount of capacity that an entity is given. Denominated by assetId.
  * @param utilizedCapacity The utilized capacity of the entity. Denominated by assetId.


### PR DESCRIPTION
In the function `_matchToExistingOffers()`, the amount to be used for the event `OrderMatched` should be the final
amounts calculated, meaning the normalized amounts if there was a normalization.
This required some refactoring to avoid stack too deep. 

 In the function `_initStaking()`, the event `TokenStakingStarted` now correctly emits the `initDate`.