### PR TITLE
Remove redundant object creation events

### DIFF
--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -38,6 +38,9 @@ error CannotSupportExternalTokenWithMoreThan18Decimals();
 /// @dev Passing in a missing address when trying to assign a new token address as the new discount token.
 error CannotAddNullDiscountToken();
 
+/// @dev Object exsists when it should not.
+error ObjectExistsAlready(bytes32 objectId);
+
 /// @dev Object does not exsit when it should.
 error ObjectDoesNotExist(bytes32 objectId);
 

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -593,7 +593,7 @@ contract T04EntityTest is D03ProtocolDefaults {
         getReadyToCreatePolicies();
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
 
-        vm.expectRevert("objectId is already being used by another object");
+        vm.expectRevert(abi.encodeWithSelector(ObjectExistsAlready.selector, policyId1));
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
     }
 
@@ -679,11 +679,11 @@ contract T04EntityTest is D03ProtocolDefaults {
         nayms.createSimplePolicy(policyId1, entityId1, stakeholders, simplePolicy, testPolicyDataHash);
 
         Vm.Log[] memory entries = vm.getRecordedLogs();
-        // events: 4 role assignments + 1 policy creation => we want event at index 4
-        assertEq(entries[6].topics.length, 2);
-        assertEq(entries[6].topics[0], keccak256("SimplePolicyCreated(bytes32,bytes32)"));
-        assertEq(entries[6].topics[1], policyId1);
-        bytes32 entityId = abi.decode(entries[6].data, (bytes32));
+        // events: 1 object creation, 4 role assignments + 1 policy creation => we want event at index 5
+        assertEq(entries[5].topics.length, 2);
+        assertEq(entries[5].topics[0], keccak256("SimplePolicyCreated(bytes32,bytes32)"));
+        assertEq(entries[5].topics[1], policyId1);
+        bytes32 entityId = abi.decode(entries[5].data, (bytes32));
         assertEq(entityId, entityId1);
     }
 


### PR DESCRIPTION
With current implementation the `LibObject._createObject(bytes32,bytes12)` method is called by the other two overloading methods(`_createObject(bytes32,bytes12,bytes32)` and `_createObject(bytes32,bytes12,bytes32,bytes32)`), but all three of them emit the `ObjectCreated(bytes32,bytes32,bytes32)` event. 

This means that calling an overloading method emits two events: the event from the method it calls and from itself, which is not ideal.

We want to always emit just one event per object created.