### PR TITLE
NAY-3 NLF itself cannot stake 

### DIFF
--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -121,6 +121,7 @@ library LibTokenizedVaultStaking {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         require(LibObject._isObjectType(_stakerId, LC.OBJECT_TYPE_ENTITY), "only an entity can stake");
+        require(_stakerId != _entityId, "staking entity itself cannot stake");
 
         bytes32 tokenId = s.stakingConfigs[_entityId].tokenId;
 

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -869,4 +869,14 @@ contract T06Staking is D03ProtocolDefaults {
         (, uint256[] memory amounts) = nayms.getRewardsBalance(stakerId, nlfId);
         return amounts.length > 0 ? amounts[0] : 0;
     }
+
+    function test_NAY3_nlfItselfCantStake() public {
+        startPrank(nlf);
+        naymToken.mint(nlf.addr, 10_000_000e18);
+        naymToken.approve(address(nayms), 10_000_000e18);
+        nayms.externalDeposit(address(naymToken), 10_000_000e18);
+
+        vm.expectRevert("staking entity itself cannot stake");
+        nayms.stake(nlf.entityId, 10 ether);
+    }
 }


### PR DESCRIPTION
As staking happens on behalf of a users' entity and due to missing checks, it is possible for users of a staking entity to
stake into their entity on its behalf. This could lead to double accounting issues.