### PR TITLE
Remaining reward adjustment when unstaking before any rewards

### DIFF
--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -190,9 +190,11 @@ library LibTokenizedVaultStaking {
         _collectRewards(_stakerId, _entityId, currentInterval);
         s.stakeCollected[_entityId][_stakerId] = currentInterval;
 
-        s.stakingDistributionAmount[vTokenIdLastPaid] -=
-            (s.stakingDistributionAmount[vTokenIdLastPaid] * s.stakeBalance[vTokenIdLastPaid][_stakerId]) /
-            s.stakeBalance[vTokenIdLastPaid][_entityId];
+        if (s.stakingDistributionAmount[vTokenIdLastPaid] != 0 && s.stakeBalance[vTokenIdLastPaid][_entityId] != 0) {
+            s.stakingDistributionAmount[vTokenIdLastPaid] -=
+                (s.stakingDistributionAmount[vTokenIdLastPaid] * s.stakeBalance[vTokenIdLastPaid][_stakerId]) /
+                s.stakeBalance[vTokenIdLastPaid][_entityId];
+        }
 
         s.stakeBalance[vTokenIdLastPaid][_entityId] -= s.stakeBalance[vTokenIdLastPaid][_stakerId];
 
@@ -273,7 +275,7 @@ library LibTokenizedVaultStaking {
             bytes32 vTokenId = _vTokenId(tokenId, _interval);
 
             // Update state
-            s.stakeCollected[_entityId][_stakerId] = _interval; // TODO: set to the actual reward interval, not current!
+            s.stakeCollected[_entityId][_stakerId] = _interval;
             s.stakeBoost[vTokenId][_stakerId] = state.boost;
             s.stakeBalance[vTokenId][_stakerId] = state.balance;
 

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -576,6 +576,21 @@ contract T06Staking is D03ProtocolDefaults {
                 : (stakingStates[na.entityId][interval].balance * rewardAmount) / stakingStates[nlf.entityId][interval].balance;
     }
 
+    function test_simpleStakeUnstake() public {
+        initStaking(I);
+        vm.warp(2 * I + 10 days); // important not to stake at [0] interval!
+
+        uint256 balanceBefore = nayms.internalBalanceOf(bob.entityId, usdcId);
+
+        startPrank(bob);
+        nayms.stake(nlf.entityId, bobStakeAmount);
+
+        vm.warp(6 * I + 15 days);
+        nayms.unstake(nlf.entityId);
+
+        assertEq(nayms.internalBalanceOf(bob.entityId, usdcId), balanceBefore, "balance should be the same");
+    }
+
     function test_unstakeScenario1() public {
         test_StakingScenario1();
 


### PR DESCRIPTION
When unstaking available rewards are automatically collected. Also, the remaining unclaimed reward amount has to be adjusted proportionally to the stake being taken out.

This adjustment is causing division by zero, if a user is unstaking at a non zero interval before any reward has been payed out.

To address this problem, there will be no adjustment unless there is a reason for it.