### PR TITLE
Approve onboarding via signature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nayms/contracts",
-  "version": "3.9.3",
+  "version": "3.9.4",
   "main": "index.js",
   "repository": "https://github.com/nayms/contracts-v3.git",
   "author": "Kevin Park <kevin@fruitful.gg>",

--- a/src/facets/AdminFacet.sol
+++ b/src/facets/AdminFacet.sol
@@ -148,26 +148,18 @@ contract AdminFacet is Modifiers {
     }
 
     /**
-     * @notice Approve a user address for self-onboarding
-     * @param _userAddress user account address
-     */
-    function approveSelfOnboarding(address _userAddress, bytes32 _entityId, bytes32 _roleId) external assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_ONBOARDING_APPROVERS) {
-        LibAdmin._approveSelfOnboarding(_userAddress, _entityId, _roleId);
-    }
-
-    /**
      * @notice Create a token holder entity for a user account
      */
     function onboard() external {
         LibAdmin._onboardUser(msg.sender);
     }
 
-    function isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, bytes32 _roleId) external view returns (bool) {
-        return LibAdmin._isSelfOnboardingApproved(_userAddress, _entityId, _roleId);
+    function onboard2(bytes32 _entityId, bytes32 _roleId, bytes calldata sig) external {
+        LibAdmin._onboardUser2(msg.sender, _entityId, _roleId, sig);
     }
 
-    function cancelSelfOnboarding(address _user) external assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_MANAGERS) {
-        LibAdmin._cancelSelfOnboarding(_user);
+    function isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, bytes32 _roleId) external view returns (bool) {
+        return LibAdmin._isSelfOnboardingApproved(_userAddress, _entityId, _roleId);
     }
 
     function getOnboardingHash(address _userAddress, bytes32 _entityId, bytes32 _roleId) external view returns (bytes32) {

--- a/src/facets/AdminFacet.sol
+++ b/src/facets/AdminFacet.sol
@@ -154,6 +154,10 @@ contract AdminFacet is Modifiers {
         LibAdmin._onboardUser(msg.sender);
     }
 
+    function isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, bytes32 _roleId) external view returns (bool) {
+        return LibAdmin._isSelfOnboardingApproved(_userAddress, _entityId, _roleId);
+    }
+
     /**
      * @notice Create a token holder entity for a user account
      * @param _entityId object ID for which the fee schedule is being set, use system ID for global fee schedule
@@ -162,10 +166,6 @@ contract AdminFacet is Modifiers {
      */
     function onboardViaSignature(bytes32 _entityId, bytes32 _roleId, bytes calldata _sig) external {
         LibAdmin._onboardUserViaSignature(msg.sender, _entityId, _roleId, _sig);
-    }
-
-    function isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, bytes32 _roleId) external view returns (bool) {
-        return LibAdmin._isSelfOnboardingApproved(_userAddress, _entityId, _roleId);
     }
 
     /**

--- a/src/facets/AdminFacet.sol
+++ b/src/facets/AdminFacet.sol
@@ -154,14 +154,26 @@ contract AdminFacet is Modifiers {
         LibAdmin._onboardUser(msg.sender);
     }
 
-    function onboardViaSignature(bytes32 _entityId, bytes32 _roleId, bytes calldata sig) external {
-        LibAdmin._onboardUserViaSignature(msg.sender, _entityId, _roleId, sig);
+    /**
+     * @notice Create a token holder entity for a user account
+     * @param _entityId object ID for which the fee schedule is being set, use system ID for global fee schedule
+     * @param _roleId Role to assign to the entity
+     * @param _sig Signature approving the user to be onboarded to the given role
+     */
+    function onboardViaSignature(bytes32 _entityId, bytes32 _roleId, bytes calldata _sig) external {
+        LibAdmin._onboardUserViaSignature(msg.sender, _entityId, _roleId, _sig);
     }
 
     function isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, bytes32 _roleId) external view returns (bool) {
         return LibAdmin._isSelfOnboardingApproved(_userAddress, _entityId, _roleId);
     }
 
+    /**
+     * @notice Hash to be signed by the onboarding approver
+     * @param _userAddress Address being approved to onboard
+     * @param _entityId Entity ID being approved for onboarding
+     * @param _roleId Role being apprved for onboarding
+     */
     function getOnboardingHash(address _userAddress, bytes32 _entityId, bytes32 _roleId) external view returns (bytes32) {
         return LibAdmin._getOnboardingHash(_userAddress, _entityId, _roleId);
     }

--- a/src/facets/AdminFacet.sol
+++ b/src/facets/AdminFacet.sol
@@ -169,4 +169,8 @@ contract AdminFacet is Modifiers {
     function cancelSelfOnboarding(address _user) external assertPrivilege(LibAdmin._getSystemId(), LC.GROUP_SYSTEM_MANAGERS) {
         LibAdmin._cancelSelfOnboarding(_user);
     }
+
+    function getOnboardingHash(address _userAddress, bytes32 _entityId, bytes32 _roleId) external view returns (bytes32) {
+        return LibAdmin._getOnboardingHash(_userAddress, _entityId, _roleId);
+    }
 }

