### PR TITLE
NAY-31 Automatically fulfilled token sales can be created due to missing `objectMinimumSell` checks

### DIFF
--- a/src/libs/LibEntity.sol
+++ b/src/libs/LibEntity.sol
@@ -240,10 +240,13 @@ library LibEntity {
     /// @param _amount the amount of entity token that is minted and put on sale
     /// @param _totalPrice the buy amount
     function _startTokenSale(bytes32 _entityId, uint256 _amount, uint256 _totalPrice) internal {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
         require(_amount > 0, "mint amount must be > 0");
         require(_totalPrice > 0, "total price must be > 0");
 
-        AppStorage storage s = LibAppStorage.diamondStorage();
+        bytes32 assetId = s.entities[_entityId].assetId;
+        require(_totalPrice > s.objectMinimumSell[assetId], "total price must be greater than asset minimum sell amount");
 
         if (!s.existingEntities[_entityId]) {
             revert EntityDoesNotExist(_entityId);

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -1007,6 +1007,9 @@ contract T04EntityTest is D03ProtocolDefaults {
         vm.expectRevert("total price must be > 0");
         nayms.startTokenSale(entityId1, sellAmount, 0);
 
+        vm.expectRevert("total price must be greater than asset minimum sell amount");
+        nayms.startTokenSale(entityId1, sellAmount, 1);
+
         uint256 lastOfferId = nayms.getLastOfferId();
 
         nayms.startTokenSale(entityId1, sellAmount, sellAtPrice);


### PR DESCRIPTION
When starting a token sale, the sold token amount may be less than the corresponding entities token `objectMinimumSell` amount, which was set during `EntityFacet.enableEntityTokenization()`, resulting in the created offer to be automatically in the `LibConstants.OFFER_STATE_FULFILLED` state. Similarly, the buyAmount is not verified to be greater than `objectMinimumSell` of the corresponding `entity.assetId`. 

Also, offers can be created for not-yet-tokenized entity p-tokens. Leading to their automatic fulfilment on creation.