### PR TITLE
Sync state data on unstake

### DIFF
--- a/gemforge.deployments.json
+++ b/gemforge.deployments.json
@@ -178,9 +178,9 @@
         "name": "StakingFacet",
         "fullyQualifiedName": "StakingFacet.sol:StakingFacet",
         "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
-        "txHash": "0xccaab243e581df5c6379844ea0de825578fe5dddfabe01a1b12567b0589a4e09",
+        "txHash": "0x81a08f5a61be855308a412349cceb4f24a1ea3eb1e1a42e034d7a049d4f5179a",
         "onChain": {
-          "address": "0x9981C2f530F3D0DD3a226ff3dd99EC08970A2b9E",
+          "address": "0xF051b13F759992662172F2f9FF361d8B86975Ba8",
           "constructorArgs": []
         }
       },
@@ -898,9 +898,9 @@
         "name": "StakingFacet",
         "fullyQualifiedName": "StakingFacet.sol:StakingFacet",
         "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
-        "txHash": "0x821b74a88828be096d4b8a4562be8096a9d30cfca39a5d89ad82dcc8db83e61f",
+        "txHash": "0xc0c24529f86c157b3af815de29edcd2419e7b224a35e68d56a6df18f9c6ab7e6",
         "onChain": {
-          "address": "0xC5B096055237aA5E045f0AB842165B48a4058028",
+          "address": "0x3E81ba215eBF5B209a4fB03E698535a3056438D6",
           "constructorArgs": []
         }
       },
@@ -1069,12 +1069,22 @@
     "chainId": 1313161555,
     "contracts": [
       {
+        "name": "PhasedDiamondCutFacet",
+        "fullyQualifiedName": "PhasedDiamondCutFacet.sol:PhasedDiamondCutFacet",
+        "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
+        "txHash": "0x9f1e16b129c17de4b77487ad562f1551ef4d4732e9485f05ed76232763031558",
+        "onChain": {
+          "address": "0xe99144d85671D6b1a941493f6D934F31D7f3A3Be",
+          "constructorArgs": []
+        }
+      },
+      {
         "name": "StakingFacet",
         "fullyQualifiedName": "StakingFacet.sol:StakingFacet",
         "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
-        "txHash": "0x89109cbc314a2d8a787df8385c7f3e9b03a40430236400bace066503201d8f50",
+        "txHash": "0xf22b7e572f44e37ef6e048a41217ff680e7e0c3a80e0b810fe0278300d6ae45f",
         "onChain": {
-          "address": "0x0397dDa927dbc11F9C427216E7e91329B42cecE4",
+          "address": "0xBeaE8a162A4AA54113A35c0137bFB24d83f4ef68",
           "constructorArgs": []
         }
       },
@@ -1085,16 +1095,6 @@
         "txHash": "0x8fb4777c91342976ecc41ef431e4add163dfb1bc01526e67e6f6b9d250fc0759",
         "onChain": {
           "address": "0x62AE01F93C7280271616E9Dd3A3789Fc734F8192",
-          "constructorArgs": []
-        }
-      },
-      {
-        "name": "PhasedDiamondCutFacet",
-        "fullyQualifiedName": "PhasedDiamondCutFacet.sol:PhasedDiamondCutFacet",
-        "sender": "0x931c3aC09202650148Edb2316e97815f904CF4fa",
-        "txHash": "0xf81039e05d58c026382eb9427ad324b8322fbfa3ee832e420bdb4d12cdd341d0",
-        "onChain": {
-          "address": "0xf7D79E6324596Fcf7f6D060EF46A9e1C90493582",
           "constructorArgs": []
         }
       },

