### PR TITLE
NAY4-3 Update _isSelfOnboardingApproved to take role as a bytes32 instead of string

### DIFF
--- a/gemforge.config.cjs
+++ b/gemforge.config.cjs
@@ -20,7 +20,7 @@ module.exports = {
   // commands to execute
   commands: {
     // the build command
-    build: "forge build",
+    build: "forge build --ast",
   },
   paths: {
     // contract built artifacts folder

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nayms/contracts",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "main": "index.js",
   "repository": "https://github.com/nayms/contracts-v3.git",
   "author": "Kevin Park <kevin@fruitful.gg>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nayms/contracts",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "main": "index.js",
   "repository": "https://github.com/nayms/contracts-v3.git",
   "author": "Kevin Park <kevin@fruitful.gg>",

--- a/src/facets/AdminFacet.sol
+++ b/src/facets/AdminFacet.sol
@@ -151,8 +151,8 @@ contract AdminFacet is Modifiers {
      * @notice Approve a user address for self-onboarding
      * @param _userAddress user account address
      */
-    function approveSelfOnboarding(address _userAddress, bytes32 _entityId, bytes32 _role) external assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_ONBOARDING_APPROVERS) {
-        LibAdmin._approveSelfOnboarding(_userAddress, _entityId, _role);
+    function approveSelfOnboarding(address _userAddress, bytes32 _entityId, bytes32 _roleId) external assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_ONBOARDING_APPROVERS) {
+        LibAdmin._approveSelfOnboarding(_userAddress, _entityId, _roleId);
     }
 
     /**
@@ -162,8 +162,8 @@ contract AdminFacet is Modifiers {
         LibAdmin._onboardUser(msg.sender);
     }
 
-    function isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, bytes32 _role) external view returns (bool) {
-        return LibAdmin._isSelfOnboardingApproved(_userAddress, _entityId, _role);
+    function isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, bytes32 _roleId) external view returns (bool) {
+        return LibAdmin._isSelfOnboardingApproved(_userAddress, _entityId, _roleId);
     }
 
     function cancelSelfOnboarding(address _user) external assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_MANAGERS) {

--- a/src/facets/AdminFacet.sol
+++ b/src/facets/AdminFacet.sol
@@ -166,7 +166,7 @@ contract AdminFacet is Modifiers {
         LibAdmin._onboardUser(msg.sender);
     }
 
-    function isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, string calldata _role) external view returns (bool) {
+    function isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, bytes32 _role) external view returns (bool) {
         return LibAdmin._isSelfOnboardingApproved(_userAddress, _entityId, _role);
     }
 

--- a/src/facets/AdminFacet.sol
+++ b/src/facets/AdminFacet.sol
@@ -151,11 +151,7 @@ contract AdminFacet is Modifiers {
      * @notice Approve a user address for self-onboarding
      * @param _userAddress user account address
      */
-    function approveSelfOnboarding(
-        address _userAddress,
-        bytes32 _entityId,
-        string calldata _role
-    ) external assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_ONBOARDING_APPROVERS) {
+    function approveSelfOnboarding(address _userAddress, bytes32 _entityId, bytes32 _role) external assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_ONBOARDING_APPROVERS) {
         LibAdmin._approveSelfOnboarding(_userAddress, _entityId, _role);
     }
 

--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -229,11 +229,11 @@ library LibAdmin {
         if (!LibObject._isObjectType(_entityId, LC.OBJECT_TYPE_ENTITY)) revert InvalidEntityId(_entityId);
 
         // Require that the user is not approved for the role already
-        bytes32 roleId = LibHelpers._stringToBytes32(_role);
-        if (_isSelfOnboardingApproved(_userAddress, _entityId, roleId)) revert EntityOnboardingAlreadyApproved(_userAddress);
+        bytes32 roleBytes32 = LibHelpers._stringToBytes32(_role);
+        if (_isSelfOnboardingApproved(_userAddress, _entityId, roleBytes32)) revert EntityOnboardingAlreadyApproved(_userAddress);
 
-        bool isTokenHolder = roleId == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
-        bool isCapitalProvider = roleId == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_CP);
+        bool isTokenHolder = roleBytes32 == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
+        bool isCapitalProvider = roleBytes32 == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_CP);
         if (!isTokenHolder && !isCapitalProvider) {
             revert InvalidSelfOnboardRoleApproval(_role);
         }

