### PR TITLE
NAY4-4 Incorrect boosted balance

### DIFF
--- a/src/facets/StakingFacet.sol
+++ b/src/facets/StakingFacet.sol
@@ -74,7 +74,7 @@ contract StakingFacet is Modifiers {
         LibTokenizedVaultStaking._payReward(_stakingRewardId, _entityId, _rewardTokenId, _amount);
     }
 
-    function getStakingAmounts(bytes32 _stakerId, bytes32 _entityId) external view returns (uint256 stakedAmount_, uint256 boostedAmount_) {
-        return LibTokenizedVaultStaking._getStakingAmounts(_stakerId, _entityId);
+    function getStakingAmounts(bytes32 _entityId, bytes32 _stakerId) external view returns (uint256 stakedAmount_, uint256 boostedAmount_) {
+        return LibTokenizedVaultStaking._getStakingAmounts(_entityId, _stakerId);
     }
 }

--- a/src/facets/StakingFacet.sol
+++ b/src/facets/StakingFacet.sol
@@ -74,7 +74,7 @@ contract StakingFacet is Modifiers {
         LibTokenizedVaultStaking._payReward(_stakingRewardId, _entityId, _rewardTokenId, _amount);
     }
 
-    function getStakingAmounts(bytes32 _entityId, bytes32 _stakerId) external view returns (uint256 stakedAmount_, uint256 boostedAmount_) {
-        return LibTokenizedVaultStaking._getStakingAmounts(_entityId, _stakerId);
+    function getStakingAmounts(bytes32 _stakerId, bytes32 _entityId) external view returns (uint256 stakedAmount_, uint256 boostedAmount_) {
+        return LibTokenizedVaultStaking._getStakingAmounts(_stakerId, _entityId);
     }
 }

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -10,13 +10,7 @@ import { StakingConfig, StakingState, RewardsBalances } from "../shared/FreeStru
 
 import { StakingNotStarted, StakingAlreadyStarted, IntervalRewardPayedOutAlready, InvalidAValue, InvalidRValue, InvalidDividerValue, InvalidStakingInitDate, APlusRCannotBeGreaterThanDivider, InvalidIntervalSecondsValue, InvalidTokenRewardAmount, EntityDoesNotExist, InitDateTooFar, IntervalOutOfRange, BoostMultiplierConvergenceFailure, InvalidTokenId, InvalidStakingAmount, InvalidStaker } from "../shared/CustomErrors.sol";
 
