### PR TITLE
Adjust withdrawn amount when same coin is used to pay out a dividends

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.0.0",
     "ethers": "^5.6.9",
-    "gemforge": "^2.9.1",
+    "gemforge": "^2.14.0",
     "glob": "^8.0.3",
     "prettier": "^2.7.1",
     "prettier-plugin-solidity": "^1.0.0-beta.19",

--- a/src/facets/TokenizedVaultFacet.sol
+++ b/src/facets/TokenizedVaultFacet.sol
@@ -174,6 +174,6 @@ contract TokenizedVaultFacet is Modifiers, ReentrancyGuard {
         // The _claimRebasingInterest method verifies the token is valid, and that there is available interest.
         // No need to do it again.
         LibTokenizedVault._claimRebasingInterest(_tokenId, _amount);
-        LibTokenizedVault._payDividend(_guid, _tokenId, _tokenId, _tokenId, _amount);
+        LibTokenizedVault._payDividend(_guid, LibAdmin._getSystemId(), _tokenId, _tokenId, _amount);
     }
 }

--- a/src/init/DividendPatchInitDiamond.sol
+++ b/src/init/DividendPatchInitDiamond.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+import { AppStorage, LibAppStorage } from "../shared/AppStorage.sol";
+
+contract DividendPatchInitDiamond {
+    function init() external {
+        AppStorage storage s = LibAppStorage.diamondStorage();
+
+        bytes32 _tokenId = 0x59d9356e565ab3a36dd77763fc0d87feaf85508c000000000000000000000000; // USDM
+        bytes32 _dividendTokenId = 0x59d9356e565ab3a36dd77763fc0d87feaf85508c000000000000000000000000; // USDM
+        bytes32 _ownerId = 0x454e54495459000000000000653eeaf2a1e51089765e3c6291e780a640085943; // ILW
+
+        s.tokenSupply[_tokenId] = 533337609745764857001482;
+        s.totalDividends[_tokenId][_dividendTokenId] = 16406802958540022191510;
+        s.withdrawnDividendPerOwner[_tokenId][_dividendTokenId][_ownerId] = 16171508827360588570817;
+    }
+}

