### PR TITLE
NAY-10 Missing input validations

### DIFF
--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -9,7 +9,6 @@ import { LibObject } from "./LibObject.sol";
 import { LibERC20 } from "./LibERC20.sol";
 import { LibEntity } from "./LibEntity.sol";
 import { LibACL } from "./LibACL.sol";
-
 // prettier-ignore
 import {
     CannotAddNullDiscountToken,
@@ -20,7 +19,9 @@ import {
     EntityExistsAlready,
     EntityOnboardingAlreadyApproved,
     EntityOnboardingNotApproved,
-    InvalidSelfOnboardRoleApproval
+    InvalidSelfOnboardRoleApproval,
+    UserAlreadyHasParentEntity,
+    InvalidEntityId
 } from "../shared/CustomErrors.sol";
 
 import { IDiamondProxy } from "src/generated/IDiamondProxy.sol";
@@ -224,6 +225,12 @@ library LibAdmin {
 
     function _approveSelfOnboarding(address _userAddress, bytes32 _entityId, string calldata _role) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
+
+        // The entityId must be the valid type (entity).
+        if (!LibObject._isObjectType(_entityId, LC.OBJECT_TYPE_ENTITY)) revert InvalidEntityId(_entityId);
+
+        // Require that the user doesn't have a parent entity set already.
+        if (LibObject._getParentFromAddress(_userAddress) != 0) revert UserAlreadyHasParentEntity(_userAddress, LibObject._getParentFromAddress(_userAddress));
 
         bytes32 roleId = LibHelpers._stringToBytes32(_role);
 

--- a/src/libs/LibConstants.sol
+++ b/src/libs/LibConstants.sol
@@ -144,7 +144,7 @@ library LibConstants {
 
     /// @dev The maximum period of time the staking initDate can be from the current time.
     uint256 internal constant MAX_INIT_DATE_PERIOD = 120 days;
-    uint256 internal constant MIN_STAKING_INTERVAL = 0 days;
+    uint256 internal constant MIN_STAKING_INTERVAL = 5 minutes;
     uint256 internal constant MAX_STAKING_INTERVAL = 90 days;
 
     string internal constant VE_NAYM_NAME = "veNAYM";

--- a/src/libs/LibConstants.sol
+++ b/src/libs/LibConstants.sol
@@ -144,6 +144,8 @@ library LibConstants {
 
     /// @dev The maximum period of time the staking initDate can be from the current time.
     uint256 internal constant MAX_INIT_DATE_PERIOD = 120 days;
+    uint256 internal constant MIN_STAKING_INTERVAL = 0 days;
+    uint256 internal constant MAX_STAKING_INTERVAL = 90 days;
 
     string internal constant VE_NAYM_NAME = "veNAYM";
     string internal constant VE_NAYM_SYMBOL = "veNAYM";

--- a/src/libs/LibConstants.sol
+++ b/src/libs/LibConstants.sol
@@ -142,6 +142,9 @@ library LibConstants {
     int128 internal constant STAKING_INCREASE_LOCK_AMOUNT = 2;
     int128 internal constant STAKING_INCREASE_UNLOCK_TIME = 3;
 
+    /// @dev The maximum period of time the staking initDate can be from the current time.
+    uint256 internal constant MAX_INIT_DATE_PERIOD = 120 days;
+
     string internal constant VE_NAYM_NAME = "veNAYM";
     string internal constant VE_NAYM_SYMBOL = "veNAYM";
     uint8 internal constant VE_NAYM_DECIMALS = 18;

--- a/src/libs/LibConstants.sol
+++ b/src/libs/LibConstants.sol
@@ -133,6 +133,8 @@ library LibConstants {
     uint256 internal constant STAKING_MINTIME = 60 days; // 60 days min lock
     uint256 internal constant STAKING_MAXTIME = 4 * 365 days; // 4 years max lock
     uint256 internal constant SCALE = 1e18; //10 ^ 18
+    uint256 internal constant MAX_MATURATION_PERIOD = 3650 days; // ~ 10 years
+    uint256 internal constant MAX_POLICY_COMMISSION_RECEIVERS = 10;
 
     /// _depositFor Types for events
     int128 internal constant STAKING_DEPOSIT_FOR_TYPE = 0;

--- a/src/libs/LibFeeRouter.sol
+++ b/src/libs/LibFeeRouter.sol
@@ -5,7 +5,7 @@ import { AppStorage, LibAppStorage, CalculatedFees, FeeAllocation, FeeSchedule }
 import { LibObject } from "./LibObject.sol";
 import { LibConstants } from "./LibConstants.sol";
 import { LibTokenizedVault } from "./LibTokenizedVault.sol";
-import { FeeBasisPointsExceedHalfMax } from "../shared/CustomErrors.sol";
+import { FeeBasisPointsExceedHalfMax, EntityDoesNotExist, InvalidReceiverCount } from "../shared/CustomErrors.sol";
 
 library LibFeeRouter {
     event FeePaid(bytes32 indexed fromId, bytes32 indexed toId, bytes32 tokenId, uint256 amount, uint256 feeType);
@@ -167,7 +167,14 @@ library LibFeeRouter {
     function _addFeeSchedule(bytes32 _entityId, uint256 _feeScheduleType, bytes32[] calldata _receiver, uint16[] calldata _basisPoints) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
+        // The entity must exist or it must be the default fee schedule
+        if (!(s.existingEntities[_entityId] || _entityId == LibConstants.DEFAULT_FEE_SCHEDULE)) {
+            revert EntityDoesNotExist(_entityId);
+        }
+
         require(_receiver.length == _basisPoints.length, "receivers and basis points mismatch");
+
+        if (_receiver.length < 1 || _receiver.length > 10) revert InvalidReceiverCount(_receiver.length);
 
         // Remove the fee schedule for this _entityId/_feeScheduleType if it already exists
         delete s.feeSchedules[_entityId][_feeScheduleType];

--- a/src/libs/LibMarket.sol
+++ b/src/libs/LibMarket.sol
@@ -7,7 +7,7 @@ import { LibConstants } from "./LibConstants.sol";
 import { LibFeeRouter } from "./LibFeeRouter.sol";
 import { LibAdmin } from "./LibAdmin.sol";
 
-import { MinimumSellCannotBeZero } from "../shared/CustomErrors.sol";
+import { MinimumSellCannotBeZero, ObjectDoesNotExist } from "../shared/CustomErrors.sol";
 
 library LibMarket {
     struct MatchingOfferResult {
@@ -517,6 +517,9 @@ library LibMarket {
 
     function _setMinimumSell(bytes32 _objectId, uint256 _minimumSell) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
+
+        if (s.existingObjects[_objectId] == false) revert ObjectDoesNotExist(_objectId);
+
         if (_minimumSell == 0) revert MinimumSellCannotBeZero();
 
         s.objectMinimumSell[_objectId] = _minimumSell;

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -10,7 +10,7 @@ import { LibObject } from "./LibObject.sol";
 import { LibTokenizedVault } from "../libs/LibTokenizedVault.sol";
 import { StakingConfig, StakingState, RewardsBalances } from "../shared/FreeStructs.sol";
 
-import { StakingNotStarted, StakingAlreadyStarted, IntervalRewardPayedOutAlready, InvalidAValue, InvalidRValue, InvalidDividerValue, InvalidStakingInitDate, APlusRCannotBeGreaterThanDivider, InvalidIntervalSecondsValue, InvalidTokenRewardAmount } from "../shared/CustomErrors.sol";
+import { StakingNotStarted, StakingAlreadyStarted, IntervalRewardPayedOutAlready, InvalidAValue, InvalidRValue, InvalidDividerValue, InvalidStakingInitDate, APlusRCannotBeGreaterThanDivider, InvalidIntervalSecondsValue, InvalidTokenRewardAmount, EntityDoesNotExist } from "../shared/CustomErrors.sol";
 
 library LibTokenizedVaultStaking {
     event TokenStakingStarted(bytes32 indexed entityId, bytes32 tokenId, uint256 initDate, uint64 a, uint64 r, uint64 divider, uint64 interval);
@@ -34,6 +34,10 @@ library LibTokenizedVaultStaking {
 
     function _initStaking(bytes32 _entityId, StakingConfig calldata _config) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
+
+        if (!s.existingEntities[_entityId]) {
+            revert EntityDoesNotExist(_entityId);
+        }
 
         _validateStakingParams(_config);
 

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -10,7 +10,7 @@ import { LibObject } from "./LibObject.sol";
 import { LibTokenizedVault } from "../libs/LibTokenizedVault.sol";
 import { StakingConfig, StakingState, RewardsBalances } from "../shared/FreeStructs.sol";
 
-import { StakingNotStarted, StakingAlreadyStarted, IntervalRewardPayedOutAlready, InvalidAValue, InvalidRValue, InvalidDividerValue, InvalidStakingInitDate, APlusRCannotBeGreaterThanDivider, InvalidIntervalSecondsValue, InvalidTokenRewardAmount, EntityDoesNotExist, InitDateTooFar, IntervalOutOfRange } from "../shared/CustomErrors.sol";
+import { StakingNotStarted, StakingAlreadyStarted, IntervalRewardPayedOutAlready, InvalidAValue, InvalidRValue, InvalidDividerValue, InvalidStakingInitDate, APlusRCannotBeGreaterThanDivider, InvalidIntervalSecondsValue, InvalidTokenRewardAmount, EntityDoesNotExist, InitDateTooFar, IntervalOutOfRange, BoostMultiplierConvergenceFailure } from "../shared/CustomErrors.sol";
 
 library LibTokenizedVaultStaking {
     event TokenStakingStarted(bytes32 indexed entityId, bytes32 tokenId, uint256 initDate, uint64 a, uint64 r, uint64 divider, uint64 interval);
@@ -291,6 +291,7 @@ library LibTokenizedVaultStaking {
         if (_config.r == 0) revert InvalidRValue();
         if (_config.divider == 0) revert InvalidDividerValue();
         if (_config.a + _config.r > _config.divider) revert APlusRCannotBeGreaterThanDivider();
+        if (_config.a + _config.r != _config.divider) revert BoostMultiplierConvergenceFailure(_config.a, _config.r, _config.divider);
         if (_config.interval == 0) revert InvalidIntervalSecondsValue();
         if (_config.interval < LC.MIN_STAKING_INTERVAL || _config.interval > LC.MAX_STAKING_INTERVAL) {
             revert IntervalOutOfRange(_config.interval);

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -114,6 +114,14 @@ library LibTokenizedVaultStaking {
     function _stake(bytes32 _stakerId, bytes32 _entityId, uint256 _amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
+        if (!s.existingEntities[_stakerId]) {
+            revert EntityDoesNotExist(_stakerId);
+        }
+
+        if (!s.existingEntities[_entityId]) {
+            revert EntityDoesNotExist(_entityId);
+        }
+
         bytes32 tokenId = s.stakingConfigs[_entityId].tokenId;
 
         uint64 currentInterval = _currentInterval(_entityId);

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -10,7 +10,7 @@ import { LibObject } from "./LibObject.sol";
 import { LibTokenizedVault } from "../libs/LibTokenizedVault.sol";
 import { StakingConfig, StakingState, RewardsBalances } from "../shared/FreeStructs.sol";
 
-import { StakingNotStarted, StakingAlreadyStarted, IntervalRewardPayedOutAlready, InvalidAValue, InvalidRValue, InvalidDividerValue, InvalidStakingInitDate, APlusRCannotBeGreaterThanDivider, InvalidIntervalSecondsValue, InvalidTokenRewardAmount, EntityDoesNotExist, InitDateTooFar, IntervalOutOfRange, BoostMultiplierConvergenceFailure, InvalidTokenId, InvalidStakingAmount } from "../shared/CustomErrors.sol";
+import { StakingNotStarted, StakingAlreadyStarted, IntervalRewardPayedOutAlready, InvalidAValue, InvalidRValue, InvalidDividerValue, InvalidStakingInitDate, APlusRCannotBeGreaterThanDivider, InvalidIntervalSecondsValue, InvalidTokenRewardAmount, EntityDoesNotExist, InitDateTooFar, IntervalOutOfRange, BoostMultiplierConvergenceFailure, InvalidTokenId, InvalidStakingAmount, InvalidStaker } from "../shared/CustomErrors.sol";
 
 library LibTokenizedVaultStaking {
     event TokenStakingStarted(bytes32 indexed entityId, bytes32 tokenId, uint256 initDate, uint64 a, uint64 r, uint64 divider, uint64 interval);
@@ -124,15 +124,9 @@ library LibTokenizedVaultStaking {
     function _stake(bytes32 _stakerId, bytes32 _entityId, uint256 _amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
-        if (!s.existingEntities[_stakerId]) {
-            revert EntityDoesNotExist(_stakerId);
-        }
-
-        if (!s.existingEntities[_entityId]) {
-            revert EntityDoesNotExist(_entityId);
-        }
-
-        require(_stakerId != _entityId, "staking entity itself cannot stake");
+        if (!s.existingEntities[_stakerId]) revert EntityDoesNotExist(_stakerId);
+        if (!s.existingEntities[_entityId]) revert EntityDoesNotExist(_entityId);
+        if (_stakerId == _entityId) revert InvalidStaker(_stakerId);
 
         bytes32 tokenId = s.stakingConfigs[_entityId].tokenId;
 

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -10,7 +10,7 @@ import { LibObject } from "./LibObject.sol";
 import { LibTokenizedVault } from "../libs/LibTokenizedVault.sol";
 import { StakingConfig, StakingState, RewardsBalances } from "../shared/FreeStructs.sol";
 
-import { StakingNotStarted, StakingAlreadyStarted, IntervalRewardPayedOutAlready, InvalidAValue, InvalidRValue, InvalidDividerValue, InvalidStakingInitDate, APlusRCannotBeGreaterThanDivider, InvalidIntervalSecondsValue, InvalidTokenRewardAmount, EntityDoesNotExist, InitDateTooFar, IntervalOutOfRange, BoostMultiplierConvergenceFailure } from "../shared/CustomErrors.sol";
+import { StakingNotStarted, StakingAlreadyStarted, IntervalRewardPayedOutAlready, InvalidAValue, InvalidRValue, InvalidDividerValue, InvalidStakingInitDate, APlusRCannotBeGreaterThanDivider, InvalidIntervalSecondsValue, InvalidTokenRewardAmount, EntityDoesNotExist, InitDateTooFar, IntervalOutOfRange, BoostMultiplierConvergenceFailure, InvalidTokenId } from "../shared/CustomErrors.sol";
 
 library LibTokenizedVaultStaking {
     event TokenStakingStarted(bytes32 indexed entityId, bytes32 tokenId, uint256 initDate, uint64 a, uint64 r, uint64 divider, uint64 interval);
@@ -298,6 +298,7 @@ library LibTokenizedVaultStaking {
         }
         if (_config.initDate <= block.timestamp) revert InvalidStakingInitDate();
         if (_config.initDate > block.timestamp + LC.MAX_INIT_DATE_PERIOD) revert InitDateTooFar(_config.initDate);
+        if (_config.tokenId == 0) revert InvalidTokenId();
     }
 
     function _getR(bytes32 _entityId) internal view returns (uint64) {

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -123,7 +123,7 @@ library LibTokenizedVaultStaking {
 
     function _stake(bytes32 _stakerId, bytes32 _entityId, uint256 _amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
-        
+
         if (!s.existingEntities[_stakerId]) {
             revert EntityDoesNotExist(_stakerId);
         }

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -10,7 +10,7 @@ import { LibObject } from "./LibObject.sol";
 import { LibTokenizedVault } from "../libs/LibTokenizedVault.sol";
 import { StakingConfig, StakingState, RewardsBalances } from "../shared/FreeStructs.sol";
 
-import { StakingNotStarted, StakingAlreadyStarted, IntervalRewardPayedOutAlready, InvalidAValue, InvalidRValue, InvalidDividerValue, InvalidStakingInitDate, APlusRCannotBeGreaterThanDivider, InvalidIntervalSecondsValue, InvalidTokenRewardAmount, EntityDoesNotExist, InitDateTooFar } from "../shared/CustomErrors.sol";
+import { StakingNotStarted, StakingAlreadyStarted, IntervalRewardPayedOutAlready, InvalidAValue, InvalidRValue, InvalidDividerValue, InvalidStakingInitDate, APlusRCannotBeGreaterThanDivider, InvalidIntervalSecondsValue, InvalidTokenRewardAmount, EntityDoesNotExist, InitDateTooFar, IntervalOutOfRange } from "../shared/CustomErrors.sol";
 
 library LibTokenizedVaultStaking {
     event TokenStakingStarted(bytes32 indexed entityId, bytes32 tokenId, uint256 initDate, uint64 a, uint64 r, uint64 divider, uint64 interval);
@@ -284,6 +284,9 @@ library LibTokenizedVaultStaking {
         if (_config.divider == 0) revert InvalidDividerValue();
         if (_config.a + _config.r > _config.divider) revert APlusRCannotBeGreaterThanDivider();
         if (_config.interval == 0) revert InvalidIntervalSecondsValue();
+        if (_config.interval < LC.MIN_STAKING_INTERVAL || _config.interval > LC.MAX_STAKING_INTERVAL) {
+            revert IntervalOutOfRange(_config.interval);
+        }
         if (_config.initDate <= block.timestamp) revert InvalidStakingInitDate();
         if (_config.initDate > block.timestamp + LC.MAX_INIT_DATE_PERIOD) revert InitDateTooFar(_config.initDate);
     }

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -114,8 +114,6 @@ library LibTokenizedVaultStaking {
     function _stake(bytes32 _stakerId, bytes32 _entityId, uint256 _amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
-        if (_amount == 0) revert InvalidStakingAmount();
-
         if (!s.existingEntities[_stakerId]) {
             revert EntityDoesNotExist(_stakerId);
         }
@@ -125,6 +123,8 @@ library LibTokenizedVaultStaking {
         }
 
         bytes32 tokenId = s.stakingConfigs[_entityId].tokenId;
+
+        if (_amount < s.objectMinimumSell[tokenId]) revert InvalidStakingAmount();
 
         uint64 currentInterval = _currentInterval(_entityId);
         bytes32 vTokenIdMax = _vTokenIdBucket(tokenId);

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -10,7 +10,7 @@ import { LibObject } from "./LibObject.sol";
 import { LibTokenizedVault } from "../libs/LibTokenizedVault.sol";
 import { StakingConfig, StakingState, RewardsBalances } from "../shared/FreeStructs.sol";
 
-import { StakingNotStarted, StakingAlreadyStarted, IntervalRewardPayedOutAlready, InvalidAValue, InvalidRValue, InvalidDividerValue, InvalidStakingInitDate, APlusRCannotBeGreaterThanDivider, InvalidIntervalSecondsValue, InvalidTokenRewardAmount, EntityDoesNotExist } from "../shared/CustomErrors.sol";
+import { StakingNotStarted, StakingAlreadyStarted, IntervalRewardPayedOutAlready, InvalidAValue, InvalidRValue, InvalidDividerValue, InvalidStakingInitDate, APlusRCannotBeGreaterThanDivider, InvalidIntervalSecondsValue, InvalidTokenRewardAmount, EntityDoesNotExist, InitDateTooFar } from "../shared/CustomErrors.sol";
 
 library LibTokenizedVaultStaking {
     event TokenStakingStarted(bytes32 indexed entityId, bytes32 tokenId, uint256 initDate, uint64 a, uint64 r, uint64 divider, uint64 interval);
@@ -285,6 +285,7 @@ library LibTokenizedVaultStaking {
         if (_config.a + _config.r > _config.divider) revert APlusRCannotBeGreaterThanDivider();
         if (_config.interval == 0) revert InvalidIntervalSecondsValue();
         if (_config.initDate <= block.timestamp) revert InvalidStakingInitDate();
+        if (_config.initDate > block.timestamp + LC.MAX_INIT_DATE_PERIOD) revert InitDateTooFar(_config.initDate);
     }
 
     function _getR(bytes32 _entityId) internal view returns (uint64) {

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -10,7 +10,7 @@ import { LibObject } from "./LibObject.sol";
 import { LibTokenizedVault } from "../libs/LibTokenizedVault.sol";
 import { StakingConfig, StakingState, RewardsBalances } from "../shared/FreeStructs.sol";
 
-import { StakingNotStarted, StakingAlreadyStarted, IntervalRewardPayedOutAlready, InvalidAValue, InvalidRValue, InvalidDividerValue, InvalidStakingInitDate, APlusRCannotBeGreaterThanDivider, InvalidIntervalSecondsValue, InvalidTokenRewardAmount, EntityDoesNotExist, InitDateTooFar, IntervalOutOfRange, BoostMultiplierConvergenceFailure, InvalidTokenId } from "../shared/CustomErrors.sol";
+import { StakingNotStarted, StakingAlreadyStarted, IntervalRewardPayedOutAlready, InvalidAValue, InvalidRValue, InvalidDividerValue, InvalidStakingInitDate, APlusRCannotBeGreaterThanDivider, InvalidIntervalSecondsValue, InvalidTokenRewardAmount, EntityDoesNotExist, InitDateTooFar, IntervalOutOfRange, BoostMultiplierConvergenceFailure, InvalidTokenId, InvalidStakingAmount } from "../shared/CustomErrors.sol";
 
 library LibTokenizedVaultStaking {
     event TokenStakingStarted(bytes32 indexed entityId, bytes32 tokenId, uint256 initDate, uint64 a, uint64 r, uint64 divider, uint64 interval);
@@ -113,6 +113,8 @@ library LibTokenizedVaultStaking {
 
     function _stake(bytes32 _stakerId, bytes32 _entityId, uint256 _amount) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
+
+        if (_amount == 0) revert InvalidStakingAmount();
 
         if (!s.existingEntities[_stakerId]) {
             revert EntityDoesNotExist(_stakerId);

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -161,8 +161,10 @@ error InsufficientBalance(bytes32 tokenId, bytes32 from, uint256 balance, uint25
 
 /// @dev Cannot unassign the role from the sender
 error CannotUnassignRoleFromSelf(string role);
+
 /// @dev The account of rebasing tokens held by Nayms is greater than the account of rebasing tokens held by the rebasing contract
 error RebasingSupplyDecreased(bytes32 tokenId, uint256 accountInNayms, uint256 accountInRebasingContract);
+
 /// @dev This error is used to indicate that the signature could not be verified.
 /// @param hash The hash of the message that was signed.
 /// @notice This error suggests that the signature itself is malformed or does not correspond to the hash provided.
@@ -172,3 +174,6 @@ error InvalidSignatureError(bytes32 hash);
 /// @param sValue The 's' value of the ECDSA signature that was deemed invalid.
 /// @notice This error is triggered when the 's' value of the signature is not within the lower half of the secp256k1 curve's order, which can lead to malleability issues.
 error InvalidSignatureSError(bytes32 sValue);
+
+/// @dev Thrown when the number of receivers specified in a transaction is not within the acceptable range.
+error InvalidReceiverCount(uint256 numberOfReceivers);

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -203,3 +203,6 @@ error IntervalOutOfRange(uint256 interval);
 
 /// @dev Thrown when the sum of parameters 'a' and 'r' does not equal the 'divider', which is necessary for the boost multiplier to asymptotically converge to 2.
 error BoostMultiplierConvergenceFailure(uint256 a, uint256 r, uint256 divider);
+
+/// @dev This internal token ID is invalid for the given context.
+error InvalidTokenId();

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -177,3 +177,9 @@ error InvalidSignatureSError(bytes32 sValue);
 
 /// @dev Thrown when the number of receivers specified in a transaction is not within the acceptable range.
 error InvalidReceiverCount(uint256 numberOfReceivers);
+
+/// @dev User cannot have a parent entity for the given context.
+error UserAlreadyHasParentEntity(address userAddress, bytes32 usersParentEntity);
+
+/// @dev The entity ID is invalid for the given context.
+error InvalidEntityId(bytes32 entityId);

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -206,3 +206,6 @@ error BoostMultiplierConvergenceFailure(uint256 a, uint256 r, uint256 divider);
 
 /// @dev This internal token ID is invalid for the given context.
 error InvalidTokenId();
+
+/// @dev Cannot stake 0 amount.
+error InvalidStakingAmount();

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -153,6 +153,9 @@ error InvalidIntervalSecondsValue();
 /// @dev Invalid staking start date provided
 error InvalidStakingInitDate();
 
+/// @dev staking entity itself should not be allowed to stake
+error InvalidStaker(bytes32 entityId);
+
 /// @dev Only one reward payment is allowed per interval
 error IntervalRewardPayedOutAlready(uint64 interval);
 

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -197,3 +197,6 @@ error ExcessiveCommissionReceivers(uint256 numberOfReceivers, uint256 maxReceive
 
 /// @dev Thrown when the initialization date for staking is set too far in the future, beyond the system-defined maximum limit.
 error InitDateTooFar(uint256 initDate);
+
+/// @dev Thrown when the staking interval is set outside the allowed range, either too short or too long, as defined by system limits.
+error IntervalOutOfRange(uint256 interval);

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -38,6 +38,9 @@ error CannotSupportExternalTokenWithMoreThan18Decimals();
 /// @dev Passing in a missing address when trying to assign a new token address as the new discount token.
 error CannotAddNullDiscountToken();
 
+/// @dev Object does not exsit when it should.
+error ObjectDoesNotExist(bytes32 objectId);
+
 /// @dev The entity does not exist when it should.
 error EntityDoesNotExist(bytes32 objectId);
 

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -200,3 +200,6 @@ error InitDateTooFar(uint256 initDate);
 
 /// @dev Thrown when the staking interval is set outside the allowed range, either too short or too long, as defined by system limits.
 error IntervalOutOfRange(uint256 interval);
+
+/// @dev Thrown when the sum of parameters 'a' and 'r' does not equal the 'divider', which is necessary for the boost multiplier to asymptotically converge to 2.
+error BoostMultiplierConvergenceFailure(uint256 a, uint256 r, uint256 divider);

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -194,3 +194,6 @@ error MaturationDateTooFar(uint256 maturationDate);
 /// @dev Thrown when the number of commission receivers for a policy exceeds the system's maximum limit.
 /// This limit is enforced to prevent out-of-gas errors during commission payouts, ensuring the system remains functional and efficient.
 error ExcessiveCommissionReceivers(uint256 numberOfReceivers, uint256 maxReceivers);
+
+/// @dev Thrown when the initialization date for staking is set too far in the future, beyond the system-defined maximum limit.
+error InitDateTooFar(uint256 initDate);

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -207,5 +207,5 @@ error BoostMultiplierConvergenceFailure(uint256 a, uint256 r, uint256 divider);
 /// @dev This internal token ID is invalid for the given context.
 error InvalidTokenId();
 
-/// @dev Cannot stake 0 amount.
+/// @dev Cannot stake an amount lower than objectMinimumSell[tokenId].
 error InvalidStakingAmount();

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -186,3 +186,11 @@ error UserAlreadyHasParentEntity(address userAddress, bytes32 usersParentEntity)
 
 /// @dev The entity ID is invalid for the given context.
 error InvalidEntityId(bytes32 entityId);
+
+/// @dev Thrown when the maturation date of a policy is set beyond the allowable future date limit.
+/// This prevents setting unrealistic maturation dates that could affect the contract's operability or the enforceability of the policy.
+error MaturationDateTooFar(uint256 maturationDate);
+
+/// @dev Thrown when the number of commission receivers for a policy exceeds the system's maximum limit.
+/// This limit is enforced to prevent out-of-gas errors during commission payouts, ensuring the system remains functional and efficient.
+error ExcessiveCommissionReceivers(uint256 numberOfReceivers, uint256 maxReceivers);

--- a/test/NewFees.t.sol
+++ b/test/NewFees.t.sol
@@ -59,12 +59,17 @@ contract NewFeesTest is D03ProtocolDefaults {
     }
 
     function test_removeFeeSchedule() public {
-        bytes32 entityId = "anything";
+        bytes32 entityId = makeId(LC.OBJECT_TYPE_ENTITY, bytes20(keccak256("anything")));
+
+        changePrank(sm);
+        nayms.createEntity(entityId, acc1.id, entityInfo, testHash);
+
         FeeSchedule memory defaultFeeSchedule = nayms.getFeeSchedule(entityId, LC.FEE_TYPE_PREMIUM);
 
         bytes32[] memory customRecipient = b32Array1("recipient");
         uint16[] memory customFeeBP = u16Array1(42);
 
+        changePrank(sa);
         nayms.addFeeSchedule(entityId, LC.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
 
         FeeSchedule memory storedFeeSchedule = nayms.getFeeSchedule(entityId, LC.FEE_TYPE_PREMIUM);
@@ -83,8 +88,21 @@ contract NewFeesTest is D03ProtocolDefaults {
         assertEq(feeSchedule, premiumFeeScheduleDefault);
     }
 
+    function test_AddFeeSchedule_EntityDoesNotExist() public {
+        bytes32 entityWithCustom = makeId(LC.OBJECT_TYPE_ENTITY, bytes20(keccak256("entity with CUSTOM fee schedule")));
+
+        bytes32[] memory customRecipient = b32Array1(NAYMS_LTD_IDENTIFIER);
+        uint16[] memory customFeeBP = u16Array1(301);
+
+        vm.expectRevert(abi.encodeWithSelector(EntityDoesNotExist.selector, entityWithCustom));
+        nayms.addFeeSchedule(entityWithCustom, LC.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
+    }
     function test_getPremiumCommissionSchedule_Custom() public {
-        bytes32 entityWithCustom = keccak256("entity with CUSTOM fee schedule");
+        bytes32 entityWithCustom = makeId(LC.OBJECT_TYPE_ENTITY, bytes20(keccak256("entity with CUSTOM fee schedule")));
+
+        changePrank(sm);
+        nayms.createEntity(entityWithCustom, acc1.id, entityInfo, testHash);
+
         FeeSchedule memory feeSchedule = nayms.getFeeSchedule(entityWithCustom, LC.FEE_TYPE_PREMIUM);
 
         assertEq(feeSchedule, premiumFeeScheduleDefault);
@@ -92,6 +110,7 @@ contract NewFeesTest is D03ProtocolDefaults {
         bytes32[] memory customRecipient = b32Array1(NAYMS_LTD_IDENTIFIER);
         uint16[] memory customFeeBP = u16Array1(301);
 
+        changePrank(sa);
         nayms.addFeeSchedule(entityWithCustom, LC.FEE_TYPE_PREMIUM, customRecipient, customFeeBP);
 
         FeeSchedule memory customFeeSchedule = feeSched(customRecipient, customFeeBP);
@@ -106,7 +125,11 @@ contract NewFeesTest is D03ProtocolDefaults {
     }
 
     function test_getTradingCommissionSchedule_Custom() public {
-        bytes32 entityWithCustom = keccak256("entity with CUSTOM");
+        bytes32 entityWithCustom = makeId(LC.OBJECT_TYPE_ENTITY, bytes20(keccak256("entity with CUSTOM")));
+
+        changePrank(sm);
+        nayms.createEntity(entityWithCustom, acc1.id, entityInfo, testHash);
+
         FeeSchedule memory feeSchedule = nayms.getFeeSchedule(entityWithCustom, LC.FEE_TYPE_TRADING);
 
         assertEq(feeSchedule, tradingFeeScheduleDefault);
@@ -114,6 +137,7 @@ contract NewFeesTest is D03ProtocolDefaults {
         bytes32[] memory customRecipient = b32Array1(NAYMS_LTD_IDENTIFIER);
         uint16[] memory customFeeBP = u16Array1(31);
 
+        changePrank(sa);
         nayms.addFeeSchedule(entityWithCustom, LC.FEE_TYPE_TRADING, customRecipient, customFeeBP);
 
         FeeSchedule memory customFeeSchedule = feeSched(customRecipient, customFeeBP);

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -1174,7 +1174,7 @@ contract T04EntityTest is D03ProtocolDefaults {
 
         vm.startPrank(em.addr);
         vm.expectRevert(abi.encodeWithSelector(InvalidSelfOnboardRoleApproval.selector, LC.ROLE_SYSTEM_MANAGER));
-        nayms.approveSelfOnboarding(signer1, randomEntityId(1), LC.ROLE_SYSTEM_MANAGER);
+        nayms.approveSelfOnboarding(address(111), randomEntityId(1), LC.ROLE_SYSTEM_MANAGER);
         vm.stopPrank();
     }
 
@@ -1184,18 +1184,18 @@ contract T04EntityTest is D03ProtocolDefaults {
         bytes32 entityId = randomEntityId(2);
 
         vm.startPrank(em.addr);
-        nayms.approveSelfOnboarding(signer1, entityId, LC.ROLE_ENTITY_TOKEN_HOLDER);
+        nayms.approveSelfOnboarding(address(111), entityId, LC.ROLE_ENTITY_TOKEN_HOLDER);
 
-        vm.expectRevert(abi.encodeWithSelector(EntityOnboardingAlreadyApproved.selector, signer1));
-        nayms.approveSelfOnboarding(signer1, entityId, LC.ROLE_ENTITY_CP);
+        vm.expectRevert(abi.encodeWithSelector(EntityOnboardingAlreadyApproved.selector, address(111)));
+        nayms.approveSelfOnboarding(address(111), entityId, LC.ROLE_ENTITY_CP);
         vm.stopPrank();
     }
 
     function testSelfOnboardingSuccess() public {
         nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
 
-        _selfOnboard(signer1, randomEntityId(1), LC.ROLE_ENTITY_TOKEN_HOLDER, LC.GROUP_TOKEN_HOLDERS);
-        _selfOnboard(signer2, randomEntityId(2), LC.ROLE_ENTITY_CP, LC.GROUP_CAPITAL_PROVIDERS);
+        _selfOnboard(address(111), randomEntityId(1), LC.ROLE_ENTITY_TOKEN_HOLDER, LC.GROUP_TOKEN_HOLDERS);
+        _selfOnboard(address(222), randomEntityId(2), LC.ROLE_ENTITY_CP, LC.GROUP_CAPITAL_PROVIDERS);
     }
 
     function testSelfOnboardingCancel() public {
@@ -1204,17 +1204,17 @@ contract T04EntityTest is D03ProtocolDefaults {
         bytes32 entityId = randomEntityId(2);
 
         vm.startPrank(em.addr);
-        nayms.approveSelfOnboarding(signer1, entityId, LC.ROLE_ENTITY_TOKEN_HOLDER);
+        nayms.approveSelfOnboarding(address(111), entityId, LC.ROLE_ENTITY_TOKEN_HOLDER);
 
-        assertTrue(nayms.isSelfOnboardingApproved(signer1, entityId), "Onboarding should be approved");
+        assertTrue(nayms.isSelfOnboardingApproved(address(111), entityId), "Onboarding should be approved");
 
         vm.expectRevert(abi.encodeWithSelector(InvalidGroupPrivilege.selector, em.addr._getIdForAddress(), systemContext, LC.ROLE_ONBOARDING_APPROVER, LC.GROUP_SYSTEM_MANAGERS));
-        nayms.cancelSelfOnboarding(signer1);
+        nayms.cancelSelfOnboarding(address(111));
 
         vm.startPrank(sm.addr);
-        nayms.cancelSelfOnboarding(signer1);
+        nayms.cancelSelfOnboarding(address(111));
 
-        assertFalse(nayms.isSelfOnboardingApproved(signer1, entityId), "Onboarding should have been cancelled");
+        assertFalse(nayms.isSelfOnboardingApproved(address(111), entityId), "Onboarding should have been cancelled");
     }
 
     function _selfOnboard(address _userAddress, bytes32 entityId, string memory roleName, string memory groupName) private {
@@ -1244,12 +1244,32 @@ contract T04EntityTest is D03ProtocolDefaults {
 
         bytes32 entityId = randomEntityId(9);
 
-        _selfOnboard(signer1, entityId, LC.ROLE_ENTITY_TOKEN_HOLDER, LC.GROUP_TOKEN_HOLDERS);
+        _selfOnboard(address(111), entityId, LC.ROLE_ENTITY_TOKEN_HOLDER, LC.GROUP_TOKEN_HOLDERS);
 
         vm.startPrank(em.addr);
         vm.expectRevert(abi.encodeWithSelector(EntityExistsAlready.selector, entityId));
-        nayms.approveSelfOnboarding(signer1, entityId, LC.ROLE_ENTITY_TOKEN_HOLDER);
+        nayms.approveSelfOnboarding(address(222), entityId, LC.ROLE_ENTITY_TOKEN_HOLDER);
         vm.stopPrank();
+    }
+
+    function test_ApproveSelfOnboarding_InvalidEntityId() public {
+        nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
+
+        bytes32 entityId = keccak256("invalid entity id");
+
+        vm.startPrank(em.addr);
+        vm.expectRevert(abi.encodeWithSelector(InvalidEntityId.selector, entityId));
+        nayms.approveSelfOnboarding(address(111), entityId, LC.ROLE_ENTITY_TOKEN_HOLDER);
+    }
+
+    function test_ApproveSelfOnboarding_UserAlreadyHasParentEntity() public {
+        nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
+
+        bytes32 entityId = randomEntityId(9);
+
+        vm.startPrank(em.addr);
+        vm.expectRevert(abi.encodeWithSelector(UserAlreadyHasParentEntity.selector, signer1, nayms.getEntity(signer1Id)));
+        nayms.approveSelfOnboarding(signer1, entityId, LC.ROLE_ENTITY_TOKEN_HOLDER);
     }
 
     function randomEntityId(uint256 salt) public view returns (bytes32) {

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -514,20 +514,21 @@ contract T04EntityTest is D03ProtocolDefaults {
 
         // fee schedule receivers
         // change fee schedule to one that does not have any receivers
-        bytes32[] memory r;
-        uint16[] memory bp;
+        // bytes32[] memory r;
+        // uint16[] memory bp;
 
-        vm.startPrank(systemAdmin);
-        nayms.addFeeSchedule(LC.DEFAULT_FEE_SCHEDULE, LC.FEE_TYPE_PREMIUM, r, bp);
-        vm.startPrank(su.addr);
-        vm.expectRevert("must have fee schedule receivers");
-        nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
+        // note: this test is not possible anymore because the fee schedule cannot be reset to be empty
+        // vm.startPrank(systemAdmin);
+        // nayms.addFeeSchedule(LC.DEFAULT_FEE_SCHEDULE, LC.FEE_TYPE_PREMIUM, r, bp);
+        // vm.startPrank(su.addr);
+        // vm.expectRevert("must have fee schedule receivers");
+        // nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
 
-        // add back fee receiver
-        r = b32Array1(NAYMS_LTD_IDENTIFIER);
-        bp = u16Array1(300);
-        vm.startPrank(systemAdmin);
-        nayms.addFeeSchedule(LC.DEFAULT_FEE_SCHEDULE, LC.FEE_TYPE_PREMIUM, r, bp);
+        // // add back fee receiver
+        // r = b32Array1(NAYMS_LTD_IDENTIFIER);
+        // bp = u16Array1(300);
+        // vm.startPrank(systemAdmin);
+        // nayms.addFeeSchedule(LC.DEFAULT_FEE_SCHEDULE, LC.FEE_TYPE_PREMIUM, r, bp);
 
         vm.startPrank(su.addr);
         vm.expectRevert("number of commissions don't match");

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -10,7 +10,7 @@ import { DummyToken } from "./utils/DummyToken.sol";
 
 import { LibTokenizedVaultStaking } from "src/libs/LibTokenizedVaultStaking.sol";
 
-import { IntervalRewardPayedOutAlready, InvalidTokenRewardAmount } from "src/shared/CustomErrors.sol";
+import { IntervalRewardPayedOutAlready, InvalidTokenRewardAmount, InvalidStakingAmount } from "src/shared/CustomErrors.sol";
 
 function makeId2(bytes12 _objecType, bytes20 randomBytes) pure returns (bytes32) {
     return bytes32((_objecType)) | (bytes32(randomBytes));
@@ -161,6 +161,16 @@ contract T06Staking is D03ProtocolDefaults {
 
         vm.warp(stakingConfig.initDate + stakingConfig.interval * 2);
         assertEq(nayms.currentInterval(nlf.entityId), 2, "current interval not 2");
+    }
+
+    function test_Stake_InvalidStakingAmount() public {
+        uint256 start = block.timestamp + 1;
+
+        initStaking(start);
+
+        startPrank(bob);
+        vm.expectRevert(abi.encodeWithSelector(InvalidStakingAmount.selector));
+        nayms.stake(nlf.entityId, 0);
     }
 
     function test_stake() public {

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -10,7 +10,7 @@ import { StakingFixture } from "test/fixtures/StakingFixture.sol";
 import { DummyToken } from "./utils/DummyToken.sol";
 import { LibTokenizedVaultStaking } from "src/libs/LibTokenizedVaultStaking.sol";
 
-import { IntervalRewardPayedOutAlready, InvalidTokenRewardAmount, InvalidStakingAmount } from "src/shared/CustomErrors.sol";
+import { IntervalRewardPayedOutAlready, InvalidTokenRewardAmount, InvalidStakingAmount, InvalidStaker } from "src/shared/CustomErrors.sol";
 
 function makeId2(bytes12 _objecType, bytes20 randomBytes) pure returns (bytes32) {
     return bytes32((_objecType)) | (bytes32(randomBytes));
@@ -887,7 +887,8 @@ contract T06Staking is D03ProtocolDefaults {
         naymToken.approve(address(nayms), 10_000_000e18);
         nayms.externalDeposit(address(naymToken), 10_000_000e18);
 
-        vm.expectRevert("staking entity itself cannot stake");
+        vm.expectRevert(abi.encodeWithSelector(InvalidStaker.selector, nlf.entityId));
+
         nayms.stake(nlf.entityId, 10 ether);
     }
 }

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -74,7 +74,7 @@ contract T06Staking is D03ProtocolDefaults {
         naymToken.mint(lou.addr, 10_000_000e18);
 
         startPrank(sa);
-        nayms.addSupportedExternalToken(address(naymToken), 1e18);
+        nayms.addSupportedExternalToken(address(naymToken), 100);
 
         vm.startPrank(sm.addr);
         hCreateEntity(bob.entityId, bob, entity, "Bob data");


### PR DESCRIPTION
## Identified Issues in Solidity Functions

### 1. LibFeeRouter._addFeeSchedule()
- **a. Entity Validation Missing**: The function does not check whether `_entityId` matches an existing entity.
- **b. Receiver Length Unchecked**: There is no minimum and maximum check for the length of `_receivers`, which could lead to a denial of service.

**Actions:**
Can only update the fee schedule of an existing entity.
Set the max number of receivers to 10.

### 2. LibAdmin._approveSelfOnboarding()
- **a. Zero Address Approval**: `_entityId` can be `address(0)`, and the approval will be recorded, but the user will not be able to onboard.
- **b. Re-Approval for Different Entities**: It is possible to repeat the steps `approveSelfOnboarding()` and `onboard()` for the same user but multiple entities, potentially leading to inconsistent state or unintended permissions.

**Actions:**
Ensure that the `_entityId` is valid. 
User must not already have a parent set.

### 3. LibMarket._setMinimumSell()
- **No Object Existence Check**: No check ensures that `_objectId` represents an existing object.

**Actions:**
Must be an existing entity.

### 4. LibEntity._validateSimplePolicyCreation()
- **a. Maturation Date Far Future**: No check ensures that the maturation date is not set too far in the future.
- **b. High Number of Commission Receivers**: No check ensures that the number of policy-level commission receivers is not too high, which could lead to out-of-gas errors during payouts.

**Actions:**
Restrict policy maturation dates to 3650 days in the future.
Set policy commission receivers limit to 10.

### 5. LibTokenizedVaultStaking._initStaking()
- **Entity Existence Check Missing**: No check ensures that `_entityId` represents an existing entity.

**Actions:**
Must be an existing entity.

### 6. LibTokenizedVaultStaking._payReward()
- **Incorrect Token Types for Rewards**: p-tokens can be transferred as rewards instead of limiting to supported external tokens.

**Actions:**


### 7. LibTokenizedVaultStaking._validateStakingParams()
- **Init Date Too Far in Future**: The value of `initDate` can be set in a very long time from the current time.

**Actions:**
Staking initDate must start within 120 days.

### 8. LibTokenizedVaultStaking._validateStakingParams()
- **Interval Bounds Unchecked**: There is no minimum or maximum check for the value of `interval`.

**Actions:**
Set minimum to 5 minutes (will update this after testing).
Set maximum to 90 days.

### 9. LibTokenizedVaultStaking._stake()
- **Zero Amount Staking**: The `_amount` can be `0`.
- **Invalid Staker ID**: `_stakerId` can be `0` if `msg.sender` has no parent.
- **Non-existent Entity**: `_entityId` can be a non-existent entity.

**Actions:**
Cannot stake the `objectMinimumSell[tokenId]` amount.
Ensure `_entityId` and parent of `msg.sender` are existing entities.

### 10. LibTokenizedVaultStaking._validateStakingParams()
- **Boost Multiplier Convergence Insufficient**: The check `if (_config.a + _config.r > _config.divider) revert APlusRCannotBeGreaterThanDivider();` is insufficient to ensure that the boost multiplier asymptotically converges to 2, which is only true when `_config.a + _config.r == _config.divider`.

**Actions:**
Ensure `a + r = divider`.

### 11. LibTokenizedVaultStaking._validateStakingParams()
- **Token ID Check Missing**: The value of `tokenId` is not checked, which could lead to using:
  - The zero/empty object ID;
  - The p-token of another entity;
  - An external token ID;
  - The ID of a wrapped internal token;
  - Any other arbitrary non-object ID.

**Actions:**
Cannot be zero address.