### PR TITLE
Auto-compound the staking rewards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nayms/contracts",
-  "version": "3.9.6",
+  "version": "3.9.7",
   "main": "index.js",
   "repository": "https://github.com/nayms/contracts-v3.git",
   "author": "Kevin Park <kevin@fruitful.gg>",

--- a/src/facets/StakingFacet.sol
+++ b/src/facets/StakingFacet.sol
@@ -134,6 +134,13 @@ contract StakingFacet is Modifiers {
         LibTokenizedVaultStaking._collectRewards(parentId, _entityId, lastPaid);
     }
 
+    function compoundRewards(bytes32 _entityId) external notLocked {
+        bytes32 parentId = LibObject._getParent(msg.sender._getIdForAddress());
+        uint64 lastPaid = LibTokenizedVaultStaking._lastPaidInterval(_entityId);
+
+        LibTokenizedVaultStaking._compoundRewards(parentId, _entityId, lastPaid);
+    }
+
     /**
      * @notice Collect rewards for a staker
      * @param _entityId staking entity ID

--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -147,8 +147,9 @@ library LibAdmin {
         s.locked[IDiamondProxy.cancelSimplePolicy.selector] = true;
         s.locked[IDiamondProxy.createSimplePolicy.selector] = true;
         s.locked[IDiamondProxy.createEntity.selector] = true;
+        s.locked[IDiamondProxy.compoundRewards.selector] = true;
 
-        bytes4[] memory lockedFunctions = new bytes4[](22);
+        bytes4[] memory lockedFunctions = new bytes4[](23);
         lockedFunctions[0] = IDiamondProxy.startTokenSale.selector;
         lockedFunctions[1] = IDiamondProxy.paySimpleClaim.selector;
         lockedFunctions[2] = IDiamondProxy.paySimplePremium.selector;
@@ -171,6 +172,7 @@ library LibAdmin {
         lockedFunctions[19] = IDiamondProxy.createSimplePolicy.selector;
         lockedFunctions[20] = IDiamondProxy.createEntity.selector;
         lockedFunctions[21] = IDiamondProxy.collectRewardsToInterval.selector;
+        lockedFunctions[22] = IDiamondProxy.compoundRewards.selector;
 
         emit FunctionsLocked(lockedFunctions);
     }
@@ -199,8 +201,9 @@ library LibAdmin {
         s.locked[IDiamondProxy.createSimplePolicy.selector] = false;
         s.locked[IDiamondProxy.createEntity.selector] = false;
         s.locked[IDiamondProxy.collectRewardsToInterval.selector] = false;
+        s.locked[IDiamondProxy.compoundRewards.selector] = false;
 
-        bytes4[] memory lockedFunctions = new bytes4[](22);
+        bytes4[] memory lockedFunctions = new bytes4[](23);
         lockedFunctions[0] = IDiamondProxy.startTokenSale.selector;
         lockedFunctions[1] = IDiamondProxy.paySimpleClaim.selector;
         lockedFunctions[2] = IDiamondProxy.paySimplePremium.selector;
@@ -223,6 +226,7 @@ library LibAdmin {
         lockedFunctions[19] = IDiamondProxy.createSimplePolicy.selector;
         lockedFunctions[20] = IDiamondProxy.createEntity.selector;
         lockedFunctions[21] = IDiamondProxy.collectRewardsToInterval.selector;
+        lockedFunctions[22] = IDiamondProxy.compoundRewards.selector;
 
         emit FunctionsUnlocked(lockedFunctions);
     }

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -317,6 +317,27 @@ library LibTokenizedVaultStaking {
         s.stakeBalance[vTokenId][_stakerId] = state.balance;
     }
 
+    function _compoundRewards(bytes32 _stakerId, bytes32 _entityId, uint64 _interval) internal {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+        bytes32 tokenId = s.stakingConfigs[_entityId].tokenId;
+
+        (, RewardsBalances memory rewards) = _getStakingStateWithRewardsBalances(_stakerId, _entityId, _interval);
+
+        uint256 rewardAmount;
+        uint256 rewardCount = rewards.currencies.length;
+        for (uint64 i = 0; i <= rewardCount; i++) {
+            if (rewards.currencies[i] == tokenId) {
+                rewardAmount = rewards.amounts[i];
+                break;
+            }
+        }
+
+        require(rewardAmount > 0, "No reward to compound");
+
+        _collectRewards(_stakerId, _entityId, _interval);
+        _stake(_stakerId, _entityId, rewardAmount);
+    }
+
     function _collectRewards(bytes32 _stakerId, bytes32 _entityId, uint64 _interval) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 

--- a/src/libs/LibTokenizedVaultStaking.sol
+++ b/src/libs/LibTokenizedVaultStaking.sol
@@ -325,7 +325,8 @@ library LibTokenizedVaultStaking {
 
         uint256 rewardAmount;
         uint256 rewardCount = rewards.currencies.length;
-        for (uint64 i = 0; i <= rewardCount; i++) {
+
+        for (uint64 i = 0; i < rewardCount; i++) {
             if (rewards.currencies[i] == tokenId) {
                 rewardAmount = rewards.amounts[i];
                 break;

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -776,6 +776,9 @@ contract T06Staking is D03ProtocolDefaults {
         assertStakedAmount(bob.entityId, bobStakeAmount, "Bob's stake should increase");
         c.log(" ~ [%s] Bob staked".blue(), currentInterval());
 
+        vm.expectRevert("No reward to compound");
+        nayms.compoundRewards(nlf.entityId);
+
         vm.warp(startStaking + 61 days);
 
         assertEq(nayms.lastPaidInterval(nlf.entityId), 0, "Last interval paid should be 0");
@@ -788,12 +791,10 @@ contract T06Staking is D03ProtocolDefaults {
 
         vm.warp(startStaking + 181 days);
 
-        uint256 balanceBeforeClaim = nayms.internalBalanceOf(bob.entityId, NAYM_ID);
-
         startPrank(bob);
-        // (bytes32[] memory currencies, uint256[] memory amounts) = nayms.getRewardsBalance(bob.entityId, nlf.entityId);
-        nayms.collectRewards(nlf.entityId);
-        assertEq(nayms.internalBalanceOf(bob.entityId, NAYM_ID), balanceBeforeClaim + 10_000, "Bob should have NAYM in his balance");
+        nayms.compoundRewards(nlf.entityId);
+        assertStakedAmount(bob.entityId, bobStakeAmount + 10_000, "Bob's stake should increase");
+        c.log(" ~ [%s] Reward1 compound".blue(), currentInterval());
     }
 
     function test_twoStakingRewardCurrencies() public {

--- a/test/T06Staking.t.sol
+++ b/test/T06Staking.t.sol
@@ -784,10 +784,15 @@ contract T06Staking is D03ProtocolDefaults {
         assertEq(nayms.lastPaidInterval(nlf.entityId), 0, "Last interval paid should be 0");
 
         startPrank(nlf);
-        nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("reward1")), nlf.entityId, NAYM_ID, 10_000);
+        nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("reward1")), nlf.entityId, usdcId, 10_000);
+        assertEq(nayms.lastPaidInterval(nlf.entityId), 2, "Last interval paid should be 0");
         c.log(" ~ [%s] Reward1 paid out".blue(), currentInterval());
 
-        assertEq(nayms.lastPaidInterval(nlf.entityId), 2, "Last interval paid should be 2");
+        vm.warp(startStaking + 91 days);
+
+        nayms.payReward(makeId(LC.OBJECT_TYPE_STAKING_REWARD, bytes20("reward2")), nlf.entityId, NAYM_ID, 10_000);
+        assertEq(nayms.lastPaidInterval(nlf.entityId), 3, "Last interval paid should be 0");
+        c.log(" ~ [%s] Reward2 paid out".blue(), currentInterval());
 
         vm.warp(startStaking + 181 days);
 


### PR DESCRIPTION
Rather then having to claim their rewards and then stake then into the NLF, users should be able to directly send their rewards into the staking pool.