--- a/src/libs/LibTokenizedVault.sol
+++ b/src/libs/LibTokenizedVault.sol
@@ -147,6 +147,7 @@ library LibTokenizedVault {
 
         _withdrawAllDividends(_from, _tokenId);
         _normalizeDividendsBurn(_tokenId, _amount);
+
         s.tokenSupply[_tokenId] -= _amount;
         s.tokenBalances[_tokenId][_from] -= _amount;
 
@@ -184,6 +185,7 @@ library LibTokenizedVault {
         uint256 withdrawnSoFar = s.withdrawnDividendPerOwner[_tokenId][_dividendTokenId][_ownerId];
 
         uint256 withdrawableDividend = _getWithdrawableDividendAndDeductionMath(amountOwned, supply, totalDividend, withdrawnSoFar);
+
         if (withdrawableDividend > 0) {
             // Bump the withdrawn dividends for the owner
             /// Special Case: (_tokenId == _dividendTokenId), i.e distributing accrued interest for rebasing coins like USDM
@@ -246,11 +248,11 @@ library LibTokenizedVault {
             // issue dividend. if you are owed dividends on the _dividendTokenId, they will be collected
             // Check for possible infinite loop, but probably not
             _internalTransfer(_from, dividendBankId, _dividendTokenId, _amount);
-            uint256 tokenSupply = LibTokenizedVault._internalTokenSupply(_dividendTokenId);
+            uint256 tokenSupply = _internalTokenSupply(_dividendTokenId);
             uint256 adjustedDividendAmount = _amount;
             if (_to == _dividendTokenId) {
                 // withdrawn dividend was adjusted for the previous holder in this case,
-                // therfore dividend amount should be increased in order to give existing token holders the correct amount
+                // therefore dividend amount should be increased in order to give existing token holders the correct amount
                 adjustedDividendAmount = (_amount * (tokenSupply)) / (tokenSupply - _amount);
             }
 
@@ -306,7 +308,6 @@ library LibTokenizedVault {
 
         address tokenAddress = LibHelpers._getAddressFromId(_tokenId);
 
-        // uint256 depositTotal = s.depositTotal[_tokenId];
         uint256 depositTotal = s.tokenSupply[_tokenId];
         uint256 total = LibERC20.balanceOf(tokenAddress, address(this));
 
@@ -329,8 +330,6 @@ library LibTokenizedVault {
             revert RebasingInterestInsufficient(_tokenId, _amount, accruedAmount);
         }
 
-        // s.tokenBalances[_tokenId][_tokenId] += _amount;
-        // s.depositTotal[_tokenId] += _amount;
         _internalMint(LibAdmin._getSystemId(), _tokenId, _amount);
     }
 }

--- a/src/libs/LibTokenizedVaultIO.sol
+++ b/src/libs/LibTokenizedVaultIO.sol
@@ -34,9 +34,6 @@ library LibTokenizedVaultIO {
         // Only mint what has been collected.
         LibTokenizedVault._internalMint(_receiverId, internalTokenId, mintAmount);
 
-        AppStorage storage s = LibAppStorage.diamondStorage();
-        s.depositTotal[internalTokenId] += mintAmount;
-
         // emit event
         emit ExternalDeposit(_receiverId, _externalTokenAddress, mintAmount);
     }
@@ -54,9 +51,6 @@ library LibTokenizedVaultIO {
 
         // transfer AFTER burn
         LibERC20.transfer(_externalTokenAddress, _receiver, _amount);
-
-        AppStorage storage s = LibAppStorage.diamondStorage();
-        s.depositTotal[internalTokenId] -= _amount;
 
         // emit event
         emit ExternalWithdraw(_entityId, _receiver, _externalTokenAddress, _amount);

--- a/src/shared/AppStorage.sol
+++ b/src/shared/AppStorage.sol
@@ -90,6 +90,7 @@ struct AppStorage {
     mapping(bytes32 vTokenId => bytes32 denomination) stakingDistributionDenomination; // [vTokenId] Reward currency
     mapping(bytes32 entityId => mapping(bytes32 stakerId => uint64 interval)) stakingSynced; // last interval when data was synced into storage for staker
     mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 balance)) stakeBalanceAdded; // raw balance staked at an interval, withouth any boost included, only for reading future intervals (to calculate the total boosted balance)
+    // mapping(uint256 => bool) initComplete; // think about adding this in the future
 }
 
 /// Staking-Related Mappings

--- a/src/shared/AppStorage.sol
+++ b/src/shared/AppStorage.sol
@@ -79,8 +79,8 @@ struct AppStorage {
     mapping(string tokenSymbol => bytes32 objectId) tokenSymbolObjectId; // reverse mapping token symbol => object ID, to ensure symbol uniqueness
     mapping(bytes32 entityId => mapping(uint256 feeScheduleTypeId => FeeSchedule)) feeSchedules; // map entity ID to a fee schedule type and then to array of FeeReceivers (feeScheduleType (1-premium, 2-trading, n-others))
     mapping(bytes32 objectId => uint256 minimumSell) objectMinimumSell; // map object ID to minimum sell amount
-    mapping(bytes32 objectId => uint256) depositTotal; // total amount deposited into contract, for rebasing tokens support
-    mapping(address userAddress => EntityApproval) selfOnboarding; // map address => { entityId, roleId }
+    mapping(bytes32 objectId => uint256) depositTotal; // note: DEPRECATED: total amount deposited into contract, for rebasing tokens support
+    mapping(address userAddress => EntityApproval) selfOnboarding; // note: DEPRECATED
     /// Staking
     mapping(bytes32 entityId => StakingConfig) stakingConfigs; // StakingConfig for an entity
     mapping(bytes32 vTokenId => mapping(bytes32 stakerId => uint256 balance)) stakeBalance; // [vTokenId][ownerId] balance at interval

--- a/yarn.lock
+++ b/yarn.lock
@@ -2678,10 +2678,10 @@ functions-have-names@^1.2.3:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
-gemforge@^2.9.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/gemforge/-/gemforge-2.9.1.tgz#a4c73378764db4c6ad3ba09e566755137c6604cb"
-  integrity sha512-F6GcJm660xaDmRlYKI7yfI6AOwAfpXqvJrzI44fOF89rbQYv5YAOVHe+CslQZiM6aGdQ4KWf7aqbdxkmoUwjOg==
+gemforge@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/gemforge/-/gemforge-2.14.0.tgz#36127a21e1a95523001def1da7427ef66188f16b"
+  integrity sha512-b9Ji69WJXXLaCvcGSsTaT+1T1eby4luZT8yS/HOaRRhtJrq8nFUbA2ZN2RqTOOo9eke+7LjWQlDlPeQLY4ANiQ==
   dependencies:
     "@solidity-parser/parser" "^0.16.1"
     bigval "^1.7.0"


### PR DESCRIPTION
In case the same coin is used to pay out a dividend, such as distibuting accrued interest on rebasing coins (i.e. `Mountain Protocol USD (USDM)`), we need to update the withdrawn-amount-so-far, with some adjustments to prevent potential dividend draining or underflows.