### PR TITLE
Fix tracking the last collected interval

### DIFF
--- a/gemforge.deployments.json
+++ b/gemforge.deployments.json
@@ -175,22 +175,22 @@
     "chainId": 11155111,
     "contracts": [
       {
+        "name": "StakingFacet",
+        "fullyQualifiedName": "StakingFacet.sol:StakingFacet",
+        "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
+        "txHash": "0xccaab243e581df5c6379844ea0de825578fe5dddfabe01a1b12567b0589a4e09",
+        "onChain": {
+          "address": "0x9981C2f530F3D0DD3a226ff3dd99EC08970A2b9E",
+          "constructorArgs": []
+        }
+      },
+      {
         "name": "PhasedDiamondCutFacet",
         "fullyQualifiedName": "PhasedDiamondCutFacet.sol:PhasedDiamondCutFacet",
         "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
         "txHash": "0xb25af109873f94eaa99ab3b5ef8a4c7d95a003abfe9f89012464b1cc5eb8ffa3",
         "onChain": {
           "address": "0x0639a051BD87E19dB7534b759de7c95d6e285a6A",
-          "constructorArgs": []
-        }
-      },
-      {
-        "name": "StakingFacet",
-        "fullyQualifiedName": "StakingFacet.sol:StakingFacet",
-        "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
-        "txHash": "0x966e5a97b6a36607792d50d79cd586a78ae33f8bbea3740348d7064fe9672254",
-        "onChain": {
-          "address": "0xed9F49c6f4Aea18dc079C54DE84bB5DFF3babE88",
           "constructorArgs": []
         }
       },
@@ -895,22 +895,22 @@
     "chainId": 84532,
     "contracts": [
       {
+        "name": "StakingFacet",
+        "fullyQualifiedName": "StakingFacet.sol:StakingFacet",
+        "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
+        "txHash": "0x821b74a88828be096d4b8a4562be8096a9d30cfca39a5d89ad82dcc8db83e61f",
+        "onChain": {
+          "address": "0xC5B096055237aA5E045f0AB842165B48a4058028",
+          "constructorArgs": []
+        }
+      },
+      {
         "name": "PhasedDiamondCutFacet",
         "fullyQualifiedName": "PhasedDiamondCutFacet.sol:PhasedDiamondCutFacet",
         "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
         "txHash": "0x2aa2ad32dcf222f2af7c68374adef9c204ce8c2dc21a4d28034c3d9b0dca141d",
         "onChain": {
           "address": "0x4DFf560895F62eCae213c4AED8A76fD6a4C41276",
-          "constructorArgs": []
-        }
-      },
-      {
-        "name": "StakingFacet",
-        "fullyQualifiedName": "StakingFacet.sol:StakingFacet",
-        "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
-        "txHash": "0xd3423acf487ccfc97e08a42ff9a68f7c6b9bd0416a8e9397d165d7d434a90d2f",
-        "onChain": {
-          "address": "0x5a84Aca1447cD6f14447cb0F76d14b473fE8ff3B",
           "constructorArgs": []
         }
       },

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -269,7 +269,7 @@ library LibTokenizedVaultStaking {
 
         (state, rewards) = _getStakingStateWithRewardsBalances(_stakerId, _entityId, _interval);
         if (rewards.currencies.length > 0) {
-            if (rewards.lastPaidInterval != _interval) {
+            if (rewards.lastPaidInterval < _interval) {
                 // we must update the stake collected for the user, to the interval when that reward was actually paid out, not the current one
                 // also update the state and boosts up to that interval, not later than that, that is why we make this call again with different intelval
                 // so that we can calculate the boosted amounts up to the desired interval

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -251,6 +251,7 @@ library LibTokenizedVaultStaking {
                         0
                     );
                     rewards.amounts[currencyIndex] += userDistributionAmount;
+                    // last interval the reward was paid out, but before the one provided in the input
                     rewards.lastPaidInterval = i;
                 }
             }

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -271,7 +271,7 @@ library LibTokenizedVaultStaking {
         if (rewards.currencies.length > 0) {
             if (rewards.lastPaidInterval < _interval) {
                 // we must update the stake collected for the user, to the interval when that reward was actually paid out, not the current one
-                // also update the state and boosts up to that interval, not later than that, that is why we make this call again with different intelval
+                // also update the state and boosts up to that interval, not later than that, that is why we make this call again with different interval
                 // so that we can calculate the boosted amounts up to the desired interval
                 (state, rewards) = _getStakingStateWithRewardsBalances(_stakerId, _entityId, rewards.lastPaidInterval);
             }

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -270,6 +270,7 @@ library LibTokenizedVaultStaking {
 
             // Update state
             s.stakeCollected[_entityId][_stakerId] = _interval;
+            // s.stakeCollected[_entityId][_stakerId] = rewards.lastPaidInterval;
             s.stakeBoost[vTokenId][_stakerId] = state.boost;
             s.stakeBalance[vTokenId][_stakerId] = state.balance;
 

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -1150,12 +1150,12 @@ contract T06Staking is D03ProtocolDefaults {
     }
 
     /**
-     *  [40] Bob stakes 100 NAYM => 100/100
-     *  [40] Sue stakes 100 NAYM => 100/200
-     *  [70] NLF pays reward1: 1000 USDC           (Bob: 100, Sue: 100, Total: 200)
-     *  [70] Sue stakes 100 NAYM => 100/300        (collects: 50% reward1)
-     *  [70] Bob stakes 100 NAYM => 100/400        (collects: 50% reward1)
-     *  [70] NLF pays reward2: 1000 USDC           (Bob: 200, Sue: 200, Total: 400)
+     *   [40] Bob stakes 100 NAYM => 100/100
+     *   [40] Sue stakes 100 NAYM => 100/200
+     *   [70] NLF pays reward1: 1000 USDC           (Bob: 100, Sue: 100, Total: 200)
+     *  [100] Sue stakes 100 NAYM => 100/300        (collects: 50% reward1)
+     *  [100] Bob stakes 100 NAYM => 100/400        (collects: 50% reward1)
+     *  [100] NLF pays reward2: 1000 USDC           (Bob: 200, Sue: 200, Total: 400)
      */
     function test_stakeAndPayRewardAtSameInterval() public {
         uint256 stake100 = 100e18;

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -1149,6 +1149,103 @@ contract T06Staking is D03ProtocolDefaults {
         // printAppstorage();
     }
 
+    /**
+     *  [40] Bob stakes 100 NAYM => 100/100
+     *  [40] Sue stakes 100 NAYM => 100/200
+     *  [70] NLF pays reward1: 1000 USDC           (Bob: 100, Sue: 100, Total: 200)
+     *  [70] Sue stakes 100 NAYM => 100/300        (collects: 50% reward1)
+     *  [70] Bob stakes 100 NAYM => 100/400        (collects: 50% reward1)
+     *  [70] NLF pays reward2: 1000 USDC           (Bob: 200, Sue: 200, Total: 400)
+     */
+    function test_stakeAndPayRewardAtSameInterval() public {
+        uint256 stake100 = 100e18;
+        uint256 reward1000usdc = 1_000_000000;
+
+        assertEq(nayms.internalBalanceOf(bob.entityId, usdcId), usdcBalance[bob.entityId], "Bob's USDC balance should be zero");
+        assertEq(nayms.internalBalanceOf(sue.entityId, usdcId), usdcBalance[sue.entityId], "Sue's USDC balance should be zero");
+
+        assertStakedAmount(bob.entityId, 0, "Bob's staked amount [1] should be zero");
+        assertStakedAmount(sue.entityId, 0, "Sue's staked amount [1] should be zero");
+
+        uint256 startStaking = block.timestamp + 100 days;
+        initStaking(startStaking);
+
+        vm.warp(startStaking + 40 days);
+        c.log("\n  ~ START Staking\n".blue());
+
+        startPrank(bob);
+        nayms.stake(nlf.entityId, stake100);
+        assertStakedAmount(bob.entityId, stake100, "Bob's staked amount [1] should increase");
+        c.log("~ [%s] Bob staked 100 NAYM".blue(), currentInterval());
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+
+        startPrank(sue);
+        nayms.stake(nlf.entityId, stake100);
+        assertStakedAmount(sue.entityId, stake100, "Sue's staked amount [1] should increase");
+        c.log("~ [%s] Sue staked 100 NAYM".blue(), currentInterval());
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+
+        vm.warp(startStaking + 70 days);
+
+        startPrank(nlf);
+        nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("reward1")), nlf.entityId, usdcId, reward1000usdc);
+        c.log("~ [%s] NLF payed out reward1: 1000 USDC".blue(), currentInterval());
+
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+
+        vm.warp(startStaking + 100 days);
+
+        startPrank(sue);
+        nayms.stake(nlf.entityId, stake100);
+        assertStakedAmount(sue.entityId, stake100 * 2, "Sue's staked amount [2] should increase");
+        usdcBalance[sue.entityId] += reward1000usdc / 2;
+        assertEq(nayms.internalBalanceOf(sue.entityId, usdcId), usdcBalance[sue.entityId], "Sue's USDC balance should increase");
+        c.log("~ [%s] Sue staked 100 NAYM (collects 50% reward1)".blue(), currentInterval());
+
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+        c.log("     Sue's USDC balance: %s".green(), nayms.internalBalanceOf(sue.entityId, usdcId) / 1e6);
+
+        startPrank(bob);
+        nayms.stake(nlf.entityId, stake100);
+        assertStakedAmount(bob.entityId, 2 * stake100, "Bob's staked amount [2] should increase");
+        usdcBalance[bob.entityId] += reward1000usdc / 2;
+        assertEq(nayms.internalBalanceOf(bob.entityId, usdcId), usdcBalance[bob.entityId], "Bob's USDC balance should increase");
+        c.log("~ [%s] Bob staked 100 NAYM (collects 50% reward1)".blue(), currentInterval());
+
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+        c.log("     Bob's USDC balance: %s".green(), nayms.internalBalanceOf(bob.entityId, usdcId) / 1e6);
+
+        startPrank(nlf);
+        nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("reward2")), nlf.entityId, usdcId, reward1000usdc);
+        c.log("~ [%s] NLF payed out reward2: 1000 USDC".blue(), currentInterval());
+
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+
+        {
+            uint256 totalStakedAmount = 2 * stake100;
+
+            uint256 sueBoost = (calculateBoost(40 days, 100 days, R, I, SCALE_FACTOR) * stake100) / totalStakedAmount;
+            uint256 bobBoost = (calculateBoost(40 days, 100 days, R, I, SCALE_FACTOR) * stake100) / totalStakedAmount;
+            uint256 totalBoost = sueBoost + bobBoost;
+
+            uint256 sueReward = (reward1000usdc * sueBoost) / totalBoost;
+            uint256 bobReward = (reward1000usdc * bobBoost) / totalBoost;
+
+            // unclaimedReward[lou.entityId][2] = louRewardR2;
+
+            assertEq(getRewards(bob.entityId, nlf.entityId), bobReward, "Bob's reward [3] should increase");
+            assertEq(getRewards(sue.entityId, nlf.entityId), sueReward, "Sue's reward [3] should increase");
+
+            // usdcBalance[sue.entityId] += sueReward;
+        }
+
+        printAppstorage();
+    }
+
     function printAppstorage() public {
         uint64 interval = currentInterval() + 2;
 
@@ -1168,11 +1265,11 @@ contract T06Staking is D03ProtocolDefaults {
         }
         c.log();
 
-        c.log("  --   Lou  --");
-        for (uint64 i = 0; i <= interval; i++) {
-            logStateAt(i, lou.entityId, nlf.entityId);
-        }
-        c.log();
+        // c.log("  --   Lou  --");
+        // for (uint64 i = 0; i <= interval; i++) {
+        //     logStateAt(i, lou.entityId, nlf.entityId);
+        // }
+        // c.log();
 
         c.log("  --   NLF  --");
         for (uint64 i = 0; i <= interval; i++) {

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -1203,9 +1203,9 @@ contract T06Staking is D03ProtocolDefaults {
         assertEq(nayms.internalBalanceOf(sue.entityId, usdcId), usdcBalance[sue.entityId], "Sue's USDC balance should increase");
         c.log("~ [%s] Sue staked 100 NAYM (collects 50% reward1)".blue(), currentInterval());
 
-        printCurrentState(nlf.entityId, bob.entityId, "Bob");
         printCurrentState(nlf.entityId, sue.entityId, "Sue");
-        c.log("     Sue's USDC balance: %s".green(), nayms.internalBalanceOf(sue.entityId, usdcId) / 1e6);
+        c.log("     Sue's USDC: %s".green(), nayms.internalBalanceOf(sue.entityId, usdcId) / 1e6);
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
 
         startPrank(bob);
         nayms.stake(nlf.entityId, stake100);
@@ -1215,8 +1215,8 @@ contract T06Staking is D03ProtocolDefaults {
         c.log("~ [%s] Bob staked 100 NAYM (collects 50% reward1)".blue(), currentInterval());
 
         printCurrentState(nlf.entityId, bob.entityId, "Bob");
+        c.log("     Bob's USDC: %s".green(), nayms.internalBalanceOf(bob.entityId, usdcId) / 1e6);
         printCurrentState(nlf.entityId, sue.entityId, "Sue");
-        c.log("     Bob's USDC balance: %s".green(), nayms.internalBalanceOf(bob.entityId, usdcId) / 1e6);
 
         startPrank(nlf);
         nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("reward2")), nlf.entityId, usdcId, reward1000usdc);
@@ -1235,15 +1235,9 @@ contract T06Staking is D03ProtocolDefaults {
             uint256 sueReward = (reward1000usdc * sueBoost) / totalBoost;
             uint256 bobReward = (reward1000usdc * bobBoost) / totalBoost;
 
-            // unclaimedReward[lou.entityId][2] = louRewardR2;
-
             assertEq(getRewards(bob.entityId, nlf.entityId), bobReward, "Bob's reward [3] should increase");
             assertEq(getRewards(sue.entityId, nlf.entityId), sueReward, "Sue's reward [3] should increase");
-
-            // usdcBalance[sue.entityId] += sueReward;
         }
-
-        printAppstorage();
     }
 
     function printAppstorage() public {


### PR DESCRIPTION
Here we address the issue with keeping track of last collected interval for user rewards. If a user collects an earlier reward at the same interval when another reward is paid after he collects(in that same interval), he should still be able to collect that second reward afterwards.