### PR TITLE
NAY-28 Children Objects Can Trigger Staking-Related Operations on Behalf of Their Parent

### DIFF
--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -110,6 +110,8 @@ library LibTokenizedVaultStaking {
     function _stake(bytes32 _stakerId, bytes32 _entityId, uint256 _amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
+        require(LibObject._isObjectType(_stakerId, LC.OBJECT_TYPE_ENTITY), "only an entity can stake");
+
         bytes32 tokenId = s.stakingConfigs[_entityId].tokenId;
 
         uint64 currentInterval = _currentInterval(_entityId);
@@ -155,6 +157,8 @@ library LibTokenizedVaultStaking {
     // Unstakes the full amount for a staker
     function _unstake(bytes32 _stakerId, bytes32 _entityId) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
+
+        require(LibObject._isObjectType(_stakerId, LC.OBJECT_TYPE_ENTITY), "only an entity can unstake");
 
         bytes32 tokenId = s.stakingConfigs[_entityId].tokenId;
 
@@ -259,6 +263,8 @@ library LibTokenizedVaultStaking {
 
     function _collectRewards(bytes32 _stakerId, bytes32 _entityId, uint64 _interval) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
+
+        require(LibObject._isObjectType(_stakerId, LC.OBJECT_TYPE_ENTITY), "only an entity can collect rewards");
 
         bytes32 tokenId = s.stakingConfigs[_entityId].tokenId;
 


### PR DESCRIPTION
The normal behavior for the staking feature is to let children objects of an entity trigger the following operations on
behalf of their parent entity: `stake()` , `unstake()` , and `collectRewards()`. While this behaviour makes sense, the fact that the parent is an entity is not checked. As a result, edge cases may be possible for parent-child relationships where the child is an address (EOA or contract) able to call one of these three operations, and the parent is not an entity that owns the staking token. In such a case, the child will be able to trigger a transfer of staking tokens on behalf of his parent. Such an operation, if feasible, could negatively impact the system and its accounting.

Added requirement that the staker ID type must be `ENTITY`.