--- a/src/facets/StakingFacet.sol
+++ b/src/facets/StakingFacet.sol
@@ -29,12 +29,12 @@ contract StakingFacet is Modifiers {
     }
 
     function stake(bytes32 _entityId, uint256 _amount) external notLocked(msg.sig) {
-        bytes32 parentId = LibObject._getParent(msg.sender._getIdForAddress());
+        bytes32 parentId = LibObject._getParentFromAddress(msg.sender);
         LibTokenizedVaultStaking._stake(parentId, _entityId, _amount);
     }
 
     function unstake(bytes32 _entityId) external notLocked(msg.sig) {
-        bytes32 parentId = LibObject._getParent(msg.sender._getIdForAddress());
+        bytes32 parentId = LibObject._getParentFromAddress(msg.sender);
         LibTokenizedVaultStaking._unstake(parentId, _entityId);
     }
 

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -177,7 +177,6 @@ library LibTokenizedVaultStaking {
         uint64 currentInterval = _currentInterval(_entityId);
         uint64 lastPaidInterval = s.stakeCollected[_entityId][_entityId];
         bytes32 vTokenIdMax = _vTokenIdBucket(_entityId, tokenId);
-        // bytes32 vTokenId = _vTokenId(_entityId, tokenId, currentInterval);
         bytes32 vTokenIdLastPaid = _vTokenId(_entityId, tokenId, lastPaidInterval);
 
         // must read states before the reward is claimed!

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -329,9 +329,7 @@ library LibTokenizedVaultStaking {
         if (_config.a + _config.r > _config.divider) revert APlusRCannotBeGreaterThanDivider();
         if (_config.a + _config.r != _config.divider) revert BoostMultiplierConvergenceFailure(_config.a, _config.r, _config.divider);
         if (_config.interval == 0) revert InvalidIntervalSecondsValue();
-        if (_config.interval < LC.MIN_STAKING_INTERVAL || _config.interval > LC.MAX_STAKING_INTERVAL) {
-            revert IntervalOutOfRange(_config.interval);
-        }
+        if (_config.interval < LC.MIN_STAKING_INTERVAL || _config.interval > LC.MAX_STAKING_INTERVAL) revert IntervalOutOfRange(_config.interval);
         if (_config.initDate <= block.timestamp) revert InvalidStakingInitDate();
         if (_config.initDate > block.timestamp + LC.MAX_INIT_DATE_PERIOD) revert InitDateTooFar(_config.initDate);
         if (_config.tokenId == 0) revert InvalidTokenId();

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -177,30 +177,39 @@ library LibTokenizedVaultStaking {
         uint64 currentInterval = _currentInterval(_entityId);
         uint64 lastPaidInterval = s.stakeCollected[_entityId][_entityId];
         bytes32 vTokenIdMax = _vTokenIdBucket(_entityId, tokenId);
-        bytes32 vTokenId = _vTokenId(_entityId, tokenId, currentInterval);
+        // bytes32 vTokenId = _vTokenId(_entityId, tokenId, currentInterval);
         bytes32 vTokenIdLastPaid = _vTokenId(_entityId, tokenId, lastPaidInterval);
 
         // must read states before the reward is claimed!
         (StakingState memory userStateAtLastPaid, ) = _getStakingStateWithRewardsBalances(_stakerId, _entityId, lastPaidInterval);
         (StakingState memory totalStateAtLastPaid, ) = _getStakingStateWithRewardsBalances(_entityId, _entityId, lastPaidInterval);
 
-        _collectRewards(_stakerId, _entityId, currentInterval); // collect rewards first
+        _syncData(_stakerId, _entityId, currentInterval);
+        _syncData(_entityId, _entityId, currentInterval);
+
+        _collectRewards(_stakerId, _entityId, currentInterval); // collect rewards first, sync data up to last paid
         s.stakeCollected[_entityId][_stakerId] = currentInterval; // update collection interval, even if no reward
 
-        if (s.stakingDistributionAmount[vTokenIdLastPaid] != 0 && s.stakeBalance[vTokenIdLastPaid][_entityId] != 0) {
+        // staker's balance in the past are never adjusted
+        // stakers and NLF balances are adjusted in the current interval when unstaking
+        // in the current interval, if a reward was paid and therefor collected, staking distribution need to be adjusted according to the balances
+        if (lastPaidInterval == currentInterval) {
             s.stakingDistributionAmount[vTokenIdLastPaid] -= (s.stakingDistributionAmount[vTokenIdLastPaid] * userStateAtLastPaid.balance) / totalStateAtLastPaid.balance;
         }
 
-        s.stakeBoost[vTokenIdLastPaid][_entityId] -= userStateAtLastPaid.boost;
-        s.stakeBoost[vTokenId][_stakerId] = 0;
+        s.stakeBoost[_vTokenId(_entityId, tokenId, currentInterval)][_entityId] -= s.stakeBoost[_vTokenId(_entityId, tokenId, currentInterval)][_stakerId];
+        s.stakeBoost[_vTokenId(_entityId, tokenId, currentInterval + 1)][_entityId] -= s.stakeBoost[_vTokenId(_entityId, tokenId, currentInterval + 1)][_stakerId];
+        s.stakeBoost[_vTokenId(_entityId, tokenId, currentInterval + 2)][_entityId] -= s.stakeBoost[_vTokenId(_entityId, tokenId, currentInterval + 2)][_stakerId];
+
+        s.stakeBoost[_vTokenId(_entityId, tokenId, currentInterval)][_stakerId] = 0;
         s.stakeBoost[_vTokenId(_entityId, tokenId, currentInterval + 1)][_stakerId] = 0;
         s.stakeBoost[_vTokenId(_entityId, tokenId, currentInterval + 2)][_stakerId] = 0;
 
-        s.stakeBalance[vTokenIdLastPaid][_entityId] -= userStateAtLastPaid.balance;
+        s.stakeBalance[_vTokenId(_entityId, tokenId, currentInterval)][_entityId] -= s.stakeBalance[_vTokenId(_entityId, tokenId, currentInterval)][_stakerId];
         s.stakeBalance[_vTokenId(_entityId, tokenId, currentInterval + 1)][_entityId] -= s.stakeBalance[_vTokenId(_entityId, tokenId, currentInterval + 1)][_stakerId];
         s.stakeBalance[_vTokenId(_entityId, tokenId, currentInterval + 2)][_entityId] -= s.stakeBalance[_vTokenId(_entityId, tokenId, currentInterval + 2)][_stakerId];
 
-        s.stakeBalance[vTokenId][_stakerId] = 0;
+        s.stakeBalance[_vTokenId(_entityId, tokenId, currentInterval)][_stakerId] = 0;
         s.stakeBalance[_vTokenId(_entityId, tokenId, currentInterval + 1)][_stakerId] = 0;
         s.stakeBalance[_vTokenId(_entityId, tokenId, currentInterval + 2)][_stakerId] = 0;
 
@@ -222,6 +231,8 @@ library LibTokenizedVaultStaking {
         AppStorage storage s = LibAppStorage.diamondStorage();
         bytes32 tokenId = s.stakingConfigs[_entityId].tokenId;
 
+        uint64 lastSynced = s.stakingSynced[_entityId][_stakerId];
+
         // Get the last interval where distribution was collected by the user.
         state.lastCollectedInterval = s.stakeCollected[_entityId][_stakerId];
         if (_interval < state.lastCollectedInterval) {
@@ -236,8 +247,13 @@ library LibTokenizedVaultStaking {
                 // check to see if there are rewards for this interval, and update arrays
                 uint256 totalDistributionAmount = s.stakingDistributionAmount[_vTokenId(_entityId, tokenId, i)];
 
-                state.balance += s.stakeBalance[_vTokenId(_entityId, tokenId, i)][_stakerId] + state.boost;
-                state.boost = s.stakeBoost[_vTokenId(_entityId, tokenId, i)][_stakerId] + (state.boost * _getR(_entityId)) / _getD(_entityId);
+                if (i == lastSynced) {
+                    state.balance = s.stakeBalance[_vTokenId(_entityId, tokenId, i)][_stakerId];
+                    state.boost = s.stakeBoost[_vTokenId(_entityId, tokenId, i)][_stakerId];
+                } else {
+                    state.balance += s.stakeBalance[_vTokenId(_entityId, tokenId, i)][_stakerId] + state.boost;
+                    state.boost = s.stakeBoost[_vTokenId(_entityId, tokenId, i)][_stakerId] + (state.boost * _getR(_entityId)) / _getD(_entityId);
+                }
 
                 if (totalDistributionAmount > 0) {
                     uint256 currencyIndex;
@@ -250,12 +266,29 @@ library LibTokenizedVaultStaking {
                         totalDistributionAmount,
                         0
                     );
+
                     rewards.amounts[currencyIndex] += userDistributionAmount;
                     // last interval the reward was paid out, but before the one provided in the input
                     rewards.lastPaidInterval = i;
                 }
             }
         }
+    }
+
+    function _syncData(bytes32 _stakerId, bytes32 _entityId, uint64 _interval) internal {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        require(_interval <= _currentInterval(_entityId), "cannot sync after current interval");
+
+        (StakingState memory state, ) = _getStakingStateWithRewardsBalances(_stakerId, _entityId, _interval);
+
+        s.stakingSynced[_entityId][_stakerId] = _interval;
+
+        bytes32 tokenId = s.stakingConfigs[_entityId].tokenId;
+        bytes32 vTokenId = _vTokenId(_entityId, tokenId, _interval);
+
+        s.stakeBoost[vTokenId][_stakerId] = state.boost;
+        s.stakeBalance[vTokenId][_stakerId] = state.balance;
     }
 
     function _collectRewards(bytes32 _stakerId, bytes32 _entityId, uint64 _interval) internal {

--- a/src/shared/AppStorage.sol
+++ b/src/shared/AppStorage.sol
@@ -84,11 +84,12 @@ struct AppStorage {
     /// Staking
     mapping(bytes32 entityId => StakingConfig) stakingConfigs; // StakingConfig for an entity
     // The totals for boost and reward are stored in the index of the vTokenID0
-    mapping(bytes32 vTokenId => mapping(bytes32 _stakerId => uint256 reward)) stakeBalance; // [vTokenId][ownerId] Reward per interval
-    mapping(bytes32 vTokenId => mapping(bytes32 _stakerId => uint256 boost)) stakeBoost; // [vTokenId][ownerId] Boost per interval
-    mapping(bytes32 entityId => mapping(bytes32 _stakerId => uint64 interval)) stakeCollected; // the entityId index is used to keep track of the last paid interval for a staker
+    mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 reward)) stakeBalance; // [vTokenId][ownerId] Reward per interval
+    mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 boost)) stakeBoost; // [vTokenId][ownerId] Boost per interval
+    mapping(bytes32 entityId => mapping(bytes32 stakerId => uint64 interval)) stakeCollected; // the entityId index is used to keep track of the last paid interval for a staker
     mapping(bytes32 vTokenId => uint256 amount) stakingDistributionAmount; // [vTokenId] Reward per interval
     mapping(bytes32 vTokenId => bytes32 denomination) stakingDistributionDenomination; // [vTokenId] Reward currency
+    mapping(bytes32 entityId => mapping(bytes32 stakerId => uint64 interval)) stakingSynced;
 }
 
 struct FunctionLockedStorage {

--- a/src/shared/AppStorage.sol
+++ b/src/shared/AppStorage.sol
@@ -84,7 +84,7 @@ struct AppStorage {
     /// Staking
     mapping(bytes32 entityId => StakingConfig) stakingConfigs; // StakingConfig for an entity
     mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 balance)) stakeBalance; // [vTokenId][ownerId] boost at interval
-    mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 boost)) stakeBoost; // [vTokenId][ownerId] Boost at interval
+    mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 boost)) stakeBoost; // [vTokenId][ownerId] boost at interval
     mapping(bytes32 entityId => mapping(bytes32 stakerId => uint64 interval)) stakeCollected; // last interval reward was collected or pain for a staker in staking entity
     mapping(bytes32 vTokenId => uint256 amount) stakingDistributionAmount; // [vTokenId] Reward at interval
     mapping(bytes32 vTokenId => bytes32 denomination) stakingDistributionDenomination; // [vTokenId] Reward currency

