### PR TITLE
NAY-4  Prevent object ID collision exploits

### DIFF
--- a/src/facets/SystemFacet.sol
+++ b/src/facets/SystemFacet.sol
@@ -52,6 +52,15 @@ contract SystemFacet is Modifiers, ReentrancyGuard {
     }
 
     /**
+     * @dev Update existing objects mapping directly. Use with great caution! Requires System Admin privilidge.
+     * @param _id object ids.
+     * @param _isExisting set the flag to this value
+     */
+    function setExistingObjects(bytes32[] calldata _id, bool _isExisting) external assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_ADMINS) {
+        LibObject._setExistingObjects(_id, _isExisting);
+    }
+
+    /**
      * @dev Get meta of given object.
      * @param _id object id.
      * @return parent object parent

--- a/src/libs/LibObject.sol
+++ b/src/libs/LibObject.sol
@@ -167,6 +167,14 @@ library LibObject {
         return s.existingObjects[_id];
     }
 
+    function _setExistingObjects(bytes32[] calldata _id, bool _isExisting) internal {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        require(_id.length <= 10, "too many ids");
+        for (uint i = 0; i < _id.length; i++) {
+            s.existingObjects[_id[i]] = _isExisting;
+        }
+    }
+
     function _getObjectType(bytes32 _objectId) internal pure returns (bytes12 objectType) {
         bytes32 shifted = _objectId >> 160;
         assembly {


### PR DESCRIPTION
The Nayms' platform uses a bytes32 identifier to distinguish the different objects in the system and store relational
attributes between them in mappings, for instance, the token balances of each object, or the access permissions between objects.

The mapping `existingObjects(bytes32 => bool)` stores the fact that an object with a specific identifier exists or not.
However, not all objects identified by an identifier are in this mapping. For instance, roles and groups have an identifier but are not considered as existing in the system. This could lead to collisions when we can create an object b with the same identifier as the object a which is already used by the system but is not an existing object according to the mapping.

Added method to update the mapping directly, assuming system admin privileges.