### PR TITLE
NAY-12 Prevent catastrophic loss of system admin controlled account

### DIFF
--- a/src/libs/LibACL.sol
+++ b/src/libs/LibACL.sol
@@ -7,9 +7,11 @@ import { LibHelpers } from "./LibHelpers.sol";
 import { LibAdmin } from "./LibAdmin.sol";
 import { LibObject } from "./LibObject.sol";
 import { LibConstants } from "./LibConstants.sol";
-import { OwnerCannotBeSystemAdmin, RoleIsMissing, AssignerGroupIsMissing } from "../shared/CustomErrors.sol";
+import { CannotUnassignRoleFromSelf, OwnerCannotBeSystemAdmin, RoleIsMissing, AssignerGroupIsMissing } from "../shared/CustomErrors.sol";
 
 library LibACL {
+    using LibHelpers for bytes32;
+
     /**
      * @dev Emitted when a role gets updated. Empty roleId is assigned upon role removal
      * @param objectId The user or object that was assigned the role.
@@ -66,6 +68,8 @@ library LibACL {
 
         bytes32 roleId = s.roles[_objectId][_contextId];
         if (_contextId == LibAdmin._getSystemId() && roleId == LibHelpers._stringToBytes32(LibConstants.ROLE_SYSTEM_ADMIN)) {
+            if (msg.sender == _objectId._getAddressFromId()) revert CannotUnassignRoleFromSelf(LibConstants.ROLE_SYSTEM_ADMIN);
+
             require(s.sysAdmins > 1, "must have at least one system admin");
             unchecked {
                 s.sysAdmins -= 1;

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -158,3 +158,6 @@ error InvalidTokenRewardAmount(bytes32 guid, bytes32 entityId, bytes32 rewardTok
 
 /// @dev Insuficient balance available to perform the transfer of funds
 error InsufficientBalance(bytes32 tokenId, bytes32 from, uint256 balance, uint256 amount);
+
+/// @dev Cannot unassign the role from the sender
+error CannotUnassignRoleFromSelf(string role);

--- a/test/T02ACL.t.sol
+++ b/test/T02ACL.t.sol
@@ -19,6 +19,11 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
     /// deployer, owner, address(this), account0 are all the same address. This address should not be able to have the system admin role
     /// systemAdmin is another address
 
+    function test_SystemAdminCannotUnassignTheirOwnSystemAdminRole() public {
+        changePrank(sa);
+        vm.expectRevert(abi.encodeWithSelector(CannotUnassignRoleFromSelf.selector, LC.ROLE_SYSTEM_ADMIN));
+        nayms.unassignRole(sa.id, systemContext);
+    }
     // the deployer should NOT be a system admin
     function testDeployerIsNotASystemAdmin() public {
         assertFalse(nayms.isInGroup(account0Id, systemContext, LC.GROUP_SYSTEM_ADMINS));


### PR DESCRIPTION
The following concern was raised:

In the contract `NaymsOwnershipFacet`, in the function `transferOwnership()`, the ownership can be lost if
`_newOwner` is an address owned by no one. A two-step transfer could solve this.

To address this:

We now prevent a user with the system admin role from unassigning this role from themselves. This forces only owned addresses to be able to renounce a system admin role. 