### PR TITLE
NAY-7 Throw custom error in accrued interest function

### DIFF
--- a/src/libs/LibTokenizedVault.sol
+++ b/src/libs/LibTokenizedVault.sol
@@ -7,7 +7,7 @@ import { LibConstants as LC } from "./LibConstants.sol";
 import { LibHelpers } from "./LibHelpers.sol";
 import { LibObject } from "./LibObject.sol";
 import { LibERC20 } from "./LibERC20.sol";
-import { RebasingInterestNotInitialized, RebasingInterestInsufficient, RebasingAmountInvalid } from "../shared/CustomErrors.sol";
+import { RebasingInterestNotInitialized, RebasingInterestInsufficient, RebasingAmountInvalid, RebasingSupplyDecreased } from "../shared/CustomErrors.sol";
 
 import { InsufficientBalance } from "../shared/CustomErrors.sol";
 
@@ -278,6 +278,10 @@ library LibTokenizedVault {
         uint256 depositTotal = s.depositTotal[_tokenId];
         uint256 total = LibERC20.balanceOf(tokenAddress, address(this));
 
+        // If the Nayms balance of the rebasing token has decreased and is lower than the deposit total, revert
+        if (total < depositTotal) {
+            revert RebasingSupplyDecreased(_tokenId, depositTotal, total);
+        }
         return total - depositTotal;
     }
 

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -158,3 +158,6 @@ error InvalidTokenRewardAmount(bytes32 guid, bytes32 entityId, bytes32 rewardTok
 
 /// @dev Insuficient balance available to perform the transfer of funds
 error InsufficientBalance(bytes32 tokenId, bytes32 from, uint256 balance, uint256 amount);
+
+/// @dev The account of rebasing tokens held by Nayms is greater than the account of rebasing tokens held by the rebasing contract
+error RebasingSupplyDecreased(bytes32 tokenId, uint256 accountInNayms, uint256 accountInRebasingContract);


### PR DESCRIPTION
In `LibTokenizedVault`, an underflow is possible in the function `_accruedInterest()`, if `total < depositTotal`. In this
case, reflecting the rebasing of the supported token will not be possible until the condition returns `true` again.

If the Nayms balance of the rebasing token has decreased and is lower than the deposit total, we now throw a custom error.