--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -229,16 +229,16 @@ library LibAdmin {
         if (!LibObject._isObjectType(_entityId, LC.OBJECT_TYPE_ENTITY)) revert InvalidEntityId(_entityId);
 
         // Require that the user is not approved for the role already
-        bytes32 roleBytes32 = LibHelpers._stringToBytes32(_role);
-        if (_isSelfOnboardingApproved(_userAddress, _entityId, roleBytes32)) revert EntityOnboardingAlreadyApproved(_userAddress);
+        bytes32 roleId = LibHelpers._stringToBytes32(_role);
+        if (_isSelfOnboardingApproved(_userAddress, _entityId, roleId)) revert EntityOnboardingAlreadyApproved(_userAddress);
 
-        bool isTokenHolder = roleBytes32 == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
-        bool isCapitalProvider = roleBytes32 == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_CP);
+        bool isTokenHolder = roleId == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
+        bool isCapitalProvider = roleId == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_CP);
         if (!isTokenHolder && !isCapitalProvider) {
             revert InvalidSelfOnboardRoleApproval(_role);
         }
 
-        s.selfOnboarding[_userAddress] = EntityApproval({ entityId: _entityId, roleId: roleBytes32 });
+        s.selfOnboarding[_userAddress] = EntityApproval({ entityId: _entityId, roleId: roleId });
 
         emit SelfOnboardingApproved(_userAddress);
     }

--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -230,7 +230,7 @@ library LibAdmin {
 
         // Require that the user is not approved for the role already
         bytes32 roleId = LibHelpers._stringToBytes32(_role);
-        if (_isSelfOnboardingApproved(_userAddress, _entityId, _role)) revert EntityOnboardingAlreadyApproved(_userAddress);
+        if (_isSelfOnboardingApproved(_userAddress, _entityId, roleId)) revert EntityOnboardingAlreadyApproved(_userAddress);
 
         bool isTokenHolder = roleId == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
         bool isCapitalProvider = roleId == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_CP);
@@ -274,12 +274,12 @@ library LibAdmin {
         emit SelfOnboardingCompleted(_userAddress);
     }
 
-    function _isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, string calldata _role) internal view returns (bool) {
+    function _isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, bytes32 _role) internal view returns (bool) {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         EntityApproval memory approval = s.selfOnboarding[_userAddress];
 
-        return approval.entityId == _entityId && approval.roleId == LibHelpers._stringToBytes32(_role);
+        return approval.entityId == _entityId && approval.roleId == _role;
     }
 
     function _cancelSelfOnboarding(address _userAddress) internal {

--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -222,23 +222,22 @@ library LibAdmin {
         emit FunctionsUnlocked(lockedFunctions);
     }
 
-    function _approveSelfOnboarding(address _userAddress, bytes32 _entityId, string calldata _role) internal {
+    function _approveSelfOnboarding(address _userAddress, bytes32 _entityId, bytes32 _roleId) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         // The entityId must be the valid type (entity).
         if (!LibObject._isObjectType(_entityId, LC.OBJECT_TYPE_ENTITY)) revert InvalidEntityId(_entityId);
 
         // Require that the user is not approved for the role already
-        bytes32 roleId = LibHelpers._stringToBytes32(_role);
-        if (_isSelfOnboardingApproved(_userAddress, _entityId, roleId)) revert EntityOnboardingAlreadyApproved(_userAddress);
+        if (_isSelfOnboardingApproved(_userAddress, _entityId, _roleId)) revert EntityOnboardingAlreadyApproved(_userAddress);
 
-        bool isTokenHolder = roleId == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
-        bool isCapitalProvider = roleId == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_CP);
+        bool isTokenHolder = _roleId == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
+        bool isCapitalProvider = _roleId == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_CP);
         if (!isTokenHolder && !isCapitalProvider) {
-            revert InvalidSelfOnboardRoleApproval(_role);
+            revert InvalidSelfOnboardRoleApproval(_roleId);
         }
 