-// solhint-disable no-console
-import { console2 as c } from "forge-std/console2.sol";
-import { StdStyle } from "forge-std/Test.sol";
-
 library LibTokenizedVaultStaking {
-    using StdStyle for *;
-
     event TokenStakingStarted(bytes32 indexed entityId, bytes32 tokenId, uint256 initDate, uint64 a, uint64 r, uint64 divider, uint64 interval);
     event TokenStaked(bytes32 indexed stakerId, bytes32 entityId, bytes32 tokenId, uint256 amount);
     event TokenUnstaked(bytes32 indexed stakerId, bytes32 entityId, bytes32 tokenId, uint256 amount);

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -396,7 +396,7 @@ library LibTokenizedVaultStaking {
         intervalTime_ = _calculateStartTimeOfInterval(_entityId, _currentInterval(_entityId));
     }
 
-    function _getStakingAmounts(bytes32 _entityId, bytes32 _stakerId) internal view returns (uint256 stakedBalance_, uint256 boostedBalance_) {
+    function _getStakingAmounts(bytes32 _stakerId, bytes32 _entityId) internal view returns (uint256 stakedBalance_, uint256 boostedBalance_) {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         uint64 currentInterval = _currentInterval(_entityId);

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -409,7 +409,6 @@ library LibTokenizedVaultStaking {
 
         uint64 currentInterval = _currentInterval(_entityId);
         bytes32 tokenId = s.stakingConfigs[_entityId].tokenId;
-
         stakedBalance_ = _stakedAmount(_stakerId, _entityId);
 
         if (!_isStakingInitialized(_entityId)) {
@@ -417,15 +416,12 @@ library LibTokenizedVaultStaking {
             return (stakedBalance_, boostedBalance_);
         }
 
-        (StakingState memory state, ) = _getStakingStateWithRewardsBalances(_stakerId, _entityId, currentInterval);
+        (StakingState memory state, ) = _getStakingStateWithRewardsBalances(_stakerId, _entityId, currentInterval + 2);
 
-        // uint256 boost1 = ((s.stakeBalance[_vTokenId(_entityId, tokenId, currentInterval + 1)][_stakerId] * _getD(_entityId)) / _getR(_entityId));
-        uint256 boost1 = s.stakeBalance[_vTokenId(_entityId, tokenId, currentInterval + 1)][_stakerId];
-        uint256 balance1 = s.stakeBalance[_vTokenId(_entityId, tokenId, currentInterval + 1)][_stakerId];
-        uint256 balance2 = s.stakeBalance[_vTokenId(_entityId, tokenId, currentInterval + 2)][_stakerId];
+        uint256 boost = (s.stakeBalance[_vTokenId(_entityId, tokenId, currentInterval + 1)][_stakerId] * _getA(_entityId)) / _getD(_entityId);
+        uint256 boost2 = s.stakeBoost[_vTokenId(_entityId, tokenId, currentInterval + 1)][_stakerId];
 
-        boostedBalance_ = state.balance + balance1 + balance2;
-        // boostedBalance_ = state.balance + balance1 + balance2 - boost1;
+        boostedBalance_ = state.balance - boost - boost2;
 
         if (boostedBalance_ < stakedBalance_) {
             boostedBalance_ = stakedBalance_;

--- a/src/shared/AppStorage.sol
+++ b/src/shared/AppStorage.sol
@@ -83,12 +83,13 @@ struct AppStorage {
     mapping(address userAddress => EntityApproval) selfOnboarding; // map address => { entityId, roleId }
     /// Staking
     mapping(bytes32 entityId => StakingConfig) stakingConfigs; // StakingConfig for an entity
-    mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 balance)) stakeBalance; // [vTokenId][ownerId] boost at interval
+    mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 balance)) stakeBalance; // [vTokenId][ownerId] balance at interval
     mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 boost)) stakeBoost; // [vTokenId][ownerId] boost at interval
     mapping(bytes32 entityId => mapping(bytes32 stakerId => uint64 interval)) stakeCollected; // last interval reward was collected or pain for a staker in staking entity
     mapping(bytes32 vTokenId => uint256 amount) stakingDistributionAmount; // [vTokenId] Reward at interval
     mapping(bytes32 vTokenId => bytes32 denomination) stakingDistributionDenomination; // [vTokenId] Reward currency
     mapping(bytes32 entityId => mapping(bytes32 stakerId => uint64 interval)) stakingSynced; // last interval when data was synced into storage for staker
+    mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 balance)) stakeBalanceAdded; // raw balance staked at an interval, withouth any boost included, only for reading future intervals (to calculate the total boosted balance)
 }
 
 struct FunctionLockedStorage {

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -166,6 +166,20 @@ contract T06Staking is D03ProtocolDefaults {
         c.log("");
     }
 
+    function printStatesBoosts(bytes32 entityId, bytes32 stakerId, uint64 interval, string memory name) internal {
+        // (uint256 s1, uint256 s2, uint s3) = nayms.getStakedAt(stakerId, entityId, inter);
+        // (uint256 b1, uint256 b2, uint b3) = nayms.getBoostAt(stakerId, entityId, inter);
+
+        c.log("");
+        c.log("   ~~~~~~~  %s  ~~~~~~~".blue().bold(), name);
+        c.log("     at i0 balance: %s boost: %s".yellow(), stakeBalance(stakerId, entityId, interval), stakeBoost(stakerId, entityId, interval));
+        c.log("     at i1 balance: %s boost: %s".yellow(), stakeBalance(stakerId, entityId, interval + 1), stakeBoost(stakerId, entityId, interval + 1));
+        c.log("     at i2 balance: %s boost: %s".yellow(), stakeBalance(stakerId, entityId, interval + 2), stakeBoost(stakerId, entityId, interval + 2));
+        c.log("     at i3 balance: %s boost: %s".yellow(), stakeBalance(stakerId, entityId, interval + 3), stakeBoost(stakerId, entityId, interval + 3));
+        c.log("     at i4 balance: %s boost: %s".yellow(), stakeBalance(stakerId, entityId, interval + 4), stakeBoost(stakerId, entityId, interval + 4));
+        c.log("");
+    }
+
     function initStaking(uint256 initDate) internal {
         StakingConfig memory config = StakingConfig({
             tokenId: NAYM_ID,
@@ -1361,5 +1375,43 @@ contract T06Staking is D03ProtocolDefaults {
 
     function logStateAt(uint64 interval, bytes32 staker, bytes32 entityId) private {
         c.log("  [%s] balance: %s, boost: %s", interval, stakeBalance(staker, entityId, interval), stakeBoost(staker, entityId, interval));
+    }
+
+    function test_stake_QS3() public {
+        uint256 start = block.timestamp + 1;
+
+        initStaking(start);
+        vm.warp(start + 15 days);
+
+        startPrank(bob);
+        nayms.stake(nlf.entityId, 1 ether);
+        printStatesBoosts(nlf.entityId, bob.entityId, 0, "Bob");
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+        vm.warp(start + 31 days);
+        printStatesBoosts(nlf.entityId, bob.entityId, 0, "Bob");
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+    }
+
+    function test_stake_QS4() public {
+        uint256 start = block.timestamp + 1;
+
+        initStaking(start);
+        vm.warp(start + 15 days);
+
+        startPrank(bob);
+        nayms.stake(nlf.entityId, 1 ether);
+        c.log("-- Stake 1 ETH -- ");
+        printStatesBoosts(nlf.entityId, bob.entityId, 0, "Bob");
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+
+        vm.warp(start + 50 days);
+        c.log("-- WARP DAYS -- ");
+        printStatesBoosts(nlf.entityId, bob.entityId, 0, "Bob");
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
+
+        c.log("~~~ Stake 1 ETH -- ");
+        nayms.stake(nlf.entityId, 1 ether);
+        printStatesBoosts(nlf.entityId, bob.entityId, 0, "Bob");
+        printCurrentState(nlf.entityId, bob.entityId, "Bob");
     }
 }

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -146,7 +146,7 @@ contract T06Staking is D03ProtocolDefaults {
     }
 
     function assertStakedAmount(bytes32 stakerId, uint256 amount, string memory message) private {
-        (uint256 staked, ) = nayms.getStakingAmounts(nlf.entityId, stakerId);
+        (uint256 staked, ) = nayms.getStakingAmounts(stakerId, nlf.entityId);
         assertEq(staked, amount, message);
     }
 
@@ -157,7 +157,7 @@ contract T06Staking is D03ProtocolDefaults {
 
     function printCurrentState(bytes32 entityId, bytes32 stakerId, string memory name) internal view {
         uint64 interval = currentInterval();
-        (uint256 stakedAmount_, uint256 boostedAmount_) = nayms.getStakingAmounts(entityId, stakerId);
+        (uint256 stakedAmount_, uint256 boostedAmount_) = nayms.getStakingAmounts(stakerId, entityId);
         c.log("");
         c.log("   ~~~~~~~  %s  ~~~~~~~".blue().bold(), name);
         c.log("     Balance[%s]:".green(), interval, stakedAmount_);
@@ -784,7 +784,7 @@ contract T06Staking is D03ProtocolDefaults {
         nayms.stake(nlf.entityId, bobStakeAmount);
 
         assertStakedAmount(bob.entityId, bobStakeAmount, "Bob's stake should increase");
-        (uint256 stakedAmount, uint256 boostedAmount) = nayms.getStakingAmounts(nlf.entityId, bob.entityId);
+        (uint256 stakedAmount, uint256 boostedAmount) = nayms.getStakingAmounts(bob.entityId, nlf.entityId);
         assertEq(stakedAmount, boostedAmount, "Bob's boost[1] should be 1");
 
         vm.warp(startStaking + 40 days);
@@ -796,7 +796,7 @@ contract T06Staking is D03ProtocolDefaults {
 
         nayms.stake(nlf.entityId, bobStakeAmount);
 
-        (uint256 stakedAmount2, uint256 boostedAmount2) = nayms.getStakingAmounts(nlf.entityId, bob.entityId);
+        (uint256 stakedAmount2, uint256 boostedAmount2) = nayms.getStakingAmounts(bob.entityId, nlf.entityId);
         assertEq(stakedAmount2, boostedAmount2, "Bob's boost [2] should be 1");
     }
     /*
@@ -1338,7 +1338,7 @@ contract T06Staking is D03ProtocolDefaults {
         startPrank(bob);
         nayms.stake(nlf.entityId, 1 ether);
 
-        (uint256 stakedBalance, uint256 boostedBalance) = nayms.getStakingAmounts(nlf.entityId, bob.entityId);
+        (uint256 stakedBalance, uint256 boostedBalance) = nayms.getStakingAmounts(bob.entityId, nlf.entityId);
         assertEq(stakedBalance, boostedBalance, "Bob should have no boost".red());
         printCurrentState(nlf.entityId, bob.entityId, "Bob");
 
@@ -1349,13 +1349,13 @@ contract T06Staking is D03ProtocolDefaults {
         uint256 bobBoost = calculateBoost(startTime, stake2Time, R, I, SCALE_FACTOR);
         uint256 boostedBalance1 = (0.5 ether * bobBoost) / SCALE_FACTOR / SCALE_FACTOR + 0.5 ether;
 
-        (, uint256 boostedBalance2) = nayms.getStakingAmounts(nlf.entityId, bob.entityId);
+        (, uint256 boostedBalance2) = nayms.getStakingAmounts(bob.entityId, nlf.entityId);
         assertEq(boostedBalance2, boostedBalance1, "Bob should have boost at[1]".red());
 
         c.log("~~~ Stake 1 ETH -- ".yellow());
         nayms.stake(nlf.entityId, 1 ether);
 
-        (, uint256 boostedBalance3) = nayms.getStakingAmounts(nlf.entityId, bob.entityId);
+        (, uint256 boostedBalance3) = nayms.getStakingAmounts(bob.entityId, nlf.entityId);
         assertEq(boostedBalance3, boostedBalance1 + 1 ether, "Bob should have boost and more stake".red());
 
         printCurrentState(nlf.entityId, bob.entityId, "Bob");


### PR DESCRIPTION
Value returned by `_getStakingAmounts()` incorrectly handles the amount staked in the current interval.

Actions:
- Fixed the method to return expected values

New mapping `stakeBalanceAdded` has been introduced in the appstorage for this purpose. This mapping records the amount added at each interval. It should only be used for reading the balance of future intervals. We use `_getStakingStateWithRewardsBalances` to read the boosted up to the current interval. To that, we add balance written to the future intervals(+1 and +2) as-is with no boost applied.