### PR TITLE
Fix remaining reward normalisation on unstake

### DIFF
--- a/gemforge.deployments.json
+++ b/gemforge.deployments.json
@@ -160,22 +160,22 @@
     "chainId": 11155111,
     "contracts": [
       {
+        "name": "StakingFacet",
+        "fullyQualifiedName": "StakingFacet.sol:StakingFacet",
+        "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
+        "txHash": "0xfa443f86d5c49e9a7c65b28d38aa1bfe2b4933b3505c312ff0c201eb658bcefe",
+        "onChain": {
+          "address": "0x43EA9F8fAEbA469D1703de4e387333384008145d",
+          "constructorArgs": []
+        }
+      },
+      {
         "name": "AdminFacet",
         "fullyQualifiedName": "AdminFacet.sol:AdminFacet",
         "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
         "txHash": "0x993476c962bbe86862c6a8971d292ecf806d9e40e64cdc5d04459b3309b9747f",
         "onChain": {
           "address": "0x7D513C6914C26bFda3eff2C85043072c706A0A9F",
-          "constructorArgs": []
-        }
-      },
-      {
-        "name": "StakingFacet",
-        "fullyQualifiedName": "StakingFacet.sol:StakingFacet",
-        "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
-        "txHash": "0x35245803d091c034804c6325c1d306a6fcfecef176e0a9ada0c8c857c22cc743",
-        "onChain": {
-          "address": "0xf3D3A7Dce67305EAC4bD90da03860495E0AC2D87",
           "constructorArgs": []
         }
       },
@@ -895,22 +895,22 @@
     "chainId": 84532,
     "contracts": [
       {
+        "name": "StakingFacet",
+        "fullyQualifiedName": "StakingFacet.sol:StakingFacet",
+        "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
+        "txHash": "0x506613ccb8a97c929869b1fb35c863789f2fa3e63e929c2573579c5d1440b01c",
+        "onChain": {
+          "address": "0x6254eFd84cE152306448E2d10c4dF7DCE6C99765",
+          "constructorArgs": []
+        }
+      },
+      {
         "name": "AdminFacet",
         "fullyQualifiedName": "AdminFacet.sol:AdminFacet",
         "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
         "txHash": "0xdeb6984ded7ed5d765023fbba841a16e2c23d3156fdce3aad4987baf30641bb8",
         "onChain": {
           "address": "0xE33cb0263Cd518E689a6b2c838cc1CA9FcD56030",
-          "constructorArgs": []
-        }
-      },
-      {
-        "name": "StakingFacet",
-        "fullyQualifiedName": "StakingFacet.sol:StakingFacet",
-        "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
-        "txHash": "0x7b09121bb4cfdb2a4dec190c5823d9edd6bd1fa2d218250ec77cb8e7a8c487c2",
-        "onChain": {
-          "address": "0xfB745DE4Fe187b5Ab18f0e5afB00ca38bC561c71",
           "constructorArgs": []
         }
       },

--- a/gemforge.deployments.json
+++ b/gemforge.deployments.json
@@ -163,9 +163,9 @@
         "name": "StakingFacet",
         "fullyQualifiedName": "StakingFacet.sol:StakingFacet",
         "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
-        "txHash": "0xfa443f86d5c49e9a7c65b28d38aa1bfe2b4933b3505c312ff0c201eb658bcefe",
+        "txHash": "0xe225da67abec24c800d9013060c473982b23a97e373e750b2eb4acf94d05a2ab",
         "onChain": {
-          "address": "0x43EA9F8fAEbA469D1703de4e387333384008145d",
+          "address": "0x9fe477A2f188EdecDaF491CcE5Be7EF24Fa837C5",
           "constructorArgs": []
         }
       },
@@ -898,9 +898,9 @@
         "name": "StakingFacet",
         "fullyQualifiedName": "StakingFacet.sol:StakingFacet",
         "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
-        "txHash": "0x506613ccb8a97c929869b1fb35c863789f2fa3e63e929c2573579c5d1440b01c",
+        "txHash": "0x1651e616eb28cb3c0bbae64ffc180b0380859bc58f8de466feb78a42da506d1a",
         "onChain": {
-          "address": "0x6254eFd84cE152306448E2d10c4dF7DCE6C99765",
+          "address": "0x0d6B1372B47eC993a7E530F914906fC31C82AaFd",
           "constructorArgs": []
         }
       },

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -225,8 +225,7 @@ library LibTokenizedVaultStaking {
         // Get the last interval where distribution was collected by the user.
         state.lastCollectedInterval = s.stakeCollected[_entityId][_stakerId];
         if (_interval < state.lastCollectedInterval) {
-            // nothing to do, return zeroes
-            return (state, rewards);
+            return (state, rewards); // nothing to do, return zeroes
         }
         if (_interval > _currentInterval(_entityId)) {
             revert("interval is in the future");

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -175,7 +175,6 @@ library LibTokenizedVaultStaking {
     // Unstakes the full amount for a staker
     function _unstake(bytes32 _stakerId, bytes32 _entityId) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
-
         require(LibObject._isObjectType(_stakerId, LC.OBJECT_TYPE_ENTITY), "only an entity can unstake");
 
         bytes32 tokenId = s.stakingConfigs[_entityId].tokenId;
@@ -226,7 +225,8 @@ library LibTokenizedVaultStaking {
         // Get the last interval where distribution was collected by the user.
         state.lastCollectedInterval = s.stakeCollected[_entityId][_stakerId];
         if (_interval < state.lastCollectedInterval) {
-            revert("rewards already collected");
+            // nothing to do, return zeroes
+            return (state, rewards);
         }
         if (_interval > _currentInterval(_entityId)) {
             revert("interval is in the future");

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -186,12 +186,12 @@ library LibTokenizedVaultStaking {
         bytes32 vTokenIdNext = _vTokenId(tokenId, currentInterval + 1);
         bytes32 vTokenIdLastPaid = _vTokenId(tokenId, lastPaidInterval);
 
+        // must read states before the reward is claimed!
         (StakingState memory userStateAtLastPaid, ) = _getStakingStateWithRewardsBalances(_stakerId, _entityId, lastPaidInterval);
         (StakingState memory totalStateAtLastPaid, ) = _getStakingStateWithRewardsBalances(_entityId, _entityId, lastPaidInterval);
 
-        // collect your rewards first
-        _collectRewards(_stakerId, _entityId, currentInterval);
-        s.stakeCollected[_entityId][_stakerId] = currentInterval;
+        _collectRewards(_stakerId, _entityId, currentInterval); // collect rewards first
+        s.stakeCollected[_entityId][_stakerId] = currentInterval; // update collection interval, even if no reward
 
         if (s.stakingDistributionAmount[vTokenIdLastPaid] != 0 && s.stakeBalance[vTokenIdLastPaid][_entityId] != 0) {
             s.stakingDistributionAmount[vTokenIdLastPaid] -= (s.stakingDistributionAmount[vTokenIdLastPaid] * userStateAtLastPaid.balance) / totalStateAtLastPaid.balance;

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -186,19 +186,19 @@ library LibTokenizedVaultStaking {
         bytes32 vTokenIdNext = _vTokenId(tokenId, currentInterval + 1);
         bytes32 vTokenIdLastPaid = _vTokenId(tokenId, lastPaidInterval);
 
-        (StakingState memory lastPaidState, ) = _getStakingStateWithRewardsBalances(_stakerId, _entityId, lastPaidInterval);
-        (StakingState memory lastCollectedState, ) = _getStakingStateWithRewardsBalances(_entityId, _entityId, lastPaidInterval);
+        (StakingState memory userStateAtLastPaid, ) = _getStakingStateWithRewardsBalances(_stakerId, _entityId, lastPaidInterval);
+        (StakingState memory totalStateAtLastPaid, ) = _getStakingStateWithRewardsBalances(_entityId, _entityId, lastPaidInterval);
 
         // collect your rewards first
         _collectRewards(_stakerId, _entityId, currentInterval);
         s.stakeCollected[_entityId][_stakerId] = currentInterval;
 
         if (s.stakingDistributionAmount[vTokenIdLastPaid] != 0 && s.stakeBalance[vTokenIdLastPaid][_entityId] != 0) {
-            s.stakingDistributionAmount[vTokenIdLastPaid] -= (s.stakingDistributionAmount[vTokenIdLastPaid] * lastPaidState.balance) / lastCollectedState.balance;
+            s.stakingDistributionAmount[vTokenIdLastPaid] -= (s.stakingDistributionAmount[vTokenIdLastPaid] * userStateAtLastPaid.balance) / totalStateAtLastPaid.balance;
         }
 
-        s.stakeBalance[vTokenIdLastPaid][_entityId] -= lastPaidState.balance;
-        s.stakeBoost[vTokenIdLastPaid][_entityId] -= lastPaidState.boost;
+        s.stakeBalance[vTokenIdLastPaid][_entityId] -= userStateAtLastPaid.balance;
+        s.stakeBoost[vTokenIdLastPaid][_entityId] -= userStateAtLastPaid.boost;
 
         s.stakeBoost[vTokenId][_stakerId] = 0;
         s.stakeBoost[vTokenIdNext][_stakerId] = 0;

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -247,8 +247,6 @@ library LibTokenizedVaultStaking {
                     uint256 currencyIndex;
                     (rewards, currencyIndex) = addUniqueValue(rewards, s.stakingDistributionDenomination[_vTokenId(tokenId, i)]);
 
-                    // c.log("  -- reward share[%s]: %s / %s".yellow(), i, state.balance / 1e18, s.stakeBalance[_vTokenId(tokenId, i)][_entityId] / 1e18);
-
                     // Use the same math as dividend distributions, assuming zero has already been collected
                     uint256 userDistributionAmount = LibTokenizedVault._getWithdrawableDividendAndDeductionMath(
                         state.balance,

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -147,7 +147,7 @@ contract T06Staking is D03ProtocolDefaults {
         return amounts.length > 0 ? amounts[0] : 0;
     }
 
-    function printBoosts(bytes32 entityId, bytes32 stakerId, string memory name) internal view {
+    function printCurrentState(bytes32 entityId, bytes32 stakerId, string memory name) internal view {
         uint64 interval = currentInterval();
         StakingState memory stakingState = nayms.getStakingState(stakerId, entityId);
 
@@ -279,7 +279,7 @@ contract T06Staking is D03ProtocolDefaults {
 
         startPrank(bob);
         nayms.stake(nlf.entityId, bobStakeAmount);
-        printBoosts(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
 
         recordStakingState(bob.entityId); // re-read state
         assertEq(stakingStates[bob.entityId][0].balance, bobStakeAmount, "Bob's staking balance[0] should increase");
@@ -293,8 +293,8 @@ contract T06Staking is D03ProtocolDefaults {
         vm.warp(stakingStart - 10 days);
         startPrank(sue);
         nayms.stake(nlf.entityId, sueStakeAmount);
-        printBoosts(nlf.entityId, sue.entityId, "Sue");
-        printBoosts(nlf.entityId, nlf.entityId, "Nayms");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+        printCurrentState(nlf.entityId, nlf.entityId, "Nayms");
 
         recordStakingState(sue.entityId);
         assertEq(stakingStates[sue.entityId][0].balance, sueStakeAmount, "Sue's staking balance[0] should increase");
@@ -311,8 +311,8 @@ contract T06Staking is D03ProtocolDefaults {
         vm.warp(stakingStart + 20 days);
         startPrank(lou);
         nayms.stake(nlf.entityId, louStakeAmount);
-        printBoosts(nlf.entityId, lou.entityId, "Lou");
-        printBoosts(nlf.entityId, nlf.entityId, "Nayms");
+        printCurrentState(nlf.entityId, lou.entityId, "Lou");
+        printCurrentState(nlf.entityId, nlf.entityId, "Nayms");
 
         recordStakingState(lou.entityId);
         assertEq(stakingStates[lou.entityId][0].balance, louStakeAmount, "Lou's staking balance[0] should increase");
@@ -345,7 +345,7 @@ contract T06Staking is D03ProtocolDefaults {
         vm.expectRevert(abi.encodeWithSelector(IntervalRewardPayedOutAlready.selector, 1));
         nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("1a")), nlf.entityId, usdcId, rewardAmount);
 
-        printBoosts(nlf.entityId, nlf.entityId, "Nayms");
+        printCurrentState(nlf.entityId, nlf.entityId, "Nayms");
 
         recordStakingState(nlf.entityId); // re-read state
         assertEq(stakingStates[nlf.entityId][1].balance, 765e6, "Nayms' staking balance[1] should increase");
@@ -363,7 +363,7 @@ contract T06Staking is D03ProtocolDefaults {
         assertEq(stakingStates[lou.entityId][1].balance, 420e6, "Lou's staking balance[1] should increase");
         assertEq(stakingStates[lou.entityId][1].boost, 57e6, "Lou's boost[1] should increase");
 
-        printBoosts(nlf.entityId, lou.entityId, "Lou");
+        printCurrentState(nlf.entityId, lou.entityId, "Lou");
 
         c.log("(TIME: 60)".blue(), " ~~~~~~~~~~~~~ Distribution[2] Paid ~~~~~~~~~~~~~".yellow());
         vm.warp(stakingStart + 60 days);
@@ -379,8 +379,8 @@ contract T06Staking is D03ProtocolDefaults {
         assertEq(stakingStates[nlf.entityId][2].balance, 86025e4, "Nayms' staking balance[2] should increase");
         assertEq(stakingStates[nlf.entityId][2].boost, 809625e2, "Nayms' boost[2] should increase");
 
-        printBoosts(nlf.entityId, nlf.entityId, "Nayms");
-        printBoosts(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, nlf.entityId, "Nayms");
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
 
         c.log("(TIME: 62)".blue(), " ~~~~~~~~~~~~~ Bob Claimed Rewards ~~~~~~~~~~~~~".yellow());
         vm.warp(stakingStart + 62 days);
@@ -415,10 +415,10 @@ contract T06Staking is D03ProtocolDefaults {
         assertEq(stakingStates[lou.entityId][2].balance, calculateBalanceAtTime(40 days, louStakeAmount), "Lou's staking balance[2] should increase");
         assertEq(stakingStates[lou.entityId][2].boost, 4845e4, "Lou's boost[2] should increase");
 
-        printBoosts(nlf.entityId, nlf.entityId, "Nayms");
-        printBoosts(nlf.entityId, bob.entityId, "Bob");
-        printBoosts(nlf.entityId, sue.entityId, "Sue");
-        printBoosts(nlf.entityId, lou.entityId, "Lou");
+        printCurrentState(nlf.entityId, nlf.entityId, "Nayms");
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+        printCurrentState(nlf.entityId, lou.entityId, "Lou");
 
         c.log("(TIME: 90)".blue(), " ~~~~~~~~~~~~~ 3rd Distribution Paid ~~~~~~~~~~~~~".yellow());
         startPrank(nlf);
@@ -429,7 +429,7 @@ contract T06Staking is D03ProtocolDefaults {
         recordStakingState(nlf.entityId); // re-read state
         assertEq(stakingStates[nlf.entityId][3].balance, 9412125e2, "Nayms' staking balance[3] should increase");
         assertEq(stakingStates[nlf.entityId][3].boost, 68818125, "Nayms' boost[3] should increase");
-        printBoosts(nlf.entityId, nlf.entityId, "Nayms");
+        printCurrentState(nlf.entityId, nlf.entityId, "Nayms");
 
         c.log("(TIME: 91)".blue(), " ~~~~~~~~~~~~~ Sue Claimed Rewards ~~~~~~~~~~~~~".yellow());
         vm.warp(stakingStart + 91 days);
@@ -505,10 +505,10 @@ contract T06Staking is D03ProtocolDefaults {
             assertEq(louStakedAmount_, louStakeAmount, "Incorrect Lou's original stake amount");
         }
 
-        printBoosts(nlf.entityId, nlf.entityId, "Nayms");
-        printBoosts(nlf.entityId, bob.entityId, "Bob");
-        printBoosts(nlf.entityId, sue.entityId, "Sue");
-        printBoosts(nlf.entityId, lou.entityId, "Lou");
+        printCurrentState(nlf.entityId, nlf.entityId, "Nayms");
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+        printCurrentState(nlf.entityId, lou.entityId, "Lou");
     }
 
     function test_scenario1Extended() public {
@@ -522,7 +522,7 @@ contract T06Staking is D03ProtocolDefaults {
         startPrank(bob);
         uint256 balBeforeStaking = nayms.internalBalanceOf(bob.entityId, usdcId);
         nayms.stake(nlf.entityId, bobStakeAmount);
-        printBoosts(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
 
         recordStakingState(bob.entityId);
         assertEq(stakingStates[bob.entityId][4].balance, 247799375, "Bob's staking balance[4] should increase");
@@ -532,7 +532,7 @@ contract T06Staking is D03ProtocolDefaults {
         startPrank(sue);
         balBeforeStaking = nayms.internalBalanceOf(sue.entityId, usdcId);
         nayms.stake(nlf.entityId, sueStakeAmount);
-        printBoosts(nlf.entityId, sue.entityId, "Sue");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
         recordStakingState(sue.entityId);
         // assertEq(stakingStates[sue.entityId][4].balance, 495598750, "Sue's staking balance[4] should increase");
         assertEq(stakingStates[sue.entityId][4].balance, 495598750, "Sue's staking balance[4] should increase");
@@ -542,7 +542,7 @@ contract T06Staking is D03ProtocolDefaults {
         startPrank(lou);
         balBeforeStaking = nayms.internalBalanceOf(lou.entityId, usdcId);
         nayms.stake(nlf.entityId, louStakeAmount);
-        printBoosts(nlf.entityId, lou.entityId, "Lou");
+        printCurrentState(nlf.entityId, lou.entityId, "Lou");
         recordStakingState(lou.entityId);
         assertEq(stakingStates[lou.entityId][4].balance, 966632500, "Lou's staking balance[4] should increase");
         assertEq(stakingStates[lou.entityId][4].boost, 93005125, "Lou's boost[4] should increase");
@@ -554,7 +554,7 @@ contract T06Staking is D03ProtocolDefaults {
         assertEq(nayms.currentInterval(nlf.entityId), 5);
         startPrank(nlf);
         nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("5")), nlf.entityId, usdcId, rewardAmount);
-        printBoosts(nlf.entityId, nlf.entityId, "Nayms");
+        printCurrentState(nlf.entityId, nlf.entityId, "Nayms");
         recordStakingState(nlf.entityId);
         assertEq(stakingStates[nlf.entityId][5].balance, 1870026031, "Nayms' staking balance[5] should increase");
         assertEq(stakingStates[nlf.entityId][5].boost, 139496095, "Nayms' boost[5] should increase");
@@ -572,7 +572,7 @@ contract T06Staking is D03ProtocolDefaults {
 
         startPrank(nlf);
         nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("6")), nlf.entityId, usdcId, rewardAmount);
-        printBoosts(nlf.entityId, nlf.entityId, "Nayms");
+        printCurrentState(nlf.entityId, nlf.entityId, "Nayms");
         recordStakingState(nlf.entityId);
         assertEq(stakingStates[nlf.entityId][6].balance, 2009522126, "Nayms' staking balance[6] should increase");
         assertEq(stakingStates[nlf.entityId][6].boost, 118571680, "Nayms' boost[6] should increase");
@@ -952,7 +952,7 @@ contract T06Staking is D03ProtocolDefaults {
         nayms.stake(nlf.entityId, stake100);
 
         c.log("~ [%s] Bob staked 100 NAYM".blue(), currentInterval());
-        printBoosts(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
 
         vm.warp(2 * I + 10 days);
 
@@ -960,13 +960,13 @@ contract T06Staking is D03ProtocolDefaults {
         nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("r1")), nlf.entityId, usdcId, reward1000usdc);
 
         c.log("~ [%s] NLF payed out 1000 USDC reward".blue(), currentInterval());
-        printBoosts(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
 
         startPrank(bob);
         nayms.collectRewards(nlf.entityId);
 
         c.log("~ [%s] Bob collected reward".blue(), currentInterval());
-        printBoosts(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
 
         assertEq(nayms.internalBalanceOf(bob.entityId, usdcId), reward1000usdc);
 
@@ -974,14 +974,14 @@ contract T06Staking is D03ProtocolDefaults {
         nayms.stake(nlf.entityId, stake100);
 
         c.log("~ [%s] Sue staked 100 NAYM".blue(), currentInterval());
-        printBoosts(nlf.entityId, sue.entityId, "Sue");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
 
         vm.warp(3 * I + 10 days);
         startPrank(nlf);
         nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("r2")), nlf.entityId, usdcId, reward1000usdc);
         c.log("~ [%s] NLF payed out 1000 USDC reward".blue(), currentInterval());
-        printBoosts(nlf.entityId, bob.entityId, "Bob");
-        printBoosts(nlf.entityId, sue.entityId, "Sue");
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
 
         vm.warp(4 * I + 10 days);
 
@@ -989,7 +989,7 @@ contract T06Staking is D03ProtocolDefaults {
         nayms.unstake(nlf.entityId);
         c.log("~ [%s] Bob unstaked 100 NAYM".blue(), currentInterval());
 
-        printBoosts(nlf.entityId, sue.entityId, "Sue");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
 
         uint256 suesExpectedReward2 = 2 * reward1000usdc - nayms.internalBalanceOf(bob.entityId, usdcId);
 
@@ -999,7 +999,7 @@ contract T06Staking is D03ProtocolDefaults {
         nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("r3")), nlf.entityId, usdcId, reward1000usdc);
         c.log("~ [%s] NLF payed out 1000 USDC reward".blue(), currentInterval());
 
-        printBoosts(nlf.entityId, sue.entityId, "Sue");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
 
         c.log("  Sue last collected: %s".green(), nayms.lastCollectedInterval(nlf.entityId, sue.entityId));
 


### PR DESCRIPTION
Whan a user unstakes he automatically collects any rewards he is eligible for. During that process, the total for the remaining reward has to be updated. However, this adjustment has to be done using boosted balances, not the raw values from the storage.

Added a change to correctly make the update to the remaining reward balance.