### PR TITLE
NAY-21 Add documentation for confusing validations

### DIFF
--- a/src/libs/LibEntity.sol
+++ b/src/libs/LibEntity.sol
@@ -119,6 +119,7 @@ library LibEntity {
 
         // policy-level receivers are expected
         uint256 commissionReceiversArrayLength = simplePolicy.commissionReceivers.length;
+        // note: The number of commission receivers could be less than the number of stakeholders, but not more.
         require(commissionReceiversArrayLength <= _stakeholders.roles.length, "too many commission receivers"); // error too many POLICY level commission receivers
 
         uint256 commissionBasisPointsArrayLength = simplePolicy.commissionBasisPoints.length;

--- a/src/libs/LibFeeRouter.sol
+++ b/src/libs/LibFeeRouter.sol
@@ -202,6 +202,8 @@ library LibFeeRouter {
     }
 
     function _removeFeeSchedule(bytes32 _entityId, uint256 _feeScheduleType) internal {
+        // note: default fee schedule is stored at s.feeSchedules[LibConstants.DEFAULT_FEE_SCHEDULE][_feeScheduleType]
+        // cannot remove this default fee schedule.
         require(_entityId != LibConstants.DEFAULT_FEE_SCHEDULE, "cannot remove default fees");
         AppStorage storage s = LibAppStorage.diamondStorage();
         delete s.feeSchedules[_entityId][_feeScheduleType];


### PR DESCRIPTION
1. In `_validateSimplePolicyCreation()`, there can be fewer commission receivers than stakeholders in a policy.
2. In ` _removeFeeSchedule()`, default fee schedule is stored at `s.feeSchedules[LibConstants.DEFAULT_FEE_SCHEDULE][_feeScheduleType]`.
3. In the case where an external token is being traded for an external token:
The fee is taken in the form of the sell token.
For example, NAYM (sell) is being traded for USDC (buy) - the fee is taken in NAYM.
USDC (sell) is being traded for NAYM (buy) - the fee is taken in USDC.