-        s.selfOnboarding[_userAddress] = EntityApproval({ entityId: _entityId, roleId: roleId });
+        s.selfOnboarding[_userAddress] = EntityApproval({ entityId: _entityId, roleId: _roleId });
 
         emit SelfOnboardingApproved(_userAddress);
     }
@@ -274,12 +273,12 @@ library LibAdmin {
         emit SelfOnboardingCompleted(_userAddress);
     }
 
-    function _isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, bytes32 _role) internal view returns (bool) {
+    function _isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, bytes32 _roleId) internal view returns (bool) {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         EntityApproval memory approval = s.selfOnboarding[_userAddress];
 
-        return approval.entityId == _entityId && approval.roleId == _role;
+        return approval.entityId == _entityId && approval.roleId == _roleId;
     }
 
     function _cancelSelfOnboarding(address _userAddress) internal {

--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -238,7 +238,7 @@ library LibAdmin {
             revert InvalidSelfOnboardRoleApproval(_role);
         }
 
-        s.selfOnboarding[_userAddress] = EntityApproval({ entityId: _entityId, roleId: roleId });
+        s.selfOnboarding[_userAddress] = EntityApproval({ entityId: _entityId, roleId: roleBytes32 });
 
         emit SelfOnboardingApproved(_userAddress);
     }

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -27,7 +27,7 @@ error InvalidGroupPrivilege(bytes32 msgSenderId, bytes32 context, string roleInC
 
 /// @notice only Token Holder or Capital Provider should be approved for self-onboarding
 /// @param role The name of the rle which should not be approaved for self-onboarding
-error InvalidSelfOnboardRoleApproval(string role);
+error InvalidSelfOnboardRoleApproval(bytes32 role);
 
 /// @dev Passing in a missing address when trying to add a token address to the supported external token list.
 error CannotAddNullSupportedExternalToken();

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -1247,19 +1247,19 @@ contract T04EntityTest is D03ProtocolDefaults {
         nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
 
         bytes32 entityId = randomEntityId(2);
+        bytes32 roleTokenHolder = LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
 
         vm.startPrank(em.addr);
         nayms.approveSelfOnboarding(address(111), entityId, LC.ROLE_ENTITY_TOKEN_HOLDER);
-
-        assertTrue(nayms.isSelfOnboardingApproved(address(111), entityId, LC.ROLE_ENTITY_TOKEN_HOLDER), "Onboarding should be approved");
+        assertTrue(nayms.isSelfOnboardingApproved(address(111), entityId, roleTokenHolder), "Onboarding should be approved");
 
         vm.expectRevert(abi.encodeWithSelector(InvalidGroupPrivilege.selector, em.addr._getIdForAddress(), systemContext, LC.ROLE_ONBOARDING_APPROVER, LC.GROUP_SYSTEM_MANAGERS));
         nayms.cancelSelfOnboarding(address(111));
-
+        vm.stopPrank();
         vm.startPrank(sm.addr);
         nayms.cancelSelfOnboarding(address(111));
 
-        assertFalse(nayms.isSelfOnboardingApproved(address(111), entityId, LC.ROLE_ENTITY_TOKEN_HOLDER), "Onboarding should have been cancelled");
+        assertFalse(nayms.isSelfOnboardingApproved(address(111), entityId, roleTokenHolder), "Onboarding should have been cancelled");
     }
 
     function _approveSelfOnboarding(address _userAddress, bytes32 entityId, string memory roleName) private {


### PR DESCRIPTION
Only the check `_isSelfOnboardingApproved` is updated to use `bytes32` for the `_role` parameter, other functions such as `_approveSelfOnboarding` still take `string`. 