--- a/src/shared/AppStorage.sol
+++ b/src/shared/AppStorage.sol
@@ -83,13 +83,12 @@ struct AppStorage {
     mapping(address userAddress => EntityApproval) selfOnboarding; // map address => { entityId, roleId }
     /// Staking
     mapping(bytes32 entityId => StakingConfig) stakingConfigs; // StakingConfig for an entity
-    // The totals for boost and reward are stored in the index of the vTokenID0
-    mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 reward)) stakeBalance; // [vTokenId][ownerId] Reward per interval
-    mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 boost)) stakeBoost; // [vTokenId][ownerId] Boost per interval
-    mapping(bytes32 entityId => mapping(bytes32 stakerId => uint64 interval)) stakeCollected; // the entityId index is used to keep track of the last paid interval for a staker
-    mapping(bytes32 vTokenId => uint256 amount) stakingDistributionAmount; // [vTokenId] Reward per interval
+    mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 balance)) stakeBalance; // [vTokenId][ownerId] boost at interval
+    mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 boost)) stakeBoost; // [vTokenId][ownerId] Boost at interval
+    mapping(bytes32 entityId => mapping(bytes32 stakerId => uint64 interval)) stakeCollected; // last interval reward was collected or pain for a staker in staking entity
+    mapping(bytes32 vTokenId => uint256 amount) stakingDistributionAmount; // [vTokenId] Reward at interval
     mapping(bytes32 vTokenId => bytes32 denomination) stakingDistributionDenomination; // [vTokenId] Reward currency