--- a/src/facets/AdminFacet.sol
+++ b/src/facets/AdminFacet.sol
@@ -154,8 +154,8 @@ contract AdminFacet is Modifiers {
         LibAdmin._onboardUser(msg.sender);
     }
 
-    function onboard2(bytes32 _entityId, bytes32 _roleId, bytes calldata sig) external {
-        LibAdmin._onboardUser2(msg.sender, _entityId, _roleId, sig);
+    function onboardViaSignature(bytes32 _entityId, bytes32 _roleId, bytes calldata sig) external {
+        LibAdmin._onboardUserViaSignature(msg.sender, _entityId, _roleId, sig);
     }
 
     function isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, bytes32 _roleId) external view returns (bool) {

--- a/src/facets/AdminFacet.sol
+++ b/src/facets/AdminFacet.sol
@@ -149,17 +149,6 @@ contract AdminFacet is Modifiers {
 
     /**
      * @notice Create a token holder entity for a user account
-     */
-    function onboard() external {
-        LibAdmin._onboardUser(msg.sender);
-    }
-
-    function isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, bytes32 _roleId) external view returns (bool) {
-        return LibAdmin._isSelfOnboardingApproved(_userAddress, _entityId, _roleId);
-    }
-
-    /**
-     * @notice Create a token holder entity for a user account
      * @param _entityId object ID for which the fee schedule is being set, use system ID for global fee schedule
      * @param _roleId Role to assign to the entity
      * @param _sig Signature approving the user to be onboarded to the given role

--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -317,7 +317,7 @@ library LibAdmin {
     function _getOnboardingHash(address _userAddress, bytes32 _entityId, bytes32 _roleId) internal view returns (bytes32) {
         return
             LibEIP712._hashTypedDataV4(
-                keccak256(abi.encode(keccak256("OnboardingApproval(address _userAddress, bytes32 _entityId, bytes32 _roleId)"), _userAddress, _entityId, _roleId))
+                keccak256(abi.encode(keccak256("OnboardingApproval(address _userAddress,bytes32 _entityId,bytes32 _roleId)"), _userAddress, _entityId, _roleId))
             );
     }
 

--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -25,7 +25,6 @@ import {
     EntityOnboardingAlreadyApproved,
     EntityOnboardingNotApproved,
     InvalidSelfOnboardRoleApproval,
-    InvalidEntityId,
     InvalidSignatureError,
     InvalidSignatureSError
 } from "../shared/CustomErrors.sol";
@@ -237,6 +236,10 @@ library LibAdmin {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         if (_entityId == 0 || _roleId == 0 || sig.length == 0) revert EntityOnboardingNotApproved(_userAddress);
+
+        bool isTokenHolder = _roleId == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
+        bool isCapitalProvider = _roleId == LibHelpers._stringToBytes32(LC.ROLE_ENTITY_CP);
+        if (!isTokenHolder && !isCapitalProvider) revert InvalidSelfOnboardRoleApproval(_roleId);
 
         bytes32 onboardingApproversGroupId = LibHelpers._stringToBytes32(LC.GROUP_ONBOARDING_APPROVERS);
         bytes32 signingHash = _getOnboardingHash(_userAddress, _entityId, _roleId);

--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -262,6 +262,8 @@ library LibAdmin {
 
         LibACL._assignRole(_entityId, LibAdmin._getSystemId(), _roleId);
         LibACL._assignRole(_entityId, _entityId, _roleId);
+
+        emit SelfOnboardingCompleted(_userAddress);
     }
 
     function _onboardUser(address _userAddress) internal {

--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -9,6 +9,8 @@ import { LibObject } from "./LibObject.sol";
 import { LibERC20 } from "./LibERC20.sol";
 import { LibEntity } from "./LibEntity.sol";
 import { LibACL } from "./LibACL.sol";
+import { LibEIP712 } from "./LibEIP712.sol";
+
 // prettier-ignore
 import {
     CannotAddNullDiscountToken,
@@ -304,5 +306,12 @@ library LibAdmin {
         s.objectMinimumSell[_objectId] = _minimumSell;
 
         emit MinimumSellUpdated(_objectId, _minimumSell);
+    }
+
+    function _getOnboardingHash(address _userAddress, bytes32 _entityId, bytes32 _roleId) internal view returns (bytes32) {
+        return
+            LibEIP712._hashTypedDataV4(
+                keccak256(abi.encode(keccak256("OnboardingApproval(address _userAddress, bytes32 _entityId, bytes32 _roleId)"), _userAddress, _entityId, _roleId))
+            );
     }
 }

--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -233,7 +233,7 @@ library LibAdmin {
         emit FunctionsUnlocked(lockedFunctions);
     }
 
-    function _onboardUser2(address _userAddress, bytes32 _entityId, bytes32 _roleId, bytes calldata sig) internal {
+    function _onboardUserViaSignature(address _userAddress, bytes32 _entityId, bytes32 _roleId, bytes calldata sig) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
         if (_entityId == 0 || _roleId == 0 || sig.length == 0) revert EntityOnboardingNotApproved(_userAddress);

--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -252,16 +252,10 @@ library LibAdmin {
             LibEntity._createEntity(_entityId, userId, entity, 0);
         }
 
-        if (s.roles[_entityId][_entityId] != 0) {
-            LibACL._unassignRole(_entityId, _entityId);
-        }
-
         if (s.roles[_entityId][LibAdmin._getSystemId()] != 0) {
             LibACL._unassignRole(_entityId, LibAdmin._getSystemId());
         }
-
         LibACL._assignRole(_entityId, LibAdmin._getSystemId(), _roleId);
-        LibACL._assignRole(_entityId, _entityId, _roleId);
 
         emit SelfOnboardingCompleted(_userAddress);
     }

--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -266,45 +266,6 @@ library LibAdmin {
         emit SelfOnboardingCompleted(_userAddress);
     }
 
-    function _onboardUser(address _userAddress) internal {
-        AppStorage storage s = LibAppStorage.diamondStorage();
-        EntityApproval memory approval = s.selfOnboarding[_userAddress];
-
-        if (approval.entityId == 0 || approval.roleId == 0) {
-            revert EntityOnboardingNotApproved(_userAddress);
-        }
-
-        bytes32 userId = LibHelpers._getIdForAddress(_userAddress);
-
-        if (!s.existingEntities[approval.entityId]) {
-            Entity memory entity;
-            LibEntity._createEntity(approval.entityId, userId, entity, 0);
-        }
-
-        if (s.roles[approval.entityId][approval.entityId] != 0) {
-            LibACL._unassignRole(approval.entityId, approval.entityId);
-        }
-
-        if (s.roles[approval.entityId][LibAdmin._getSystemId()] != 0) {
-            LibACL._unassignRole(approval.entityId, LibAdmin._getSystemId());
-        }
-
-        LibACL._assignRole(approval.entityId, LibAdmin._getSystemId(), approval.roleId);
-        LibACL._assignRole(approval.entityId, approval.entityId, approval.roleId);
-
-        delete s.selfOnboarding[_userAddress];
-
-        emit SelfOnboardingCompleted(_userAddress);
-    }
-
-    function _isSelfOnboardingApproved(address _userAddress, bytes32 _entityId, bytes32 _roleId) internal view returns (bool) {
-        AppStorage storage s = LibAppStorage.diamondStorage();
-
-        EntityApproval memory approval = s.selfOnboarding[_userAddress];
-
-        return approval.entityId == _entityId && approval.roleId == _roleId;
-    }
-
     function _setMinimumSell(bytes32 _objectId, uint256 _minimumSell) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
         if (_minimumSell == 0) revert MinimumSellCannotBeZero();

--- a/src/libs/LibConstants.sol
+++ b/src/libs/LibConstants.sol
@@ -50,19 +50,18 @@ library LibConstants {
     string internal constant ROLE_ENTITY_COMPTROLLER_CLAIM = "Comptroller Claim";
     string internal constant ROLE_ENTITY_COMPTROLLER_DIVIDEND = "Comptroller Dividend";
 
-    /// old roles
+    string internal constant ROLE_ONBOARDING_APPROVER = "Onboarding Approver";
 
+    /// old roles
     string internal constant ROLE_SPONSOR = "Sponsor";
     string internal constant ROLE_CAPITAL_PROVIDER = "Capital Provider";
     string internal constant ROLE_INSURED_PARTY = "Insured";
     string internal constant ROLE_BROKER = "Broker";
     string internal constant ROLE_SERVICE_PROVIDER = "Service Provider";
-
     string internal constant ROLE_UNDERWRITER = "Underwriter";
     string internal constant ROLE_CLAIMS_ADMIN = "Claims Admin";
     string internal constant ROLE_TRADER = "Trader";
     string internal constant ROLE_SEGREGATED_ACCOUNT = "Segregated Account";
-    string internal constant ROLE_ONBOARDING_APPROVER = "Onboarding Approver";
 
     /// Groups
 

--- a/src/libs/LibHelpers.sol
+++ b/src/libs/LibHelpers.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import { LibConstants as LC } from "./LibConstants.sol";
-
 /// @notice Pure functions
 library LibHelpers {
     function _getIdForAddress(address _addr) internal pure returns (bytes32) {

--- a/src/shared/AppStorage.sol
+++ b/src/shared/AppStorage.sol
@@ -80,7 +80,7 @@ struct AppStorage {
     mapping(bytes32 entityId => mapping(uint256 feeScheduleTypeId => FeeSchedule)) feeSchedules; // map entity ID to a fee schedule type and then to array of FeeReceivers (feeScheduleType (1-premium, 2-trading, n-others))
     mapping(bytes32 objectId => uint256 minimumSell) objectMinimumSell; // map object ID to minimum sell amount
     mapping(bytes32 objectId => uint256) depositTotal; // total amount deposited into contract, for rebasing tokens support
-    mapping(address userAddress => EntityApproval) selfOnboarding; // map address => { entityId, roleId }
+    mapping(address userAddress => EntityApproval) selfOnboarding; // note: DEPRECATED
     /// Staking
     mapping(bytes32 entityId => StakingConfig) stakingConfigs; // StakingConfig for an entity
     mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 balance)) stakeBalance; // [vTokenId][ownerId] balance at interval

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -184,9 +184,6 @@ error InvalidSignatureSError(bytes32 sValue);
 /// @dev Thrown when the number of receivers specified in a transaction is not within the acceptable range.
 error InvalidReceiverCount(uint256 numberOfReceivers);
 
-/// @dev The entity ID is invalid for the given context.
-error InvalidEntityId(bytes32 entityId);
-
 /// @dev Thrown when the maturation date of a policy is set beyond the allowable future date limit.
 /// This prevents setting unrealistic maturation dates that could affect the contract's operability or the enforceability of the policy.
 error MaturationDateTooFar(uint256 maturationDate);

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -29,14 +29,8 @@ error InvalidGroupPrivilege(bytes32 msgSenderId, bytes32 context, string roleInC
 /// @param role The name of the rle which should not be approaved for self-onboarding
 error InvalidSelfOnboardRoleApproval(bytes32 role);
 
-/// @dev Passing in a missing address when trying to add a token address to the supported external token list.
-error CannotAddNullSupportedExternalToken();
-
 /// @dev Cannot add a ERC20 token to the supported external token list that has more than 18 decimal places.
 error CannotSupportExternalTokenWithMoreThan18Decimals();
-
-/// @dev Passing in a missing address when trying to assign a new token address as the new discount token.
-error CannotAddNullDiscountToken();
 
 /// @dev Object exsists when it should not.
 error ObjectExistsAlready(bytes32 objectId);
@@ -49,9 +43,6 @@ error EntityDoesNotExist(bytes32 objectId);
 
 /// @dev The entity self onboarding not approved
 error EntityOnboardingNotApproved(address userAddress);
-
-/// @dev The entity self onboarding already approved
-error EntityOnboardingAlreadyApproved(address userAddress);
 
 /// @dev Cannot create an entity that already exists.
 error EntityExistsAlready(bytes32 entityId);

--- a/test/T02ACL.t.sol
+++ b/test/T02ACL.t.sol
@@ -92,26 +92,11 @@ contract T02ACLTest is D03ProtocolDefaults, MockAccounts {
         string memory role = LC.ROLE_ENTITY_ADMIN;
 
         vm.recordLogs();
-
         nayms.assignRole(signer1Id, context, role);
 
         Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        assertEq(entries[0].topics.length, 2);
-        assertEq(entries[0].topics[0], keccak256("RoleUpdated(bytes32,bytes32,bytes32,string)"));
-        assertEq(entries[0].topics[1], signer1Id);
-        (bytes32 contextId, bytes32 roleId, string memory action) = abi.decode(entries[0].data, (bytes32, bytes32, string));
-        assertEq(contextId, context);
-        assertEq(roleId, bytes32(0));
-        assertEq(action, "_unassignRole");
-
-        assertEq(entries[1].topics.length, 2);
-        assertEq(entries[1].topics[0], keccak256("RoleUpdated(bytes32,bytes32,bytes32,string)"));
-        assertEq(entries[1].topics[1], signer1Id);
-        (contextId, roleId, action) = abi.decode(entries[1].data, (bytes32, bytes32, string));
-        assertEq(contextId, context);
-        assertEq(roleId, LibHelpers._stringToBytes32(role));
-        assertEq(action, "_assignRole");
+        assertRoleUpdateEvent(entries, 0, context, signer1Id, bytes32(0), "_unassignRole");
+        assertRoleUpdateEvent(entries, 1, context, signer1Id, LibHelpers._stringToBytes32(role), "_assignRole");
     }
 
     function testInvalidObjectIdWhenAssignRole() public {

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -339,9 +339,9 @@ contract T04EntityTest is D03ProtocolDefaults {
         bytes32 signingHash = nayms.getSigningHash(simplePolicy.startDate, simplePolicy.maturationDate, simplePolicy.asset, simplePolicy.limit, testPolicyDataHash);
 
         bytes[] memory signatures = new bytes[](3);
-        signatures[0] = initPolicySig(0xACC1, signingHash); // 0x2337f702bc9A7D1f415050365634FEbEdf4054Be
-        signatures[1] = initPolicySig(0xACC2, signingHash); // 0x167D6b35e51df22f42c4F42f26d365756D244fDE
-        signatures[2] = initPolicySig(0xACC3, signingHash); // 0x167D6b35e51df22f42c4F42f26d365756D244fDE
+        signatures[0] = signWithPK(0xACC1, signingHash); // 0x2337f702bc9A7D1f415050365634FEbEdf4054Be
+        signatures[1] = signWithPK(0xACC2, signingHash); // 0x167D6b35e51df22f42c4F42f26d365756D244fDE
+        signatures[2] = signWithPK(0xACC3, signingHash); // 0x167D6b35e51df22f42c4F42f26d365756D244fDE
 
         bytes32[] memory roles = new bytes32[](3);
         roles[0] = LibHelpers._stringToBytes32(LC.ROLE_UNDERWRITER);
@@ -389,9 +389,9 @@ contract T04EntityTest is D03ProtocolDefaults {
         bytes32 signingHash = nayms.getSigningHash(simplePolicy.startDate, simplePolicy.maturationDate, simplePolicy.asset, simplePolicy.limit, testPolicyDataHash);
 
         bytes[] memory signatures = new bytes[](3);
-        signatures[0] = initPolicySig(0xACC2, signingHash);
-        signatures[1] = initPolicySig(0xACC1, signingHash);
-        signatures[2] = initPolicySig(0xACC3, signingHash);
+        signatures[0] = signWithPK(0xACC2, signingHash);
+        signatures[1] = signWithPK(0xACC1, signingHash);
+        signatures[2] = signWithPK(0xACC3, signingHash);
 
         bytes32[] memory roles = new bytes32[](3);
         roles[0] = LibHelpers._stringToBytes32(LC.ROLE_UNDERWRITER);
@@ -438,10 +438,10 @@ contract T04EntityTest is D03ProtocolDefaults {
 
         bytes32 signingHash = nayms.getSigningHash(simplePolicy.startDate, simplePolicy.maturationDate, simplePolicy.asset, simplePolicy.limit, testPolicyDataHash);
 
-        stakeholders.signatures[0] = initPolicySig(0xACC2, signingHash);
-        stakeholders.signatures[1] = initPolicySig(0xACC1, signingHash);
-        stakeholders.signatures[2] = initPolicySig(0xACC3, signingHash);
-        stakeholders.signatures[3] = initPolicySig(0xACC4, signingHash);
+        stakeholders.signatures[0] = signWithPK(0xACC2, signingHash);
+        stakeholders.signatures[1] = signWithPK(0xACC1, signingHash);
+        stakeholders.signatures[2] = signWithPK(0xACC3, signingHash);
+        stakeholders.signatures[3] = signWithPK(0xACC4, signingHash);
 
         // external token not supported
         vm.expectRevert("external token is not supported");

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -1225,7 +1225,6 @@ contract T04EntityTest is D03ProtocolDefaults {
         assertEq(nayms.getEntity(LibHelpers._getIdForAddress(userAddress)), entityId, "parent should be set");
 
         assertTrue(nayms.isInGroup(entityId, systemContext, LC.GROUP_CAPITAL_PROVIDERS), "should belong capital providers group");
-        assertTrue(nayms.isInGroup(entityId, entityId, LC.GROUP_CAPITAL_PROVIDERS), "should belong capital providers group");
     }
 
     function testSelfOnboardingUpgradeToCapitalProvider() public {
@@ -1249,10 +1248,8 @@ contract T04EntityTest is D03ProtocolDefaults {
 
         Vm.Log[] memory entries = vm.getRecordedLogs();
 
-        assertRoleUpdateEvent(entries, 0, e1, e1, roleIdTokenHolder, "_unassignRole");
-        assertRoleUpdateEvent(entries, 1, systemContext, e1, roleIdTokenHolder, "_unassignRole");
-        assertRoleUpdateEvent(entries, 2, systemContext, e1, roleIdCapitalProvider, "_assignRole");
-        assertRoleUpdateEvent(entries, 3, e1, e1, roleIdCapitalProvider, "_assignRole");
+        assertRoleUpdateEvent(entries, 0, systemContext, e1, roleIdTokenHolder, "_unassignRole");
+        assertRoleUpdateEvent(entries, 1, systemContext, e1, roleIdCapitalProvider, "_assignRole");
     }
 
     function test_selfOnboarding_InvalidEntityId() public {

--- a/test/T04Entity.t.sol
+++ b/test/T04Entity.t.sol
@@ -1172,133 +1172,133 @@ contract T04EntityTest is D03ProtocolDefaults {
         vm.stopPrank();
     }
 
-    function testSelfOnboardingInvalidGroup() public {
-        bytes32 roleId = LibHelpers._stringToBytes32(LC.ROLE_SYSTEM_MANAGER);
-        nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
+    // function testSelfOnboardingInvalidGroup() public {
+    //     bytes32 roleId = LibHelpers._stringToBytes32(LC.ROLE_SYSTEM_MANAGER);
+    //     nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
 
-        vm.startPrank(em.addr);
-        vm.expectRevert(abi.encodeWithSelector(InvalidSelfOnboardRoleApproval.selector, roleId));
-        nayms.approveSelfOnboarding(address(111), randomEntityId(1), roleId);
-        vm.stopPrank();
-    }
+    //     vm.startPrank(em.addr);
+    //     vm.expectRevert(abi.encodeWithSelector(InvalidSelfOnboardRoleApproval.selector, roleId));
+    //     nayms.approveSelfOnboarding(address(111), randomEntityId(1), roleId);
+    //     vm.stopPrank();
+    // }
 
-    function testSelfOnboardingAlreadyApproved() public {
-        nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
+    // function testSelfOnboardingAlreadyApproved() public {
+    //     nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
 
-        bytes32 entityId = randomEntityId(2);
-        bytes32 roleId = LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
-        vm.startPrank(em.addr);
-        nayms.approveSelfOnboarding(address(111), entityId, roleId);
+    //     bytes32 entityId = randomEntityId(2);
+    //     bytes32 roleId = LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
+    //     vm.startPrank(em.addr);
+    //     nayms.approveSelfOnboarding(address(111), entityId, roleId);
 
-        vm.expectRevert(abi.encodeWithSelector(EntityOnboardingAlreadyApproved.selector, address(111)));
-        nayms.approveSelfOnboarding(address(111), entityId, roleId);
-        vm.stopPrank();
-    }
+    //     vm.expectRevert(abi.encodeWithSelector(EntityOnboardingAlreadyApproved.selector, address(111)));
+    //     nayms.approveSelfOnboarding(address(111), entityId, roleId);
+    //     vm.stopPrank();
+    // }
 
-    function testSelfOnboardingSuccess() public {
-        nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
+    // function testSelfOnboardingSuccess() public {
+    //     nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
 
-        bytes32 roleId = LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
-        bytes32 e1 = randomEntityId(1);
-        _approveSelfOnboarding(address(111), e1, roleId);
-        _selfOnboard(address(111), e1, LC.GROUP_TOKEN_HOLDERS);
+    //     bytes32 roleId = LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
+    //     bytes32 e1 = randomEntityId(1);
+    //     _approveSelfOnboarding(address(111), e1, roleId);
+    //     _selfOnboard(address(111), e1, LC.GROUP_TOKEN_HOLDERS);
 
-        bytes32 roleId2 = LibHelpers._stringToBytes32(LC.ROLE_ENTITY_CP);
-        bytes32 e2 = randomEntityId(2);
-        _approveSelfOnboarding(address(222), e2, roleId2);
-        _selfOnboard(address(222), e2, LC.GROUP_CAPITAL_PROVIDERS);
-    }
+    //     bytes32 roleId2 = LibHelpers._stringToBytes32(LC.ROLE_ENTITY_CP);
+    //     bytes32 e2 = randomEntityId(2);
+    //     _approveSelfOnboarding(address(222), e2, roleId2);
+    //     _selfOnboard(address(222), e2, LC.GROUP_CAPITAL_PROVIDERS);
+    // }
 
-    function testSelfOnboardingUpgradeToCapitalProvider() public {
-        nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
-        bytes32 roleIdTokenHolder = LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
-        bytes32 roleIdCP = LibHelpers._stringToBytes32(LC.ROLE_ENTITY_CP);
-        // test upgrade before onboarding
-        bytes32 e1 = randomEntityId(1);
+    // function testSelfOnboardingUpgradeToCapitalProvider() public {
+    //     nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
+    //     bytes32 roleIdTokenHolder = LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
+    //     bytes32 roleIdCP = LibHelpers._stringToBytes32(LC.ROLE_ENTITY_CP);
+    //     // test upgrade before onboarding
+    //     bytes32 e1 = randomEntityId(1);
 
-        _approveSelfOnboarding(address(111), e1, roleIdTokenHolder);
-        _approveSelfOnboarding(address(111), e1, roleIdCP);
-        _selfOnboard(address(111), e1, LC.GROUP_CAPITAL_PROVIDERS);
+    //     _approveSelfOnboarding(address(111), e1, roleIdTokenHolder);
+    //     _approveSelfOnboarding(address(111), e1, roleIdCP);
+    //     _selfOnboard(address(111), e1, LC.GROUP_CAPITAL_PROVIDERS);
 
-        // test upgrade after onboarding
-        bytes32 e2 = randomEntityId(2);
-        _approveSelfOnboarding(address(222), e2, roleIdTokenHolder);
-        _selfOnboard(address(222), e2, LC.GROUP_TOKEN_HOLDERS);
-        _approveSelfOnboarding(address(222), e2, roleIdCP);
+    //     // test upgrade after onboarding
+    //     bytes32 e2 = randomEntityId(2);
+    //     _approveSelfOnboarding(address(222), e2, roleIdTokenHolder);
+    //     _selfOnboard(address(222), e2, LC.GROUP_TOKEN_HOLDERS);
+    //     _approveSelfOnboarding(address(222), e2, roleIdCP);
 
-        vm.recordLogs();
+    //     vm.recordLogs();
 
-        _selfOnboard(address(222), e2, LC.GROUP_CAPITAL_PROVIDERS);
+    //     _selfOnboard(address(222), e2, LC.GROUP_CAPITAL_PROVIDERS);
 
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        assertEq(entries[0].topics.length, 2);
-        assertEq(entries[0].topics[0], keccak256("RoleUpdated(bytes32,bytes32,bytes32,string)"));
-        assertEq(entries[0].topics[1], e2);
-        (bytes32 contextId, bytes32 roleId, string memory action) = abi.decode(entries[0].data, (bytes32, bytes32, string));
-        assertEq(contextId, e2);
-        assertEq(roleId, roleIdTokenHolder);
-        assertEq(action, "_unassignRole");
+    //     Vm.Log[] memory entries = vm.getRecordedLogs();
+    //     assertEq(entries[0].topics.length, 2);
+    //     assertEq(entries[0].topics[0], keccak256("RoleUpdated(bytes32,bytes32,bytes32,string)"));
+    //     assertEq(entries[0].topics[1], e2);
+    //     (bytes32 contextId, bytes32 roleId, string memory action) = abi.decode(entries[0].data, (bytes32, bytes32, string));
+    //     assertEq(contextId, e2);
+    //     assertEq(roleId, roleIdTokenHolder);
+    //     assertEq(action, "_unassignRole");
 
-        assertEq(entries[1].topics.length, 2);
-        assertEq(entries[1].topics[0], keccak256("RoleUpdated(bytes32,bytes32,bytes32,string)"));
-        assertEq(entries[1].topics[1], e2, "object ID doesn't match");
-        (bytes32 contextId2, bytes32 roleId2, string memory action2) = abi.decode(entries[1].data, (bytes32, bytes32, string));
-        assertEq(contextId2, systemContext, "incorrect context");
-        assertEq(roleId2, roleIdTokenHolder, "wrong role");
-        assertEq(action2, "_unassignRole", "wrong operation");
-    }
+    //     assertEq(entries[1].topics.length, 2);
+    //     assertEq(entries[1].topics[0], keccak256("RoleUpdated(bytes32,bytes32,bytes32,string)"));
+    //     assertEq(entries[1].topics[1], e2, "object ID doesn't match");
+    //     (bytes32 contextId2, bytes32 roleId2, string memory action2) = abi.decode(entries[1].data, (bytes32, bytes32, string));
+    //     assertEq(contextId2, systemContext, "incorrect context");
+    //     assertEq(roleId2, roleIdTokenHolder, "wrong role");
+    //     assertEq(action2, "_unassignRole", "wrong operation");
+    // }
 
-    function testSelfOnboardingCancel() public {
-        nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
+    // function testSelfOnboardingCancel() public {
+    //     nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
 
-        bytes32 entityId = randomEntityId(2);
-        bytes32 roleIdTokenHolder = LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
+    //     bytes32 entityId = randomEntityId(2);
+    //     bytes32 roleIdTokenHolder = LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
 
-        vm.startPrank(em.addr);
-        nayms.approveSelfOnboarding(address(111), entityId, roleIdTokenHolder);
-        assertTrue(nayms.isSelfOnboardingApproved(address(111), entityId, roleIdTokenHolder), "Onboarding should be approved");
+    //     vm.startPrank(em.addr);
+    //     nayms.approveSelfOnboarding(address(111), entityId, roleIdTokenHolder);
+    //     assertTrue(nayms.isSelfOnboardingApproved(address(111), entityId, roleIdTokenHolder), "Onboarding should be approved");
 
-        vm.expectRevert(abi.encodeWithSelector(InvalidGroupPrivilege.selector, em.addr._getIdForAddress(), systemContext, LC.ROLE_ONBOARDING_APPROVER, LC.GROUP_SYSTEM_MANAGERS));
-        nayms.cancelSelfOnboarding(address(111));
-        vm.stopPrank();
-        vm.startPrank(sm.addr);
-        nayms.cancelSelfOnboarding(address(111));
+    //     vm.expectRevert(abi.encodeWithSelector(InvalidGroupPrivilege.selector, em.addr._getIdForAddress(), systemContext, LC.ROLE_ONBOARDING_APPROVER, LC.GROUP_SYSTEM_MANAGERS));
+    //     nayms.cancelSelfOnboarding(address(111));
+    //     vm.stopPrank();
+    //     vm.startPrank(sm.addr);
+    //     nayms.cancelSelfOnboarding(address(111));
 
-        assertFalse(nayms.isSelfOnboardingApproved(address(111), entityId, roleIdTokenHolder), "Onboarding should have been cancelled");
-    }
+    //     assertFalse(nayms.isSelfOnboardingApproved(address(111), entityId, roleIdTokenHolder), "Onboarding should have been cancelled");
+    // }
 
-    function _approveSelfOnboarding(address _userAddress, bytes32 entityId, bytes32 roleId) private {
-        vm.recordLogs();
+    // function _approveSelfOnboarding(address _userAddress, bytes32 entityId, bytes32 roleId) private {
+    //     vm.recordLogs();
 
-        vm.startPrank(em.addr);
-        nayms.approveSelfOnboarding(_userAddress, entityId, roleId);
-        vm.stopPrank();
+    //     vm.startPrank(em.addr);
+    //     nayms.approveSelfOnboarding(_userAddress, entityId, roleId);
+    //     vm.stopPrank();
 
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        assertEq(entries[0].topics.length, 2);
-        assertEq(entries[0].topics[0], keccak256("SelfOnboardingApproved(address)"));
-        assertEq(abi.decode(LibHelpers._bytes32ToBytes(entries[0].topics[1]), (address)), _userAddress);
-    }
+    //     Vm.Log[] memory entries = vm.getRecordedLogs();
+    //     assertEq(entries[0].topics.length, 2);
+    //     assertEq(entries[0].topics[0], keccak256("SelfOnboardingApproved(address)"));
+    //     assertEq(abi.decode(LibHelpers._bytes32ToBytes(entries[0].topics[1]), (address)), _userAddress);
+    // }
 
-    function _selfOnboard(address _userAddress, bytes32 entityId, string memory groupName) private {
-        vm.startPrank(_userAddress);
-        nayms.onboard();
-        vm.stopPrank();
+    // function _selfOnboard(address _userAddress, bytes32 entityId, string memory groupName) private {
+    //     vm.startPrank(_userAddress);
+    //     nayms.onboard();
+    //     vm.stopPrank();
 
-        assertTrue(nayms.isInGroup(entityId, systemContext, groupName));
-        assertTrue(nayms.isInGroup(entityId, entityId, groupName));
-    }
+    //     assertTrue(nayms.isInGroup(entityId, systemContext, groupName));
+    //     assertTrue(nayms.isInGroup(entityId, entityId, groupName));
+    // }
 
-    function test_ApproveSelfOnboarding_InvalidEntityId() public {
-        nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
+    // function test_ApproveSelfOnboarding_InvalidEntityId() public {
+    //     nayms.assignRole(em.id, systemContext, LC.ROLE_ONBOARDING_APPROVER);
 
-        bytes32 entityId = keccak256("invalid entity id");
-        bytes32 roleId = LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
+    //     bytes32 entityId = keccak256("invalid entity id");
+    //     bytes32 roleId = LibHelpers._stringToBytes32(LC.ROLE_ENTITY_TOKEN_HOLDER);
 
-        vm.startPrank(em.addr);
-        vm.expectRevert(abi.encodeWithSelector(InvalidEntityId.selector, entityId));
-        nayms.approveSelfOnboarding(address(111), entityId, roleId);
-    }
+    //     vm.startPrank(em.addr);
+    //     vm.expectRevert(abi.encodeWithSelector(InvalidEntityId.selector, entityId));
+    //     nayms.approveSelfOnboarding(address(111), entityId, roleId);
+    // }
 
     function randomEntityId(uint256 salt) public view returns (bytes32) {
         bytes32 hash = keccak256(abi.encodePacked(block.timestamp, block.prevrandao, msg.sender, salt));

--- a/test/defaults/D03ProtocolDefaults.sol
+++ b/test/defaults/D03ProtocolDefaults.sol
@@ -440,16 +440,16 @@ contract D03ProtocolDefaults is D02TestSetup {
             bytes[] memory signatures = new bytes[](4);
             bytes32 signingHash = nayms.getSigningHash(policy.startDate, policy.maturationDate, policy.asset, policy.limit, offchainDataHash);
 
-            signatures[0] = initPolicySig(0xACC2, signingHash);
-            signatures[1] = initPolicySig(0xACC1, signingHash);
-            signatures[2] = initPolicySig(0xACC3, signingHash);
-            signatures[3] = initPolicySig(0xACC4, signingHash);
+            signatures[0] = signWithPK(0xACC2, signingHash);
+            signatures[1] = signWithPK(0xACC1, signingHash);
+            signatures[2] = signWithPK(0xACC3, signingHash);
+            signatures[3] = signWithPK(0xACC4, signingHash);
 
             policyStakeholders = Stakeholders(roles, entityIds, signatures);
         }
     }
 
-    function initPolicySig(uint256 privateKey, bytes32 signingHash) internal pure returns (bytes memory sig_) {
+    function signWithPK(uint256 privateKey, bytes32 signingHash) internal pure returns (bytes memory sig_) {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, MessageHashUtils.toEthSignedMessageHash(signingHash));
         sig_ = abi.encodePacked(r, s, v);
     }

--- a/test/defaults/D03ProtocolDefaults.sol
+++ b/test/defaults/D03ProtocolDefaults.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
+import { Vm } from "forge-std/Vm.sol";
+
 import { D02TestSetup, LibHelpers, c } from "./D02TestSetup.sol";
 import { Entity, SimplePolicy, MarketInfo, Stakeholders, FeeSchedule } from "src/shared/FreeStructs.sol";
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
@@ -480,5 +482,16 @@ contract D03ProtocolDefaults is D02TestSetup {
         for (uint256 i; i < cr.length; i++) {
             c.logBytes32(cr[i]);
         }
+    }
+
+    function assertRoleUpdateEvent(Vm.Log[] memory entries, uint256 _index, bytes32 _ctxId, bytes32 _entityId, bytes32 _roleId, string memory _action) internal {
+        assertEq(entries[_index].topics.length, 2);
+        assertEq(entries[_index].topics[0], keccak256("RoleUpdated(bytes32,bytes32,bytes32,string)"));
+        assertEq(entries[_index].topics[1], _entityId, "incorrect entityID".red());
+
+        (bytes32 contextId, bytes32 roleId, string memory action) = abi.decode(entries[_index].data, (bytes32, bytes32, string));
+        assertEq(contextId, _ctxId, "incorrect context".red());
+        assertEq(_roleId, roleId, "incorrect role ID".red());
+        assertEq(action, _action, "incorrect action".red());
     }
 }


### PR DESCRIPTION
It should no longer be needed to make two transactions for a user to onboard. Replace the approval transaction with a signature, which will be verified when the user performs the onboarding transaction.