### PR TITLE
fix: revert on invalid signature length [NAY-3]

### DIFF
--- a/src/libs/LibAdmin.sol
+++ b/src/libs/LibAdmin.sol
@@ -22,7 +22,8 @@ import {
     EntityOnboardingNotApproved,
     InvalidSelfOnboardRoleApproval,
     InvalidSignatureError,
-    InvalidSignatureSError
+    InvalidSignatureSError,
+    InvalidSignatureLength
 } from "../shared/CustomErrors.sol";
 
 import { IDiamondProxy } from "src/generated/IDiamondProxy.sol";
@@ -291,23 +292,25 @@ library LibAdmin {
         uint8 v;
 
         // ecrecover takes the signature parameters, and the only way to get them
-        if (signature.length == 65) {
-            // currently is to use assembly.
-            /// @solidity memory-safe-assembly
-            assembly {
-                r := mload(add(signature, 0x20))
-                s := mload(add(signature, 0x40))
-                v := byte(0, mload(add(signature, 0x60)))
+        if (signature.length != 65) {
+            revert InvalidSignatureLength();
+        }
 
-                switch v
-                // if v == 0, then v = 27
-                case 0 {
-                    v := 27
-                }
-                // if v == 1, then v = 28
-                case 1 {
-                    v := 28
-                }
+        // currently is to use assembly.
+        /// @solidity memory-safe-assembly
+        assembly {
+            r := mload(add(signature, 0x20))
+            s := mload(add(signature, 0x40))
+            v := byte(0, mload(add(signature, 0x60)))
+
+            switch v
+            // if v == 0, then v = 27
+            case 0 {
+                v := 27
+            }
+            // if v == 1, then v = 28
+            case 1 {
+                v := 28
             }
         }
 

--- a/src/shared/CustomErrors.sol
+++ b/src/shared/CustomErrors.sol
@@ -167,6 +167,10 @@ error RebasingSupplyDecreased(bytes32 tokenId, uint256 accountInNayms, uint256 a
 /// @notice This error suggests that the signature itself is malformed or does not correspond to the hash provided.
 error InvalidSignatureError(bytes32 hash);
 
+/// @dev This error indicates that the signatures is not 65 bytes.
+/// @notice This error indicates invalid signature length.
+error InvalidSignatureLength();
+
 /// @dev This error is used to indicate that the signature has an invalid 's' value.
 /// @param sValue The 's' value of the ECDSA signature that was deemed invalid.
 /// @notice This error is triggered when the 's' value of the signature is not within the lower half of the secp256k1 curve's order, which can lead to malleability issues.


### PR DESCRIPTION
The `_getSigner` function checks if the provided signature length is 65 bytes before extracting the `r` , `s` , and `v` values. However, it does not revert if the signature is not 65 bytes.