-    mapping(bytes32 entityId => mapping(bytes32 stakerId => uint64 interval)) stakingSynced;
+    mapping(bytes32 entityId => mapping(bytes32 stakerId => uint64 interval)) stakingSynced; // last interval when data was synced into storage for staker
 }
 
 struct FunctionLockedStorage {

--- a/src/shared/FreeStructs.sol
+++ b/src/shared/FreeStructs.sol
@@ -89,13 +89,6 @@ struct LockedBalance {
     uint256 endTime;
 }
 
-struct StakingCheckpoint {
-    int128 bias;
-    int128 slope; // - dweight / dt
-    uint256 ts; // timestamp
-    uint256 blk; // block number
-}
-
 struct FeeSchedule {
     bytes32[] receiver;
     uint16[] basisPoints;

--- a/test/ForkTest.t.sol
+++ b/test/ForkTest.t.sol
@@ -17,34 +17,39 @@ contract ForkTest is Test {
     using StdStyle for *;
     using LibHelpers for *;
 
-    IDiamondProxy nayms = IDiamondProxy(0x6404f9C48562F39E1BAf2cD160c6f16D80b2f37F);
+    IDiamondProxy nayms = IDiamondProxy(0x2561E3F2f79b2597CCF1752C47fb2EA54F463c95);
 
     function test_fork() public {
-        vm.createSelectFork("base_sepolia", 10828508);
+        vm.createSelectFork("base_sepolia", 11773451);
+        // vm.createSelectFork("base_sepolia");
 
-        bytes32 nlfId = 0x454e544954590000000000000f474eb52b77eec4308fb39fdf589b68ce4775c5;
+        bytes32 nlfId = 0x454e544954590000000000003bb87a26cb3adfbaa9931e33505cb23a50abca90;
 
         StakingFacet sf = new StakingFacet();
-        vm.etch(0x5eA7b3745061DbF892A7114f749A5ba2b8696607, address(sf).code);
+        vm.etch(0x3E81ba215eBF5B209a4fB03E698535a3056438D6, address(sf).code);
 
-        address sender = 0x9e55dbaED8480E0955F25D9269beD1ce4f1Ba437;
-        // bytes32 senderId = 0x9e55dbaED8480E0955F25D9269beD1ce4f1Ba437000000000000000000000000;
-        bytes32 parentId = 0x454e544954590000000000000af39486c725cb99db01684e91c7579ed7882033;
+        address sender = 0xDD3e88c074B272Da66ff5Be7EA5BF4263080dDA3;
+        bytes32 parentId = nayms.getEntity(LibHelpers._getIdForAddress(sender));
+        // bytes32 senderId = 0xdd3e88c074b272da66ff5be7ea5bf4263080dda3000000000000000000000000;
+        // bytes32 parentId = 454E544954590000000000006F26B7C2A46C0194FFDB21295DB1F12A93EC3988;
+        c.log("parentId: ", parentId.greenBytes32());
+
         vm.label(sender, "Sender Account");
         vm.startPrank(sender);
 
-        c.log(" current interval: %s", nayms.currentInterval(nlfId));
+        c.log("interval:  %s", nayms.currentInterval(nlfId));
 
-        c.log("  -- getting amounts".green());
+        c.log("getting amounts...".green());
         (uint256 stakedAmount_, uint256 boostedAmount_) = nayms.getStakingAmounts(parentId, nlfId);
-        c.log("  -- amount: %s, bosted: %s".green(), stakedAmount_ / 1e18, boostedAmount_ / 1e18);
+        c.log("amount: %s, bosted: %s".green(), stakedAmount_ / 1e18, boostedAmount_ / 1e18);
 
-        nayms.unstake(nlfId);
+        // nayms.unstake(nlfId);
+        nayms.stake(nlfId, 50_000_000_000_000_000_000);
 
-        c.log("  -- getting amounts again".green());
+        c.log("getting amounts again".green());
         (uint256 stakedAmount_2, uint256 boostedAmount_2) = nayms.getStakingAmounts(parentId, nlfId);
-        c.log("  -- amount: %s, boosted: %s".green(), stakedAmount_2 / 1e18, boostedAmount_2 / 1e18);
+        c.log("amount: %s, boosted: %s".green(), stakedAmount_2 / 1e18, boostedAmount_2 / 1e18);
 
-        c.log(" >> unstake DONE!".green());
+        c.log("[+] Done");
     }
 }

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -1240,6 +1240,146 @@ contract T06Staking is D03ProtocolDefaults {
         }
     }
 
+    /**
+     *   [40] Bob stakes 100 NAYM => 100/100
+     *   [40] Sue stakes 100 NAYM => 100/200
+     *   [70] NLF pays reward1: 1000 USDC           (Bob: 100, Sue: 100, Total: 200)
+     *  [100] Sue stakes 100 NAYM => 100/300        (collects: 50% reward1)
+     *  [100] Bob stakes 100 NAYM => 100/400        (collects: 50% reward1)
+     *  [100] NLF pays reward2: 1000 USDC           (Bob: 200, Sue: 200, Total: 400)
+     *  [130] Sue collect
+     *  [160] Bob unstake
+     *  [160] NLF pays reward3: 1000 USDC
+     */
+    function test_stakeAndPayRewardAtSameIntervalThenUnstake() public {
+        uint256 stake100 = 100e18;
+        uint256 reward1000usdc = 1_000_000000;
+
+        assertEq(nayms.internalBalanceOf(bob.entityId, usdcId), usdcBalance[bob.entityId], "Bob's USDC balance should be zero");
+        assertEq(nayms.internalBalanceOf(sue.entityId, usdcId), usdcBalance[sue.entityId], "Sue's USDC balance should be zero");
+
+        assertStakedAmount(bob.entityId, 0, "Bob's staked amount [1] should be zero");
+        assertStakedAmount(sue.entityId, 0, "Sue's staked amount [1] should be zero");
+
+        uint256 startStaking = block.timestamp + 100 days;
+        initStaking(startStaking);
+
+        vm.warp(startStaking + 40 days);
+        c.log("\n  ~ START Staking\n".blue());
+
+        startPrank(bob);
+        nayms.stake(nlf.entityId, stake100);
+        assertStakedAmount(bob.entityId, stake100, "Bob's staked amount [1] should increase");
+        c.log("~ [%s] Bob staked 100 NAYM".blue(), currentInterval());
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+
+        startPrank(sue);
+        nayms.stake(nlf.entityId, stake100);
+        assertStakedAmount(sue.entityId, stake100, "Sue's staked amount [1] should increase");
+        c.log("~ [%s] Sue staked 100 NAYM".blue(), currentInterval());
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+
+        vm.warp(startStaking + 70 days);
+
+        startPrank(nlf);
+        nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("reward1")), nlf.entityId, usdcId, reward1000usdc);
+        c.log("~ [%s] NLF payed out reward1: 1000 USDC".blue(), currentInterval());
+
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+
+        vm.warp(startStaking + 100 days);
+
+        startPrank(sue);
+        nayms.stake(nlf.entityId, stake100);
+        assertStakedAmount(sue.entityId, stake100 * 2, "Sue's staked amount [2] should increase");
+        usdcBalance[sue.entityId] += reward1000usdc / 2;
+        assertEq(nayms.internalBalanceOf(sue.entityId, usdcId), usdcBalance[sue.entityId], "Sue's USDC balance should increase");
+        c.log("~ [%s] Sue staked 100 NAYM (collects 50% reward1)".blue(), currentInterval());
+
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+        c.log("     Sue's USDC: %s".green(), nayms.internalBalanceOf(sue.entityId, usdcId) / 1e6);
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+
+        startPrank(bob);
+        nayms.stake(nlf.entityId, stake100);
+        assertStakedAmount(bob.entityId, 2 * stake100, "Bob's staked amount [2] should increase");
+        usdcBalance[bob.entityId] += reward1000usdc / 2;
+        assertEq(nayms.internalBalanceOf(bob.entityId, usdcId), usdcBalance[bob.entityId], "Bob's USDC balance should increase");
+        c.log("~ [%s] Bob staked 100 NAYM (collects 50% reward1)".blue(), currentInterval());
+
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+        c.log("     Bob's USDC: %s".green(), nayms.internalBalanceOf(bob.entityId, usdcId) / 1e6);
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+
+        startPrank(nlf);
+        nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("reward2")), nlf.entityId, usdcId, reward1000usdc);
+        c.log("~ [%s] NLF payed out reward2: 1000 USDC".blue(), currentInterval());
+
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+
+        {
+            uint256 totalStakedAmount = 2 * stake100;
+
+            uint256 sueBoost = (calculateBoost(40 days, 100 days, R, I, SCALE_FACTOR) * stake100) / totalStakedAmount;
+            uint256 bobBoost = (calculateBoost(40 days, 100 days, R, I, SCALE_FACTOR) * stake100) / totalStakedAmount;
+            uint256 totalBoost = sueBoost + bobBoost;
+
+            uint256 sueReward = (reward1000usdc * sueBoost) / totalBoost;
+            uint256 bobReward = (reward1000usdc * bobBoost) / totalBoost;
+
+            unclaimedReward[bob.entityId][3] = bobReward;
+            unclaimedReward[sue.entityId][3] = sueReward;
+
+            assertEq(getRewards(bob.entityId, nlf.entityId), bobReward, "Bob's reward [3] should increase");
+            assertEq(getRewards(sue.entityId, nlf.entityId), sueReward, "Sue's reward [3] should increase");
+        }
+
+        //  *  [130] Sue collect
+        //  *  [160] Bob unstake
+        //  *  [160] NLF pays reward3: 1000 USDC
+        vm.warp(startStaking + 130 days);
+
+        startPrank(sue);
+        nayms.collectRewards(nlf.entityId);
+        usdcBalance[sue.entityId] += unclaimedReward[sue.entityId][3];
+        assertEq(nayms.internalBalanceOf(sue.entityId, usdcId), usdcBalance[sue.entityId], "Sue's USDC balance should increase");
+        c.log("~ [%s] Sue collects 50% reward2".blue(), currentInterval());
+
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+        printCurrentState(nlf.entityId, nlf.entityId, "NLF");
+
+        printAppstorage();
+
+        vm.warp(startStaking + 160 days);
+
+        startPrank(bob);
+        nayms.unstake(nlf.entityId);
+        usdcBalance[bob.entityId] += unclaimedReward[bob.entityId][3];
+        assertEq(nayms.internalBalanceOf(bob.entityId, usdcId), usdcBalance[bob.entityId], "Bob's USDC balance should increase");
+        c.log("~ [%s] Bob unstaked (collects 50% reward2)".blue(), currentInterval());
+
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+        printCurrentState(nlf.entityId, nlf.entityId, "NLF");
+
+        startPrank(nlf);
+        nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("reward3")), nlf.entityId, usdcId, reward1000usdc);
+        c.log("~ [%s] NLF payed out reward3: 1000 USDC".blue(), currentInterval());
+
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+        printCurrentState(nlf.entityId, sue.entityId, "Sue");
+        printCurrentState(nlf.entityId, nlf.entityId, "NLF");
+
+        // vm.warp(startStaking + 200 days);
+        assertEq(getRewards(sue.entityId, nlf.entityId), reward1000usdc, "Sue should get the entire reward3".red());
+        c.log(" Sue's rewards: %s".green(), getRewards(sue.entityId, nlf.entityId) / 1e6);
+
+        printAppstorage();
+    }
+
     function printAppstorage() public {
         uint64 interval = currentInterval() + 2;
 

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -1273,11 +1273,15 @@ contract T06Staking is D03ProtocolDefaults {
         c.log("~ [%s] Bob staked 100 NAYM".blue(), currentInterval());
         printCurrentState(nlf.entityId, bob.entityId, "Bob");
 
+        printAppstorage();
+
         startPrank(sue);
         nayms.stake(nlf.entityId, stake100);
         assertStakedAmount(sue.entityId, stake100, "Sue's staked amount [1] should increase");
         c.log("~ [%s] Sue staked 100 NAYM".blue(), currentInterval());
         printCurrentState(nlf.entityId, sue.entityId, "Sue");
+
+        printAppstorage();
 
         vm.warp(startStaking + 70 days);
 
@@ -1287,6 +1291,8 @@ contract T06Staking is D03ProtocolDefaults {
 
         printCurrentState(nlf.entityId, bob.entityId, "Bob");
         printCurrentState(nlf.entityId, sue.entityId, "Sue");
+
+        printAppstorage();
 
         vm.warp(startStaking + 100 days);
 
@@ -1301,6 +1307,8 @@ contract T06Staking is D03ProtocolDefaults {
         c.log("     Sue's USDC: %s".green(), nayms.internalBalanceOf(sue.entityId, usdcId) / 1e6);
         printCurrentState(nlf.entityId, bob.entityId, "Bob");
 
+        printAppstorage();
+
         startPrank(bob);
         nayms.stake(nlf.entityId, stake100);
         assertStakedAmount(bob.entityId, 2 * stake100, "Bob's staked amount [2] should increase");
@@ -1312,12 +1320,16 @@ contract T06Staking is D03ProtocolDefaults {
         c.log("     Bob's USDC: %s".green(), nayms.internalBalanceOf(bob.entityId, usdcId) / 1e6);
         printCurrentState(nlf.entityId, sue.entityId, "Sue");
 
+        printAppstorage();
+
         startPrank(nlf);
         nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("reward2")), nlf.entityId, usdcId, reward1000usdc);
         c.log("~ [%s] NLF payed out reward2: 1000 USDC".blue(), currentInterval());
 
         printCurrentState(nlf.entityId, bob.entityId, "Bob");
         printCurrentState(nlf.entityId, sue.entityId, "Sue");
+
+        printAppstorage();
 
         {
             uint256 totalStakedAmount = 2 * stake100;
@@ -1365,9 +1377,13 @@ contract T06Staking is D03ProtocolDefaults {
         printCurrentState(nlf.entityId, sue.entityId, "Sue");
         printCurrentState(nlf.entityId, nlf.entityId, "NLF");
 
+        printAppstorage();
+
         startPrank(nlf);
         nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("reward3")), nlf.entityId, usdcId, reward1000usdc);
         c.log("~ [%s] NLF payed out reward3: 1000 USDC".blue(), currentInterval());
+
+        printAppstorage();
 
         printCurrentState(nlf.entityId, bob.entityId, "Bob");
         printCurrentState(nlf.entityId, sue.entityId, "Sue");


### PR DESCRIPTION
A new variable `stakingSynced` keeps track of the last interval in which the staking data was synced for the staker. On the interval where staking was synced, `_getStakingStateWithRewardsBalances` uses the stake balance and stake boost directly from storage. On the intervals beyond the synced interval, the balance is accumulated and the boost is calculated incrementally.