### PR TITLE
NAY-8 Fix check in updateRoleGroup to ensure null padded System Admins group name does not pass

### DIFF
--- a/src/facets/ACLFacet.sol
+++ b/src/facets/ACLFacet.sol
@@ -147,7 +147,7 @@ contract ACLFacet is Modifiers {
      * @param _roleInGroup is member of
      */
     function updateRoleGroup(string memory _role, string memory _group, bool _roleInGroup) external assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_ADMINS) {
-        require(!LibString.eq(_group, LC.GROUP_SYSTEM_ADMINS), "system admins group is not modifiable");
+        require(_group._stringToBytes32() != LC.GROUP_SYSTEM_ADMINS._stringToBytes32(), "system admins group is not modifiable");
         LibACL._updateRoleGroup(_role, _group, _roleInGroup);
     }
 }

--- a/test/T02ACL.t.sol
+++ b/test/T02ACL.t.sol
@@ -344,30 +344,15 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
         vm.stopPrank();
     }
 
-    function test_UpdateRoleGroup_PaddedGroupName() public {
-        // In our system, "System Admins" is the special group name for System Admins.
-        // ""System Admins " with a padded space or any other string is not the same as "System Admins".
-        string memory paddedGroup = string.concat(LC.GROUP_SYSTEM_ADMINS, " ");
+    function test_UpdateRoleGroup_NullPaddedGroupName() public {
+        // Pad "System Admins" with null characters
+        // "System Admins\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+        string memory paddedGroup = string(LC.GROUP_SYSTEM_ADMINS._stringToBytes32()._bytes32ToBytes());
+
         changePrank(sa);
-        nayms.updateRoleGroup(LC.ROLE_SYSTEM_UNDERWRITER, paddedGroup, true);
-
-        // A system admin is able to call the following function.
-        nayms.setMaxDividendDenominations(3);
-
-        // Can a SYSTEM UNDERWRITER now do something that only a SYSTEM_ADMIN should be able to do?
-        changePrank(su);
-        vm.expectRevert();
-        nayms.setMaxDividendDenominations(2);
-
-        // We can't add anything to the system admins group
-        changePrank(sa);
+        // Ensure that "System Admins" concatenated with null values does not bypass the check
         vm.expectRevert("system admins group is not modifiable");
-        nayms.updateRoleGroup(LC.ROLE_SYSTEM_UNDERWRITER, LC.GROUP_SYSTEM_ADMINS, true);
-
-        assertTrue(nayms.isRoleInGroup(LC.ROLE_SYSTEM_UNDERWRITER, paddedGroup));
-        assertFalse(nayms.isRoleInGroup(LC.ROLE_SYSTEM_UNDERWRITER, LC.GROUP_SYSTEM_ADMINS));
-        assertTrue(nayms.isInGroup(su.id, systemContext, paddedGroup));
-        assertFalse(nayms.isInGroup(su.id, systemContext, LC.GROUP_SYSTEM_ADMINS));
+        nayms.updateRoleGroup(LC.ROLE_SYSTEM_UNDERWRITER, paddedGroup, true);
     }
 
     function testUpdateRoleGroup() public {

--- a/test/T02ACL.t.sol
+++ b/test/T02ACL.t.sol
@@ -344,6 +344,32 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
         vm.stopPrank();
     }
 
+    function test_UpdateRoleGroup_PaddedGroupName() public {
+        // In our system, "System Admins" is the special group name for System Admins.
+        // ""System Admins " with a padded space or any other string is not the same as "System Admins".
+        string memory paddedGroup = string.concat(LC.GROUP_SYSTEM_ADMINS, " ");
+        changePrank(sa);
+        nayms.updateRoleGroup(LC.ROLE_SYSTEM_UNDERWRITER, paddedGroup, true);
+
+        // A system admin is able to call the following function.
+        nayms.setMaxDividendDenominations(3);
+
+        // Can a SYSTEM UNDERWRITER now do something that only a SYSTEM_ADMIN should be able to do?
+        changePrank(su);
+        vm.expectRevert();
+        nayms.setMaxDividendDenominations(2);
+
+        // We can't add anything to the system admins group
+        changePrank(sa);
+        vm.expectRevert("system admins group is not modifiable");
+        nayms.updateRoleGroup(LC.ROLE_SYSTEM_UNDERWRITER, LC.GROUP_SYSTEM_ADMINS, true);
+
+        assertTrue(nayms.isRoleInGroup(LC.ROLE_SYSTEM_UNDERWRITER, paddedGroup));
+        assertFalse(nayms.isRoleInGroup(LC.ROLE_SYSTEM_UNDERWRITER, LC.GROUP_SYSTEM_ADMINS));
+        assertTrue(nayms.isInGroup(su.id, systemContext, paddedGroup));
+        assertFalse(nayms.isInGroup(su.id, systemContext, LC.GROUP_SYSTEM_ADMINS));
+    }
+
     function testUpdateRoleGroup() public {
         changePrank(sa.addr);
         nayms.assignRole(em.id, systemContext, LC.ROLE_ENTITY_MANAGER);


### PR DESCRIPTION
Fixed the `GROUP_SYSTEM_ADMINS` group name check in `updateRoleGroup()` to ensure that the string "System Admins" padded with null values does not bypass the check to ensure that this group (`System Admins`) is not modifiable.